### PR TITLE
fix: Ensure workflow groups and names fit properly in PR and Branch views

### DIFF
--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -37,7 +37,7 @@
     @for (group of pipeline.groups; track group.name) {
       @if (group.workflows.length > 0) {
         <ng-container>
-          <p-panel [header]="group.name">
+          <p-panel [header]="group.name" class="max-w-[250px]">
             <div class="flex flex-col gap-4">
               @for (workflowRun of group.workflows; track workflowRun.id) {
                 <div class="flex items-center space-x-2">

--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -59,8 +59,8 @@
                     <i-tabler name="progress-help" class="text-gray-500" pTooltip="Unknown"></i-tabler>
                   }
                   <!-- Fixed width to ensure consistent alignment -->
-                  <span class="font-medium w-36 flex items-center">
-                    <span class="truncate" [pTooltip]="workflowRun.name">{{ workflowRun.name }}</span>
+                  <span class="font-medium flex items-center justify-between w-full">
+                    <span [pTooltip]="workflowRun.name">{{ workflowRun.name }}</span>
                     <a class="ml-1" [href]="workflowRun.htmlUrl" target="_new"><i-tabler name="external-link" class="w-20 h-20"></i-tabler></a>
                   </span>
                 </div>

--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -24,7 +24,7 @@
 }
 
 @if (pipeline(); as pipeline) {
-  <div class="flex items-start mt-2">
+  <div class="flex flex-wrap items-start gap-y-4 mt-2">
     <!-- Check if all groups have no workflow runs -->
     <!-- If so, display a message saying that no workflow runs have been found -->
     @if (allGroupsHaveNoWorkflowRuns()) {


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
This change addresses an issue where workflow groups and names were not displayed properly in the PR and Branch views, as reported in #258. Panels failed to wrap when space was limited, and workflow names were truncated.


### Description
<!-- Describe your changes in detail -->
- Added `flex-wrap` to ensure workflow panels wrap to the next row when they exceed available space.
- Introduced `max-w-[250px]` to limit panel widths.
- Replaced fixed width (`w-36`) for workflow names with flexible width (`w-full`) for full utilization of available space.
- Removed truncation (`truncate`) for names.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
![image](https://github.com/user-attachments/assets/b2a8ae0a-8a6d-49b4-9227-6dcdbbc8d59c)

![image](https://github.com/user-attachments/assets/28c32f09-3ebe-4665-95d3-86b8f7050ccf)

![image](https://github.com/user-attachments/assets/c6f6b688-ed6f-473d-b9cf-f864af06f2fd)

