### PR TITLE
feat: Add information banner if logged out

### DIFF
--- a/client/src/app/pages/main-layout/main-layout.component.html
+++ b/client/src/app/pages/main-layout/main-layout.component.html
@@ -1,3 +1,10 @@
+@if (!isLoggedIn()) {
+  <div class="top-1 bg-gray-700 text-white rounded-b-2xl z-50 text-center flex items-center justify-center gap-1">
+    You are currently using Helios in readonly mode.
+    <button (click)="login()" class="p-0 text-white hover:text-gray-300 underline">Login here.</button>
+  </div>
+}
+
 <main class="h-screen overflow-hidden">
   <div class="flex h-full p-3">
     <!-- Fixed Navigation Bar -->

--- a/client/src/app/pages/main-layout/main-layout.component.ts
+++ b/client/src/app/pages/main-layout/main-layout.component.ts
@@ -58,6 +58,8 @@ export class MainLayoutComponent {
     this.keycloakService.login();
   }
 
+  isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
+
   items = computed(() => {
     const baseItems = [
       {


### PR DESCRIPTION
If the user is not logged in,  the readonly banner is shown to ensure the user is aware of it
![image](https://github.com/user-attachments/assets/3ff88883-96ee-4ad2-95af-9cbf14ab9171)
