### PR TITLE
feat: Implement pipeline for processing test workflow results

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -22,9 +22,11 @@ import okhttp3.Request;
 import okhttp3.Request.Builder;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+import org.kohsuke.github.GHArtifact;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHWorkflow;
+import org.kohsuke.github.PagedIterable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -95,6 +97,17 @@ public class GitHubService {
    */
   public GHRepository getRepository(String repoNameWithOwners) throws IOException {
     return github.getRepository(repoNameWithOwners);
+  }
+
+  /**
+   * Retrieves the artifacts for a given repository.
+   * 
+   * @param repoNameWithOwners
+   * @return the list of repositories as a PagedIterable object (not thread-safe)
+   * @throws IOException
+   */
+  public PagedIterable<GHArtifact> getWorkflowRunArtifacts(long repoId, long workflowRunId) throws IOException {
+    return github.getRepositoryById(repoId).getWorkflowRun(workflowRunId).listArtifacts();
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResult.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResult.java
@@ -1,0 +1,48 @@
+package de.tum.cit.aet.helios.tests;
+
+import de.tum.cit.aet.helios.workflow.WorkflowRun;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class TestResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    private WorkflowRun workflowRun;
+
+    @Min(0)
+    @Column(nullable = false)
+    private int total;
+
+    @Min(0)
+    @Column(nullable = false)
+    private int passed;
+
+    @Min(0)
+    @Column(nullable = false)
+    private int failures;
+
+    @Min(0)
+    @Column(nullable = false)
+    private int errors;
+
+    @Min(0)
+    @Column(nullable = false)
+    private int skipped;
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.helios.tests;
+
+import java.util.List;
+import kotlin.NotImplementedError;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/test-results")
+public class TestResultController {
+    @GetMapping("/pr/{pullRequestId}")
+    public ResponseEntity<List<TestResult>> getTestResultsByPullRequestIdAndHeadCommit(
+            @PathVariable Long pullRequestId) {
+        throw new NotImplementedError("Not implemented yet");
+    }
+
+    @GetMapping("/branch")
+    public ResponseEntity<List<TestResult>> getTestResultsByBranchAndHeadCommit(@RequestParam String branch) {
+        throw new NotImplementedError("Not implemented yet");
+    }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultException.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultException.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.helios.tests;
+
+public class TestResultException extends RuntimeException {
+    public TestResultException(String message) {
+        super(message);
+    }
+
+    public TestResultException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -1,0 +1,106 @@
+package de.tum.cit.aet.helios.tests;
+
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.tests.parsers.JUnitParser;
+import de.tum.cit.aet.helios.tests.parsers.TestParserResult;
+import de.tum.cit.aet.helios.workflow.WorkflowRun;
+import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.kohsuke.github.GHArtifact;
+import org.kohsuke.github.PagedIterable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class TestResultProcessor {
+    private final GitHubService gitHubService;
+    private final WorkflowRunRepository workflowRunRepository;
+    private final TestResultRepository testResultRepository;
+    private final JUnitParser junitParser;
+
+    @Value("${tests.artifactName:Test Results}")
+    private String testArtifactName;
+
+    public void processRun(long workflowRunId) {
+        final WorkflowRun workflowRun = this.workflowRunRepository.findById(workflowRunId)
+                .orElseThrow(() -> new TestResultException("Workflow run not found"));
+
+        log.debug("Processing test results for workflow run {}", workflowRunId);
+
+        GHArtifact testResultsArtifact = null;
+
+        try {
+            PagedIterable<GHArtifact> artifacts = this.gitHubService.getWorkflowRunArtifacts(
+                    workflowRun.getRepository().getRepositoryId(), workflowRunId);
+
+            // Traverse page iterable to find the first artifact with the configured name
+            for (GHArtifact artifact : artifacts) {
+                if (artifact.getName().equals(this.testArtifactName)) {
+                    testResultsArtifact = artifact;
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw new TestResultException("Failed to fetch artifacts", e);
+        }
+
+        if (testResultsArtifact == null) {
+            throw new TestResultException("Test results artifact not found");
+        }
+
+        log.debug("Found test results artifact {}", testResultsArtifact.getName());
+
+        List<TestParserResult> results;
+
+        try {
+            results = this.processTestResultArtifact(testResultsArtifact);
+        } catch (IOException e) {
+            throw new TestResultException("Failed to process test results artifact", e);
+        }
+
+        log.debug("Parsed {} test results. Persisting...", results.size());
+
+        results.forEach(result -> {
+            final TestResult testResult = new TestResult();
+            testResult.setWorkflowRun(workflowRun);
+            testResult.setTotal(result.total());
+            testResult.setPassed(result.passed());
+            testResult.setFailures(result.failures());
+            testResult.setErrors(result.errors());
+            testResult.setSkipped(result.skipped());
+            testResultRepository.save(testResult);
+        });
+
+        log.debug("Persisted test results");
+    }
+
+    private List<TestParserResult> processTestResultArtifact(GHArtifact artifact) throws IOException {
+        // Download the ZIP artifact, find all parsable XML files and parse them
+        return artifact.download(stream -> {
+            List<TestParserResult> results = new ArrayList<>();
+
+            try (ZipInputStream zipInput = new ZipInputStream(stream)) {
+                ZipEntry entry;
+
+                while ((entry = zipInput.getNextEntry()) != null) {
+                    if (!entry.isDirectory()) {
+                        if (this.junitParser.supports(entry.getName())) {
+                            results.add(this.junitParser.parse(zipInput));
+                        }
+                    }
+                    zipInput.closeEntry();
+                }
+            }
+
+            return results;
+        });
+    }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultRepository.java
@@ -1,0 +1,9 @@
+package de.tum.cit.aet.helios.tests;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestResultRepository extends JpaRepository<TestResult, Long> {
+
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/JUnitParser.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/JUnitParser.java
@@ -1,0 +1,49 @@
+package de.tum.cit.aet.helios.tests.parsers;
+
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import java.io.InputStream;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+
+@Component
+@Log4j2
+public class JUnitParser implements TestResultParser {
+  public TestParserResult parse(InputStream inputStream) {
+    try {
+      JAXBContext context = JAXBContext.newInstance(TestSuite.class);
+      Unmarshaller unmarshaller = context.createUnmarshaller();
+      TestSuite suite = (TestSuite) unmarshaller.unmarshal(inputStream);
+
+      return new TestParserResult(
+          suite.tests,
+          suite.failures,
+          suite.errors,
+          suite.skipped,
+          suite.time);
+    } catch (JAXBException e) {
+      throw new TestResultParseException("Failed to parse JUnit XML", e);
+    }
+  }
+
+  public boolean supports(String fileName) {
+    return fileName.startsWith("TEST-") && fileName.endsWith(".xml");
+  }
+
+  @XmlRootElement(name = "testsuite")
+  public static class TestSuite {
+    @XmlAttribute
+    public int tests;
+    @XmlAttribute
+    public int failures;
+    @XmlAttribute
+    public int errors;
+    @XmlAttribute
+    public int skipped;
+    @XmlAttribute
+    public double time;
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestParserResult.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestParserResult.java
@@ -1,0 +1,13 @@
+package de.tum.cit.aet.helios.tests.parsers;
+
+public record TestParserResult(int total, int failures, int errors, int skipped, double time) {
+    public TestParserResult {
+        if (total < 0 || failures < 0 || errors < 0 || skipped < 0 || time < 0) {
+            throw new IllegalArgumentException("Negative values not allowed");
+        }
+    }
+
+    public int passed() {
+        return total - failures - errors - skipped;
+    }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestResultParseException.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestResultParseException.java
@@ -1,0 +1,7 @@
+package de.tum.cit.aet.helios.tests.parsers;
+
+public class TestResultParseException extends RuntimeException {
+    public TestResultParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestResultParser.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/TestResultParser.java
@@ -1,0 +1,9 @@
+package de.tum.cit.aet.helios.tests.parsers;
+
+import java.io.InputStream;
+
+public interface TestResultParser {
+    TestParserResult parse(InputStream content);
+
+    boolean supports(String artifactName);
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -1,11 +1,14 @@
 package de.tum.cit.aet.helios.workflow;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface WorkflowRunRepository extends JpaRepository<WorkflowRun, Long> {
+  Optional<WorkflowRun> findById(long id);
+
   List<WorkflowRun> findByPullRequestsIdAndHeadSha(Long pullRequestsId, String headSha);
 
   List<WorkflowRun> findByHeadBranchAndHeadShaAndPullRequestsIsNull(String branch, String headSha);


### PR DESCRIPTION
I started looking into the implementation of our test case overview that we want to show within Helios in the near future for branches and PRs. Right now, we're only showing the checks/status of the workflow runs.

## Objective
This PR will cover a first implementation of a test processing pipeline that will create `TestResult` entities based on a `WorkflowRun` containing Junit test results (xml files) within its artifacts. Additionally, it should expose challenges or edge-cases that we might have to deal with in the future.

## Current pipeline
1. Artifact fetching
  - Retrieves workflow run artifacts via GitHub API (returns `PagedIterator`)
  - Looks for specifically named artifact ("Test Results")
2. ZIP processing
  - Downloads and unpacks zip archive (using stream)
  - Searches for JUnit XML files within the archive
3. Result parsing
  - Simple JUnit XML parsing using JAXB
  - Basic aggregation of totals (passed/failed/time)
5. Persistence
  - Stores summarized results linked to workflow runs

## Todos

- [ ] **Trigger Test Workflow Processing**
Implement automatic processing of a test workflow when relevant events occur (e.g., upon receiving a webhook event indicating completion or failure).

- [ ] **Consider using labels or markers to limit processing to relevant workflows only.**
Handle Invalid Files and Enforce Zip Format
Ensure proper handling of invalid files by verifying that uploaded artifacts are always in the zip format.

- [ ] **Manage Large Files**
Develop strategies for handling large files, including setting a maximum file size or applying timeouts to prevent prolonged processing.

- [ ] **Error Handling & Validation**
"Test Results" artifact could be uploaded as a non-zip, XML/JUnit reports could be malformed, etc.

- [ ] **Prevent Duplicate Artifact Processing**
Ensure that the artifacts of a workflow run are processed only once to avoid redundant operations.

- [ ] **Delay Workflow Processing**
Introduce a short delay (e.g., a few seconds) before processing completed workflows, giving the system time to make artifacts fully available.. (maybe not necessary)

- [ ] **Queue-Based Workflow Test Processing**
Implement a queue-based system for workflow test result processing to prevent blocking the webhook handler. This is crucial for handling large artifacts, which may take time to process.

- [ ] **Implement API routes**
Implement routes for fetching the latest test results given a branch or a pull request.

## Testing

I created a [repository](https://github.com/ege-test-org/test-junit-repo) that contains a simple test workflow matching the configuration that is required here (artifact containing junit file). Right now the processor is not connected to the webhook event handler yet, so testing will be documented in a later state.

## Future Work
- Extend supported parsers so we can also include client tests
- Document usage for users (e.g. they will have to upload their results with a specific artifact name and set a workflow label)
- Show data within our UI
- Parse test results in more detail (each test case individually)
- Create a PR for Artemis so the test results are uploaded in the artifact and make sure we can deal with their existing workflow


