### PR TITLE
fix: Add missing deployment icons and remove settings icon from sidebar

### DIFF
--- a/client/src/app/pages/main-layout/main-layout.component.html
+++ b/client/src/app/pages/main-layout/main-layout.component.html
@@ -25,7 +25,6 @@
           <span class="w-20">{{ timeSinceLocked(lockQuery.data()?.lockedAt) }}</span>
         </p>
       }
-      <i-tabler name="settings" pTooltip="Settings" class="!size-10 text-gray-500 hover:text-gray-700 !stroke-1" />
       <app-profile-nav-section />
     </div>
 

--- a/client/src/icons.module.ts
+++ b/client/src/icons.module.ts
@@ -46,6 +46,8 @@ import {
   IconLogin,
   IconExclamationCircle,
   IconInfoCircle,
+  IconExclamationMark,
+  IconTimeDurationOff,
 } from 'angular-tabler-icons/icons';
 
 // Select some icons (use an object, not an array)
@@ -94,6 +96,8 @@ const icons = {
   IconLogin,
   IconExclamationCircle,
   IconInfoCircle,
+  IconExclamationMark,
+  IconTimeDurationOff,
 };
 
 @NgModule({


### PR DESCRIPTION
* Removed the settings icon from the main layout component, because it's currently unused (`client/src/app/pages/main-layout/main-layout.component.html`)

* Added new icons `IconExclamationMark` and `IconTimeDurationOff` to the import statement and the `icons` object in the icons module, because they are used by the deployment states, but not imported correctly. (`client/src/icons.module.ts`) [[1]](diffhunk://#diff-d087b05c840f170fdaa86fa16f6bc6e7a4fa2ea08fb0fee0d94f2e313db7f623R49-R50) [[2]](diffhunk://#diff-d087b05c840f170fdaa86fa16f6bc6e7a4fa2ea08fb0fee0d94f2e313db7f623R99-R100)
