### PR TITLE
fix: Get the latest token every request

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -16,18 +16,18 @@ export class AppComponent {
   private messageService = inject(MessageService);
 
   constructor() {
-    const token = this.keycloakService.keycloak.token;
-
     client.setConfig({
       baseUrl: environment.serverUrl,
     });
 
-    if (token) {
-      client.interceptors.request.use(request => {
+    client.interceptors.request.use(request => {
+      const token = this.keycloakService.keycloak.token;
+
+      if (token) {
         request.headers.set('Authorization', `Bearer ${token}`);
-        return request;
-      });
-    }
+      }
+      return request;
+    });
 
     client.interceptors.response.use(async response => {
       if (response.ok == false) {


### PR DESCRIPTION
In #182 I added logic that would periodically refresh the access token. However, the query client middleware that sets the API token within the Authorization header of an API request retrieved the token only once after the page load.

This code updates the middleware to always get the latest token before a request. That fixes #149 