### PR TITLE
fix: Expand nodes and highlight text on branch search

### DIFF
--- a/client/src/app/components/branches-table/branches-table.component.html
+++ b/client/src/app/components/branches-table/branches-table.component.html
@@ -45,7 +45,17 @@
             <div class="flex items-center gap-2">
               <p-treeTableToggler [rowNode]="rowNode" />
 
-              <p-tag [value]="branch.name" />
+              <p-tag>
+                @for (part of (branch.name | highlight: searchTableService.searchValue()); track part.text) {
+                  <span
+                    [class.bg-yellow-200]="part.highlight"
+                    [class.font-semibold]="part.highlight"
+                    [class.rounded]="part.highlight"
+                  >
+                    {{ part.text }}
+                  </span>
+                }
+              </p-tag>
               @if (branch.isProtected) {
                 <i-tabler name="shield-half" pTooltip="Protected Branch" />
               }

--- a/client/src/app/components/branches-table/branches-table.component.html
+++ b/client/src/app/components/branches-table/branches-table.component.html
@@ -46,12 +46,8 @@
               <p-treeTableToggler [rowNode]="rowNode" />
 
               <p-tag>
-                @for (part of (branch.name | highlight: searchTableService.searchValue()); track part.text) {
-                  <span
-                    [class.bg-yellow-200]="part.highlight"
-                    [class.font-semibold]="part.highlight"
-                    [class.rounded]="part.highlight"
-                  >
+                @for (part of branch.name | highlight: searchTableService.searchValue(); track part.text) {
+                  <span [class.bg-yellow-200]="part.highlight" [class.font-semibold]="part.highlight" [class.rounded]="part.highlight">
                     {{ part.text }}
                   </span>
                 }

--- a/client/src/app/components/branches-table/branches-table.component.html
+++ b/client/src/app/components/branches-table/branches-table.component.html
@@ -46,11 +46,13 @@
               <p-treeTableToggler [rowNode]="rowNode" />
 
               <p-tag>
-                @for (part of branch.name | highlight: searchTableService.searchValue(); track part.text) {
-                  <span [class.bg-yellow-200]="part.highlight" [class.font-semibold]="part.highlight" [class.rounded]="part.highlight">
-                    {{ part.text }}
-                  </span>
-                }
+                <div class="flex items-center">
+                  @for (part of branch.name | highlight: searchTableService.searchValue(); track part.text) {
+                    <span [class.bg-yellow-200]="part.highlight" [class.font-semibold]="part.highlight" [class.rounded]="part.highlight">
+                      {{ part.text }}
+                    </span>
+                  }
+                </div>
               </p-tag>
               @if (branch.isProtected) {
                 <i-tabler name="shield-half" pTooltip="Protected Branch" />

--- a/client/src/app/components/branches-table/branches-table.component.ts
+++ b/client/src/app/components/branches-table/branches-table.component.ts
@@ -21,7 +21,7 @@ import { FormsModule } from '@angular/forms';
 import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
 import { FILTER_OPTIONS_TOKEN, SearchTableService } from '@app/core/services/search-table.service';
 import { TableFilterComponent } from '../table-filter/table-filter.component';
-import {HighlightPipe} from '@app/pipes/highlight.pipe';
+import { HighlightPipe } from '@app/pipes/highlight.pipe';
 
 type BranchInfoWithLink = BranchInfoDto & { link: string; lastCommitLink: string };
 
@@ -149,9 +149,7 @@ export class BranchTableComponent {
 
     // Function to check if the branch name matches the search value
     const matchesSearch = (branch: BranchInfoWithLink) =>
-      this.searchTableService.searchValue().toLowerCase() &&
-      branch.name.toLowerCase().includes(this.searchTableService.searchValue().toLowerCase());
-
+      this.searchTableService.searchValue().toLowerCase() && branch.name.toLowerCase().includes(this.searchTableService.searchValue().toLowerCase());
 
     branches.forEach(branch => {
       const pathParts = branch.name.split('/');
@@ -207,9 +205,7 @@ export class BranchTableComponent {
                 parentNode.expanded = true;
               }
               // Move up one level by removing the last segment of the path
-              parentPath = parentPath.includes('/')
-                ? parentPath.slice(0, parentPath.lastIndexOf('/'))
-                : '';
+              parentPath = parentPath.includes('/') ? parentPath.slice(0, parentPath.lastIndexOf('/')) : '';
             }
           }
         }

--- a/client/src/app/components/branches-table/branches-table.component.ts
+++ b/client/src/app/components/branches-table/branches-table.component.ts
@@ -158,6 +158,7 @@ export class BranchTableComponent {
             data: {
               name: part,
             },
+            expanded: false,
           };
 
           // If it's a leaf node, add the branch info

--- a/client/src/app/components/branches-table/branches-table.component.ts
+++ b/client/src/app/components/branches-table/branches-table.component.ts
@@ -21,6 +21,7 @@ import { FormsModule } from '@angular/forms';
 import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
 import { FILTER_OPTIONS_TOKEN, SearchTableService } from '@app/core/services/search-table.service';
 import { TableFilterComponent } from '../table-filter/table-filter.component';
+import {HighlightPipe} from '@app/pipes/highlight.pipe';
 
 type BranchInfoWithLink = BranchInfoDto & { link: string; lastCommitLink: string };
 
@@ -72,6 +73,7 @@ const FILTER_OPTIONS = [
     InputIconModule,
     InputTextModule,
     FormsModule,
+    HighlightPipe,
   ],
   providers: [SearchTableService, { provide: FILTER_OPTIONS_TOKEN, useValue: FILTER_OPTIONS }],
   templateUrl: './branches-table.component.html',

--- a/client/src/app/components/branches-table/branches-table.component.ts
+++ b/client/src/app/components/branches-table/branches-table.component.ts
@@ -145,6 +145,12 @@ export class BranchTableComponent {
     ];
     const nodeMap = new Map<string, TreeNode>();
 
+    // Function to check if the branch name matches the search value
+    const matchesSearch = (branch: BranchInfoWithLink) =>
+      this.searchTableService.searchValue().toLowerCase() &&
+      branch.name.toLowerCase().includes(this.searchTableService.searchValue().toLowerCase());
+
+
     branches.forEach(branch => {
       const pathParts = branch.name.split('/');
       let currentPath = '';
@@ -185,6 +191,23 @@ export class BranchTableComponent {
             const parentNode = nodeMap.get(parentPath);
             if (parentNode && parentNode.children) {
               parentNode.children.push(newNode);
+            }
+          }
+
+          // Expand nodes if they match the search
+          if (matchesSearch(branch)) {
+            // Start from the current node path and expand all the way up to the root
+            let parentPath = currentPath;
+            while (parentPath) {
+              const parentNode = nodeMap.get(parentPath);
+              if (parentNode) {
+                // Expand the parent node
+                parentNode.expanded = true;
+              }
+              // Move up one level by removing the last segment of the path
+              parentPath = parentPath.includes('/')
+                ? parentPath.slice(0, parentPath.lastIndexOf('/'))
+                : '';
             }
           }
         }

--- a/client/src/app/pipes/highlight.pipe.spec.ts
+++ b/client/src/app/pipes/highlight.pipe.spec.ts
@@ -1,0 +1,69 @@
+import { HighlightPipe } from './highlight.pipe';
+
+describe('HighlightPipe', () => {
+  let highlightPipe: HighlightPipe;
+
+  beforeEach(() => {
+    highlightPipe = new HighlightPipe();
+  });
+
+  it('should return unaltered text when term is null or empty', () => {
+    const result = highlightPipe.transform('example text', '');
+    expect(result).toEqual([{ text: 'example text', highlight: false }]);
+
+    const resultNull = highlightPipe.transform('example text', null);
+    expect(resultNull).toEqual([{ text: 'example text', highlight: false }]);
+  });
+
+  it('should return unaltered text when text is null or undefined', () => {
+    const resultNullText = highlightPipe.transform(null, 'term');
+    expect(resultNullText).toEqual([{ text: '', highlight: false }]);
+
+    const resultUndefinedText = highlightPipe.transform(undefined, 'term');
+    expect(resultUndefinedText).toEqual([{ text: '', highlight: false }]);
+  });
+
+  it('should highlight matching text correctly', () => {
+    const result = highlightPipe.transform('example text', 'text');
+    expect(result).toEqual([
+      { text: 'example ', highlight: false },
+      { text: 'text', highlight: true },
+    ]);
+  });
+
+  it('should handle case-insensitive matches correctly', () => {
+    const result = highlightPipe.transform('Example Text', 'text');
+    expect(result).toEqual([
+      { text: 'Example ', highlight: false },
+      { text: 'Text', highlight: true },
+    ]);
+  });
+
+  it('should highlight multiple occurrences correctly', () => {
+    const result = highlightPipe.transform('text example text', 'text');
+    expect(result).toEqual([
+      { text: 'text', highlight: true },
+      { text: ' example ', highlight: false },
+      { text: 'text', highlight: true },
+    ]);
+  });
+
+  it('should return unaltered text when term does not match', () => {
+    const result = highlightPipe.transform('example text', 'term');
+    expect(result).toEqual([{ text: 'example text', highlight: false }]);
+  });
+
+  it('should handle empty text input correctly', () => {
+    const result = highlightPipe.transform('', 'term');
+    expect(result).toEqual([{ text: '', highlight: false }]);
+  });
+
+  it('should handle string with spaces at the beginning and end correctly', () => {
+    const result = highlightPipe.transform(' text ', 'text');
+    expect(result).toEqual([
+      { text: ' ', highlight: false },
+      { text: 'text', highlight: true },
+      { text: ' ', highlight: false },
+    ]);
+  });
+});

--- a/client/src/app/pipes/highlight.pipe.ts
+++ b/client/src/app/pipes/highlight.pipe.ts
@@ -3,10 +3,7 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'highlight',
 })
 export class HighlightPipe implements PipeTransform {
-  transform(
-    text: string | null | undefined,
-    term: string | null | undefined
-  ): { text: string; highlight: boolean }[] {
+  transform(text: string | null | undefined, term: string | null | undefined): { text: string; highlight: boolean }[] {
     // Handle edge cases
     if (!text || !term || term.trim() === '') {
       return [{ text: text || '', highlight: false }];

--- a/client/src/app/pipes/highlight.pipe.ts
+++ b/client/src/app/pipes/highlight.pipe.ts
@@ -1,0 +1,27 @@
+import { Pipe, PipeTransform } from '@angular/core';
+@Pipe({
+  name: 'highlight',
+})
+export class HighlightPipe implements PipeTransform {
+  transform(
+    text: string | null | undefined,
+    term: string | null | undefined
+  ): { text: string; highlight: boolean }[] {
+    // Handle edge cases
+    if (!text || !term || term.trim() === '') {
+      return [{ text: text || '', highlight: false }];
+    }
+
+    // Case-insensitive matching
+    const regex = new RegExp(`(${term})`, 'gi');
+    const parts = text.split(regex);
+
+    // Filter out empty strings and return each part with highlight flag
+    return parts
+      .filter(part => part !== '')
+      .map(part => ({
+        text: part,
+        highlight: regex.test(part),
+      }));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
The change enhances user experience by automatically expanding nodes in the tree view during branch search and highlighting the matching text.

### Description
- Implemented automatic expansion of tree nodes when a branch search matches any part of the tree.
- Added `HighlightPipe` to handle text highlighting for matched search terms efficiently.
- Included tests for the `HighlightPipe`.
- Added text highlighting for matched search terms to improve visual clarity.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->

https://github.com/user-attachments/assets/84f7d7d2-2d6f-4c02-b545-a43579420d5c

**Question:** Should we consider highlighting only the leaf nodes instead of intermediate nodes? For example, if the search key is `feature`, we would not highlight `feature` itself but only `feature/add-new-tab` or similar leaf nodes in the tree.
