### PR TITLE
Allow users to visit Helios without login

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -22,10 +22,12 @@ export class AppComponent {
       baseUrl: environment.serverUrl,
     });
 
-    client.interceptors.request.use(request => {
-      request.headers.set('Authorization', `Bearer ${token}`);
-      return request;
-    });
+    if (token) {
+      client.interceptors.request.use(request => {
+        request.headers.set('Authorization', `Bearer ${token}`);
+        return request;
+      });
+    }
 
     client.interceptors.response.use(async response => {
       if (response.ok == false) {

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -28,7 +28,7 @@
 
           <div class="flex-grow"></div>
 
-          @if (!environment.locked && deployable()) {
+          @if (isLoggedIn() && !environment.locked && deployable()) {
             <button (click)="deployEnvironment(environment); $event.stopPropagation()" class="p-button p-button-secondary p-2">
               <i-tabler name="cloud-upload" class="mr-1" />Deploy
             </button>
@@ -43,10 +43,12 @@
                 ><i-tabler name="external-link" class="mr-1" />Open</a
               >
             }
-            <button (click)="onUnlockEnvironment($event, environment)" class="p-button p-button-danger p-2"><i-tabler name="lock-open" class="mr-1" />Unlock</button>
+            @if (isLoggedIn()) {
+              <button (click)="onUnlockEnvironment($event, environment)" class="p-button p-button-danger p-2"><i-tabler name="lock-open" class="mr-1" />Unlock</button>
+            }
           }
 
-          @if (editable()) {
+          @if (isLoggedIn() && editable()) {
             <a icon [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'" class="p-button p-button-secondary p-2"
               ><i-tabler name="pencil"
             /></a>

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, output, signal } from '@angular/core';
+import { Component, computed, inject, input, output, signal } from '@angular/core';
 import { AccordionModule } from 'primeng/accordion';
 
 import { TagModule } from 'primeng/tag';
@@ -13,6 +13,7 @@ import { EnvironmentDeploymentInfoComponent } from '../deployment-info/environme
 import { getAllEnvironmentsOptions, getAllEnvironmentsQueryKey, unlockEnvironmentMutation } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { EnvironmentDto } from '@app/core/modules/openapi';
 import { LockTimeComponent } from '../lock-time/lock-time.component';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 
 @Component({
   selector: 'app-environment-list-view',
@@ -32,6 +33,7 @@ import { LockTimeComponent } from '../lock-time/lock-time.component';
 })
 export class EnvironmentListViewComponent {
   private queryClient = injectQueryClient();
+  private keycloakService = inject(KeycloakService);
 
   editable = input<boolean | undefined>();
   deployable = input<boolean | undefined>();
@@ -51,6 +53,8 @@ export class EnvironmentListViewComponent {
       this.queryClient.invalidateQueries({ queryKey: getAllEnvironmentsQueryKey() });
     },
   }));
+
+  isLoggedIn = computed(() => this.keycloakService.loggedIn());
 
   onUnlockEnvironment(event: Event, environment: EnvironmentDto) {
     this.unlockEnvironment.mutate({ path: { id: environment.id } });

--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.html
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.html
@@ -1,0 +1,13 @@
+<p-divider />
+<div class="flex flex-col items-center">
+  @if (!isLoggedIn()) {
+    <button class="rounded-xl p-2 flex items-center text-green-500 hover:text-green-700" pTooltip="Login" (click)="login()">
+      <i-tabler name="login" class="!size-10 !stroke-1" />
+    </button>
+  } @else {
+    <p-avatar [pTooltip]="fullName()" [label]="initials()" size="large" />
+    <button class="rounded-xl p-2 flex items-center text-red-500 hover:text-red-700" pTooltip="Logout" (click)="logout()">
+      <i-tabler name="logout" class="!size-10 !stroke-1" />
+    </button>
+  }
+</div>

--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.spec.ts
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProfileNavSectionComponent } from './profile-nav-section.component';
+
+describe('ProfileNavSectionComponent', () => {
+  let component: ProfileNavSectionComponent;
+  let fixture: ComponentFixture<ProfileNavSectionComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileNavSectionComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileNavSectionComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
@@ -1,0 +1,54 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { IconsModule } from 'icons.module';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { ChipModule } from 'primeng/chip';
+import { DataViewModule } from 'primeng/dataview';
+import { TagModule } from 'primeng/tag';
+import { ToastModule } from 'primeng/toast';
+import { TooltipModule } from 'primeng/tooltip';
+import { DividerModule } from 'primeng/divider';
+import { AvatarModule } from 'primeng/avatar';
+
+@Component({
+  selector: 'app-profile-nav-section',
+  imports: [ToastModule, TooltipModule, DividerModule, AvatarModule, DataViewModule, ButtonModule, TagModule, CommonModule, CardModule, ChipModule, IconsModule],
+  templateUrl: './profile-nav-section.component.html',
+})
+export class ProfileNavSectionComponent {
+  constructor(private keycloakService: KeycloakService) {}
+
+  isLoggedIn() {
+    return this.keycloakService.loggedIn();
+  }
+
+  logout() {
+    this.keycloakService.logout();
+  }
+
+  initials() {
+    if (!this.isLoggedIn()) {
+      return '';
+    }
+
+    const profile = this.keycloakService.profile;
+
+    return `${profile?.firstName?.charAt(0) ?? ''}${profile?.lastName?.charAt(0) ?? ''}`;
+  }
+
+  fullName() {
+    if (!this.isLoggedIn()) {
+      return '';
+    }
+
+    const profile = this.keycloakService.profile;
+
+    return `${profile?.firstName} ${profile?.lastName}`;
+  }
+
+  login() {
+    this.keycloakService.login();
+  }
+}

--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -22,6 +22,7 @@ import type {
   GetLatestWorkflowRunsByPullRequestIdAndHeadCommitData,
   GetLatestWorkflowRunsByBranchAndHeadCommitData,
   GetGroupsWithWorkflowsData,
+  GetRepositoriesData,
   GetRepositoryByIdData,
   GetAllPullRequestsData,
   GetPullRequestByIdData,
@@ -56,6 +57,7 @@ import {
   getLatestWorkflowRunsByPullRequestIdAndHeadCommit,
   getLatestWorkflowRunsByBranchAndHeadCommit,
   getGroupsWithWorkflows,
+  getRepositories,
   getRepositoryById,
   getAllPullRequests,
   getPullRequestById,
@@ -373,6 +375,23 @@ export const getGroupsWithWorkflowsOptions = (options: Options<GetGroupsWithWork
       return data;
     },
     queryKey: getGroupsWithWorkflowsQueryKey(options),
+  });
+};
+
+export const getRepositoriesQueryKey = (options?: Options<GetRepositoriesData>) => [createQueryKey('getRepositories', options)];
+
+export const getRepositoriesOptions = (options?: Options<GetRepositoriesData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getRepositories({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getRepositoriesQueryKey(options),
   });
 };
 

--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -22,7 +22,7 @@ import type {
   GetLatestWorkflowRunsByPullRequestIdAndHeadCommitData,
   GetLatestWorkflowRunsByBranchAndHeadCommitData,
   GetGroupsWithWorkflowsData,
-  GetRepositoriesData,
+  GetAllRepositoriesData,
   GetRepositoryByIdData,
   GetAllPullRequestsData,
   GetPullRequestByIdData,
@@ -57,7 +57,7 @@ import {
   getLatestWorkflowRunsByPullRequestIdAndHeadCommit,
   getLatestWorkflowRunsByBranchAndHeadCommit,
   getGroupsWithWorkflows,
-  getRepositories,
+  getAllRepositories,
   getRepositoryById,
   getAllPullRequests,
   getPullRequestById,
@@ -378,12 +378,12 @@ export const getGroupsWithWorkflowsOptions = (options: Options<GetGroupsWithWork
   });
 };
 
-export const getRepositoriesQueryKey = (options?: Options<GetRepositoriesData>) => [createQueryKey('getRepositories', options)];
+export const getAllRepositoriesQueryKey = (options?: Options<GetAllRepositoriesData>) => [createQueryKey('getAllRepositories', options)];
 
-export const getRepositoriesOptions = (options?: Options<GetRepositoriesData>) => {
+export const getAllRepositoriesOptions = (options?: Options<GetAllRepositoriesData>) => {
   return queryOptions({
     queryFn: async ({ queryKey, signal }) => {
-      const { data } = await getRepositories({
+      const { data } = await getAllRepositories({
         ...options,
         ...queryKey[0],
         signal,
@@ -391,7 +391,7 @@ export const getRepositoriesOptions = (options?: Options<GetRepositoriesData>) =
       });
       return data;
     },
-    queryKey: getRepositoriesQueryKey(options),
+    queryKey: getAllRepositoriesQueryKey(options),
   });
 };
 

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -30,8 +30,8 @@ import type {
   GetLatestWorkflowRunsByBranchAndHeadCommitResponse,
   GetGroupsWithWorkflowsData,
   GetGroupsWithWorkflowsResponse,
-  GetRepositoriesData,
-  GetRepositoriesResponse,
+  GetAllRepositoriesData,
+  GetAllRepositoriesResponse,
   GetRepositoryByIdData,
   GetRepositoryByIdResponse,
   GetAllPullRequestsData,
@@ -196,8 +196,8 @@ export const getGroupsWithWorkflows = <ThrowOnError extends boolean = false>(opt
   });
 };
 
-export const getRepositories = <ThrowOnError extends boolean = false>(options?: Options<GetRepositoriesData, ThrowOnError>) => {
-  return (options?.client ?? client).get<GetRepositoriesResponse, unknown, ThrowOnError>({
+export const getAllRepositories = <ThrowOnError extends boolean = false>(options?: Options<GetAllRepositoriesData, ThrowOnError>) => {
+  return (options?.client ?? client).get<GetAllRepositoriesResponse, unknown, ThrowOnError>({
     ...options,
     url: '/api/repository',
   });

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -30,6 +30,8 @@ import type {
   GetLatestWorkflowRunsByBranchAndHeadCommitResponse,
   GetGroupsWithWorkflowsData,
   GetGroupsWithWorkflowsResponse,
+  GetRepositoriesData,
+  GetRepositoriesResponse,
   GetRepositoryByIdData,
   GetRepositoryByIdResponse,
   GetAllPullRequestsData,
@@ -191,6 +193,13 @@ export const getGroupsWithWorkflows = <ThrowOnError extends boolean = false>(opt
   return (options?.client ?? client).get<GetGroupsWithWorkflowsResponse, unknown, ThrowOnError>({
     ...options,
     url: '/api/settings/{repositoryId}/groups',
+  });
+};
+
+export const getRepositories = <ThrowOnError extends boolean = false>(options?: Options<GetRepositoriesData, ThrowOnError>) => {
+  return (options?.client ?? client).get<GetRepositoriesResponse, unknown, ThrowOnError>({
+    ...options,
+    url: '/api/repository',
   });
 };
 

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -446,6 +446,24 @@ export type GetGroupsWithWorkflowsResponses = {
 
 export type GetGroupsWithWorkflowsResponse = GetGroupsWithWorkflowsResponses[keyof GetGroupsWithWorkflowsResponses];
 
+export type GetRepositoriesData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/api/repository';
+};
+
+export type GetRepositoriesResponses = {
+  /**
+   * OK
+   */
+  200: {
+    [key: string]: unknown;
+  };
+};
+
+export type GetRepositoriesResponse = GetRepositoriesResponses[keyof GetRepositoriesResponses];
+
 export type GetRepositoryByIdData = {
   body?: never;
   path: {

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -446,23 +446,21 @@ export type GetGroupsWithWorkflowsResponses = {
 
 export type GetGroupsWithWorkflowsResponse = GetGroupsWithWorkflowsResponses[keyof GetGroupsWithWorkflowsResponses];
 
-export type GetRepositoriesData = {
+export type GetAllRepositoriesData = {
   body?: never;
   path?: never;
   query?: never;
   url: '/api/repository';
 };
 
-export type GetRepositoriesResponses = {
+export type GetAllRepositoriesResponses = {
   /**
    * OK
    */
-  200: {
-    [key: string]: unknown;
-  };
+  200: Array<RepositoryInfoDto>;
 };
 
-export type GetRepositoriesResponse = GetRepositoriesResponses[keyof GetRepositoriesResponses];
+export type GetAllRepositoriesResponse = GetAllRepositoriesResponses[keyof GetAllRepositoriesResponses];
 
 export type GetRepositoryByIdData = {
   body?: never;

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -32,6 +32,10 @@ export class KeycloakService {
     }
   }
 
+  loggedIn() {
+    return this.keycloak.authenticated;
+  }
+
   login() {
     return this.keycloak.login();
   }

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -23,7 +23,7 @@ export class KeycloakService {
 
   async init() {
     const authenticated = await this.keycloak.init({
-      onLoad: 'login-required',
+      onLoad: 'check-sso',
     });
 
     if (authenticated) {
@@ -37,7 +37,6 @@ export class KeycloakService {
   }
 
   logout() {
-    // this.keycloak.accountManagement();
     return this.keycloak.logout({ redirectUri: environment.clientUrl });
   }
 }

--- a/client/src/app/pages/branch-details/branch-details.component.html
+++ b/client/src/app/pages/branch-details/branch-details.component.html
@@ -16,7 +16,9 @@
 
 <div class="flex flex-col gap-6 max-w-6xl mr-4">
   <app-pipeline [selector]="pipelineSelector()" />
-  @if (query.data(); as branch) {
-    <app-deployment-selection [sourceRef]="branch.name" />
+  @if (isLoggedIn()) {
+    @if (query.data(); as branch) {
+      <app-deployment-selection [sourceRef]="branch.name" />
+    }
   }
 </div>

--- a/client/src/app/pages/branch-details/branch-details.component.ts
+++ b/client/src/app/pages/branch-details/branch-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 
 import { PipelineComponent, PipelineSelector } from '@app/components/pipeline/pipeline.component';
 import { TagModule } from 'primeng/tag';
@@ -9,6 +9,7 @@ import { DeploymentSelectionComponent } from '@app/components/deployment-selecti
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { SkeletonModule } from 'primeng/skeleton';
 import { getBranchByRepositoryIdAndNameOptions, getCommitByRepositoryIdAndNameOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 
 @Component({
   selector: 'app-branch-details',
@@ -16,6 +17,8 @@ import { getBranchByRepositoryIdAndNameOptions, getCommitByRepositoryIdAndNameOp
   templateUrl: './branch-details.component.html',
 })
 export class BranchDetailsComponent {
+  private keycloakService = inject(KeycloakService);
+
   repositoryId = input.required<number>();
   branchName = input.required<string>();
 
@@ -29,6 +32,8 @@ export class BranchDetailsComponent {
     enabled: !!this.repositoryId() && !!this.query.data(),
   }));
   commit = computed(() => this.commitQuery.data());
+
+  isLoggedIn = computed(() => this.keycloakService.loggedIn());
 
   pipelineSelector = computed<PipelineSelector | null>(() => {
     const branch = this.query.data();

--- a/client/src/app/pages/main-layout/main-layout.component.html
+++ b/client/src/app/pages/main-layout/main-layout.component.html
@@ -26,12 +26,7 @@
         </p>
       }
       <i-tabler name="settings" pTooltip="Settings" class="!size-10 text-gray-500 hover:text-gray-700 !stroke-1" />
-      <p-divider />
-      <p-avatar label="U" size="large" />
-      <p-divider />
-      <button class="rounded-xl p-2 flex items-center text-red-500 hover:text-red-700" pTooltip="Logout" (click)="logout()">
-        <i-tabler name="logout" class="!size-10 !stroke-1" />
-      </button>
+      <app-profile-nav-section />
     </div>
 
     <!-- Scrollable Content Area -->

--- a/client/src/app/pages/main-layout/main-layout.component.ts
+++ b/client/src/app/pages/main-layout/main-layout.component.ts
@@ -47,6 +47,7 @@ export class MainLayoutComponent implements OnInit, OnDestroy {
   lockQuery = injectQuery(() => ({
     ...getEnvironmentsByUserLockingOptions(),
     refetchInterval: 10000,
+    enabled: () => !!this.keycloakService.loggedIn(),
   }));
 
   items!: { label: string; icon: string; path: string }[];

--- a/client/src/app/pages/main-layout/main-layout.component.ts
+++ b/client/src/app/pages/main-layout/main-layout.component.ts
@@ -12,6 +12,7 @@ import { CardModule } from 'primeng/card';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getEnvironmentsByUserLockingOptions, getRepositoryByIdOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { SlicePipe } from '@angular/common';
+import { ProfileNavSectionComponent } from '@app/components/profile-nav-section/profile-nav-section.component';
 
 @Component({
   selector: 'app-main-layout',
@@ -29,6 +30,7 @@ import { SlicePipe } from '@angular/common';
     DividerModule,
     AvatarModule,
     CardModule,
+    ProfileNavSectionComponent,
   ],
   templateUrl: './main-layout.component.html',
 })
@@ -56,6 +58,10 @@ export class MainLayoutComponent implements OnInit, OnDestroy {
     this.keycloakService.logout();
   }
 
+  login() {
+    this.keycloakService.login();
+  }
+
   ngOnInit() {
     this.items = [
       {
@@ -73,11 +79,15 @@ export class MainLayoutComponent implements OnInit, OnDestroy {
         icon: 'server-cog',
         path: 'environment/list',
       },
-      {
-        label: 'Project Settings',
-        icon: 'adjustments-alt',
-        path: 'settings',
-      },
+      ...(this.keycloakService.profile
+        ? [
+            {
+              label: 'Project Settings',
+              icon: 'adjustments-alt',
+              path: 'settings',
+            },
+          ]
+        : []),
     ];
 
     this.intervalId = setInterval(() => {

--- a/client/src/app/pages/pull-request-details/pull-request-details.component.html
+++ b/client/src/app/pages/pull-request-details/pull-request-details.component.html
@@ -29,9 +29,11 @@
 
 <div class="flex flex-col gap-6 max-w-6xl mr-4">
   <app-pipeline [selector]="pipelineSelector()" />
-  @if (query.data(); as pr) {
-    @if (pr.headRefRepoNameWithOwner === pr.repository?.nameWithOwner) {
-      <app-deployment-selection [sourceRef]="pr.headRefName" />
+  @if (isLoggedIn()) {
+    @if (query.data(); as pr) {
+      @if (pr.headRefRepoNameWithOwner === pr.repository?.nameWithOwner) {
+        <app-deployment-selection [sourceRef]="pr.headRefName" />
+      }
     }
   }
 </div>

--- a/client/src/app/pages/pull-request-details/pull-request-details.component.ts
+++ b/client/src/app/pages/pull-request-details/pull-request-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { MarkdownPipe } from '@app/core/modules/markdown/markdown.pipe';
 
 import { PipelineComponent, PipelineSelector } from '@app/components/pipeline/pipeline.component';
@@ -10,6 +10,7 @@ import { DeploymentSelectionComponent } from '@app/components/deployment-selecti
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { SkeletonModule } from 'primeng/skeleton';
 import { getPullRequestByRepositoryIdAndNumberOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 
 @Component({
   selector: 'app-branch-details',
@@ -17,6 +18,8 @@ import { getPullRequestByRepositoryIdAndNumberOptions } from '@app/core/modules/
   templateUrl: './pull-request-details.component.html',
 })
 export class PullRequestDetailsComponent {
+  private keycloakService = inject(KeycloakService);
+
   repositoryId = input.required<number>();
   pullRequestNumber = input.required<number>();
 
@@ -24,6 +27,8 @@ export class PullRequestDetailsComponent {
     ...getPullRequestByRepositoryIdAndNumberOptions({ path: { repoId: this.repositoryId(), number: this.pullRequestNumber() } }),
     refetchInterval: 30000,
   }));
+
+  isLoggedIn = computed(() => this.keycloakService.loggedIn());
 
   pipelineSelector = computed<PipelineSelector | null>(() => {
     const pr = this.query.data();

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -1,31 +1,45 @@
-<div class="container mx-auto p-4">
-  <app-page-heading>
-    <div subheading></div>
-    <div class="flex justify-between items-center w-full" heading>
-      <div>Your Repositories</div>
-      <!-- TODO: Remove and replace by update handlers directly on dropdowns -->
-      <p-button label="Connect Repository" (click)="showDialog()" size="small" [loading]="loading()"></p-button>
+<main>
+  <div class="flex h-screen py-3 pl-3 w-screen">
+    <div class="rounded-2xl p-5 mr-3 bg-slate-100 flex flex-col items-center justify-between h-full">
+      <app-helios-icon routerLink="/" size="3rem" class="rounded-xl w-12 cursor-pointer" />
+      <span class="flex-grow"></span>
+      <app-profile-nav-section />
     </div>
-    <span description> In the repository list you can find all of the repositories of your organization connected to Helios and are able to connect new ones. </span>
-  </app-page-heading>
-
-  <div class="card">
-    <div class="border rounded-md">
-      @for (item of repositories(); track item.id; let idx = $index, first = $first) {
-        <div class="flex justify-between items-center border-b p-4 gap-2 cursor-pointer hover:bg-slate-50" (click)="navigateToProject(item)">
-          <div class="flex flex-col">
-            <div class="text-xl font-medium mt-2">
-              {{ item.name }}
-              <span class="text-sm"><p-tag value="Public" [rounded]="true" severity="secondary" /></span>
-            </div>
-            <div class="text-base text-600">{{ item.description }}</div>
+    <div class="flex-grow">
+      <div class="container mx-auto p-4">
+        <app-page-heading>
+          <div subheading></div>
+          <div class="flex justify-between items-center w-full" heading>
+            <div>Connected Repositories</div>
+            <!-- TODO: Remove and replace by update handlers directly on dropdowns -->
+            @if (loggedIn()) {
+              <p-button label="Connect Repository" (click)="showDialog()" size="small" [loading]="loading()"></p-button>
+            }
           </div>
-          <div class="mr-2">
-            <i-tabler name="chevron-right"></i-tabler>
+          <span description> In the repository list you can find all of the repositories of your organization connected to Helios and are able to connect new ones. </span>
+        </app-page-heading>
+
+        <div class="card">
+          <div class="border rounded-md">
+            @for (item of repositories(); track item.id; let idx = $index, first = $first) {
+              <div class="flex justify-between items-center border-b p-4 gap-2 cursor-pointer hover:bg-slate-50" (click)="navigateToProject(item)">
+                <div class="flex flex-col">
+                  <div class="text-xl font-medium mt-2">
+                    {{ item.name }}
+                    <span class="text-sm"><p-tag value="Public" [rounded]="true" severity="secondary" /></span>
+                  </div>
+                  <div class="text-base text-600">{{ item.description }}</div>
+                </div>
+                <div class="mr-2">
+                  <i-tabler name="chevron-right"></i-tabler>
+                </div>
+              </div>
+            }
           </div>
         </div>
-      }
+        <app-connect-repo></app-connect-repo>
+      </div>
     </div>
+    <p-toast></p-toast>
   </div>
-  <app-connect-repo></app-connect-repo>
-</div>
+</main>

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -12,16 +12,16 @@
           <div class="flex justify-between items-center w-full" heading>
             <div>Connected Repositories</div>
             <!-- TODO: Remove and replace by update handlers directly on dropdowns -->
-            @if (loggedIn()) {
-              <p-button label="Connect Repository" (click)="showDialog()" size="small" [loading]="loading()"></p-button>
-            }
+            <!-- @if (loggedIn()) {
+              <p-button label="Connect Repository" (click)="showDialog()" size="small"></p-button>
+            } -->
           </div>
-          <span description> In the repository list you can find all of the repositories of your organization connected to Helios and are able to connect new ones. </span>
+          <span description> In the repository list you can find all of the repositories that were added to Helios. </span>
         </app-page-heading>
 
         <div class="card">
           <div class="border rounded-md">
-            @for (item of repositories(); track item.id; let idx = $index, first = $first) {
+            @for (item of query.data(); track item.id) {
               <div class="flex justify-between items-center border-b p-4 gap-2 cursor-pointer hover:bg-slate-50" (click)="navigateToProject(item)">
                 <div class="flex flex-col">
                   <div class="text-xl font-medium mt-2">

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -1,8 +1,11 @@
 import { Component, computed, inject, viewChild } from '@angular/core';
 import { Router } from '@angular/router';
 import { ConnectRepoComponent } from '@app/components/connect-repo/connect-repo.component';
+import { HeliosIconComponent } from '@app/components/helios-icon/helios-icon.component';
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
+import { ProfileNavSectionComponent } from '@app/components/profile-nav-section/profile-nav-section.component';
 import { RepositoryInfoDto } from '@app/core/modules/openapi';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 import { RepositoryService } from '@app/core/services/repository.service';
 import { IconsModule } from 'icons.module';
 import { ButtonModule } from 'primeng/button';
@@ -10,14 +13,28 @@ import { CardModule } from 'primeng/card';
 import { ChipModule } from 'primeng/chip';
 import { DataViewModule } from 'primeng/dataview';
 import { TagModule } from 'primeng/tag';
+import { ToastModule } from 'primeng/toast';
 
 @Component({
   selector: 'app-repository-overview',
-  imports: [DataViewModule, ButtonModule, TagModule, CardModule, ChipModule, IconsModule, ConnectRepoComponent, PageHeadingComponent],
+  imports: [
+    DataViewModule,
+    ButtonModule,
+    TagModule,
+    CardModule,
+    ChipModule,
+    IconsModule,
+    ConnectRepoComponent,
+    PageHeadingComponent,
+    ToastModule,
+    ProfileNavSectionComponent,
+    HeliosIconComponent,
+  ],
   templateUrl: './repository-overview.component.html',
 })
 export class ProjectOverviewComponent {
   private repositoryService = inject(RepositoryService);
+  private keycloakService = inject(KeycloakService);
   private router = inject(Router);
 
   readonly repositoryConnection = viewChild.required(ConnectRepoComponent);
@@ -26,8 +43,11 @@ export class ProjectOverviewComponent {
   loading = computed(() => this.repositoryService.loading());
 
   showDialog() {
-    console.log(this.repositories());
     this.repositoryConnection().show();
+  }
+
+  loggedIn() {
+    return this.keycloakService.loggedIn();
   }
 
   refreshRepositories() {

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -5,8 +5,10 @@ import { HeliosIconComponent } from '@app/components/helios-icon/helios-icon.com
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
 import { ProfileNavSectionComponent } from '@app/components/profile-nav-section/profile-nav-section.component';
 import { RepositoryInfoDto } from '@app/core/modules/openapi';
+import { getAllRepositoriesOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 import { RepositoryService } from '@app/core/services/repository.service';
+import { injectQuery } from '@tanstack/angular-query-experimental';
 import { IconsModule } from 'icons.module';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -37,10 +39,10 @@ export class ProjectOverviewComponent {
   private keycloakService = inject(KeycloakService);
   private router = inject(Router);
 
-  readonly repositoryConnection = viewChild.required(ConnectRepoComponent);
+  query = injectQuery(() => getAllRepositoriesOptions());
+  repositories = computed(() => this.query.data());
 
-  repositories = computed(() => this.repositoryService.repositories());
-  loading = computed(() => this.repositoryService.loading());
+  readonly repositoryConnection = viewChild.required(ConnectRepoComponent);
 
   showDialog() {
     this.repositoryConnection().show();

--- a/client/src/icons.module.ts
+++ b/client/src/icons.module.ts
@@ -43,6 +43,7 @@ import {
   IconList,
   IconBinaryTree,
   IconShieldHalf,
+  IconLogin,
 } from 'angular-tabler-icons/icons';
 
 // Select some icons (use an object, not an array)
@@ -88,6 +89,7 @@ const icons = {
   IconFilterPlus,
   IconLock,
   IconShieldHalf,
+  IconLogin,
 };
 
 @NgModule({

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -325,14 +325,16 @@ paths:
     get:
       tags:
       - repository-controller
-      operationId: getRepositories
+      operationId: getAllRepositories
       responses:
         "200":
           description: OK
           content:
             application/json:
               schema:
-                type: object
+                type: array
+                items:
+                  $ref: "#/components/schemas/RepositoryInfoDto"
   /api/repository/{id}:
     get:
       tags:

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -321,6 +321,18 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/WorkflowGroupDto"
+  /api/repository:
+    get:
+      tags:
+      - repository-controller
+      operationId: getRepositories
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
   /api/repository/{id}:
     get:
       tags:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/auth/AuthService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/auth/AuthService.java
@@ -33,4 +33,8 @@ public class AuthService {
 
     throw new IllegalStateException("Unable to fetch user ID");
   }
+
+  public boolean isLoggedIn() {
+    return SecurityContextHolder.getContext().getAuthentication() != null;
+  }
 } 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.lang.NonNull;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -36,20 +37,23 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable) // Disable CSRF
         .authorizeHttpRequests(
             auth -> {
-              auth.requestMatchers(
-                      "/auth/**",
-                      "/bus/v3/api-docs/**",
-                      "/v2/api-docs",
-                      "/v3/api-docs",
-                      "/v3/api-docs/**",
-                      "/v3/api-docs.yaml",
-                      "/swagger-resources",
-                      "/swagger-resources/**",
-                      "/configuration/ui",
-                      "/configuration/security",
-                      "/swagger-ui/**",
-                      "/webjars/**",
-                      "/swagger-ui.html")
+              auth
+                .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                .requestMatchers(
+                        "/auth/**",
+                        "/bus/v3/api-docs/**",
+                        "/v2/api-docs",
+                        "/v3/api-docs",
+                        "/v3/api-docs/**",
+                        "/v3/api-docs.yaml",
+                        "/swagger-resources",
+                        "/swagger-resources/**",
+                        "/configuration/ui",
+                        "/configuration/security",
+                        "/swagger-ui/**",
+                        "/webjars/**",
+                        "/swagger-ui.html",
+                        "/api/**")
                   .permitAll()
                   .anyRequest()
                   .authenticated();

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.gitrepo;
 
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,8 +18,8 @@ public class RepositoryController {
   }
 
   @GetMapping
-  public ResponseEntity<Iterable<RepositoryInfoDto>> getRepositories() {
-    return ResponseEntity.ok(repositoryService.getRepositories());
+  public ResponseEntity<List<RepositoryInfoDto>> getAllRepositories() {
+    return ResponseEntity.ok(repositoryService.getAllRepositories());
   }
 
   @GetMapping("/{id}")

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryController.java
@@ -16,6 +16,11 @@ public class RepositoryController {
     this.repositoryService = repositoryService;
   }
 
+  @GetMapping
+  public ResponseEntity<Iterable<RepositoryInfoDto>> getRepositories() {
+    return ResponseEntity.ok(repositoryService.getRepositories());
+  }
+
   @GetMapping("/{id}")
   public ResponseEntity<RepositoryInfoDto> getRepositoryById(@PathVariable Long id) {
     return repositoryService

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryService.java
@@ -12,6 +12,10 @@ public class RepositoryService {
     this.repositoryRepository = repositoryRepository;
   }
 
+  public Iterable<RepositoryInfoDto> getRepositories() {
+    return repositoryRepository.findAll().stream().map(RepositoryInfoDto::fromRepository).toList();
+  }
+
   public Optional<RepositoryInfoDto> getRepositoryById(Long id) {
     return repositoryRepository.findById(id).map(RepositoryInfoDto::fromRepository);
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/gitrepo/RepositoryService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.gitrepo;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +13,7 @@ public class RepositoryService {
     this.repositoryRepository = repositoryRepository;
   }
 
-  public Iterable<RepositoryInfoDto> getRepositories() {
+  public List<RepositoryInfoDto> getAllRepositories() {
     return repositoryRepository.findAll().stream().map(RepositoryInfoDto::fromRepository).toList();
   }
 


### PR DESCRIPTION
This pull request allows users to see most pages without login and show their proper initials. For now, I allowed all GET requests without login as that should be safe, but we can change that to a more granular selection in the future. I'm hiding some actions/views such as the repo settings and deployment section.

Additionally, I temporarily commented out the "Connect repo" button because AFAIK it was just adding the repo the local storage and not actually adding it to the database, right? Showing all of the repos in the DB right now instead, so a not logged-in user does not see an empty screen. If I am wrong here , I can easily add it back.

In order to fix #104 completely, I still have to enable auto refresh of the tokens.