### PR TITLE
fix: Lock issue on environment update

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -186,7 +186,7 @@ public class EnvironmentService {
                 throw new EnvironmentException(
                     "Environment is locked and can not be disabled. "
                         + "Please unlock the environment first.");
-              } else if (environmentDto.enabled()) {
+              } else if (!environment.isEnabled() && environmentDto.enabled()) {
                 environment.setLocked(false);
                 environment.setLockedBy(null);
                 environment.setLockedAt(null);


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixed a bug where updating the environment with active set to true was unintentionally clearing the lock status. The intended behavior is to clear the previous lock information in the environment entity only when the environment is being re-enabled (i.e., transitioning from disabled to enabled). This ensures that no outdated lock data is retained. 