### PR TITLE
fix: Flyway validation not working properly for PRs

### DIFF
--- a/.github/workflows/flyway-validate.yml
+++ b/.github/workflows/flyway-validate.yml
@@ -53,7 +53,7 @@ jobs:
             echo "Flyway migration changes detected:"
             echo "$CHANGED_PATHS"
 
-            if echo "$CHANGED_FILES" | grep -q "^[^A]"; then
+            if echo "$CHANGED_PATHS" | grep -q "^[^A]"; then
               echo "Error: One or more existing migrations were changed."
               exit 1
             else

--- a/.github/workflows/flyway-validate.yml
+++ b/.github/workflows/flyway-validate.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check for changes
         id: check_changes
         run: |
-          CHANGED_PATHS=$(git diff --name-status origin/${{ github.base_ref }} origin/${{ github.head_ref }} | grep -E "server/application-server/src/main/resources/db/migration/")
+          CHANGED_PATHS=$(git diff --name-status origin/${{ github.base_ref }} origin/${{ github.head_ref }} | grep -E "server/application-server/src/main/resources/db/migration/" || true)
 
           if [[ -z "$CHANGED_PATHS" ]]; then
             echo "CHANGE_DETECTED=false" >> "$GITHUB_OUTPUT"

--- a/server/application-server/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/server/application-server/src/main/resources/db/migration/V1__initial_schema.sql
@@ -476,5 +476,3 @@ ALTER TABLE ONLY public.helios_deployment
 
 ALTER TABLE ONLY public.issue_label
     ADD CONSTRAINT fkxbk5rr30kkb6k4ech7x4vh9h FOREIGN KEY (label_id) REFERENCES public.label(id);
-
-test

--- a/server/application-server/src/main/resources/db/migration/V1__initial_schema.sql
+++ b/server/application-server/src/main/resources/db/migration/V1__initial_schema.sql
@@ -476,3 +476,5 @@ ALTER TABLE ONLY public.helios_deployment
 
 ALTER TABLE ONLY public.issue_label
     ADD CONSTRAINT fkxbk5rr30kkb6k4ech7x4vh9h FOREIGN KEY (label_id) REFERENCES public.label(id);
+
+test


### PR DESCRIPTION
Right now, Flyway validate PRs are failing for workflows that don't change anything about migrations. That will be addressed here.

The issue was that when checking any file changes within the migration directory `git diff` will return an error exit code if there are no changes. The PR updates that logic.