### PR TITLE
fix: Truncating commit messages when longer than 255 chars

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubCommitConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubCommitConverter.java
@@ -24,7 +24,7 @@ public class GitHubCommitConverter implements Converter<GHCommit, Commit> {
         throw new IllegalArgumentException("Commit hash cannot be null");
       }
       if (source.getCommitShortInfo().getMessage().length() > 255) {
-        commit.setMessage(commit.getMessage().substring(0, 255));
+        commit.setMessage(source.getCommitShortInfo().getMessage().substring(0, 255));
       } else {
         commit.setMessage(source.getCommitShortInfo().getMessage());
       }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubCommitConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubCommitConverter.java
@@ -23,7 +23,11 @@ public class GitHubCommitConverter implements Converter<GHCommit, Commit> {
       } else {
         throw new IllegalArgumentException("Commit hash cannot be null");
       }
-      commit.setMessage(source.getCommitShortInfo().getMessage());
+      if (source.getCommitShortInfo().getMessage().length() > 255) {
+        commit.setMessage(commit.getMessage().substring(0, 255));
+      } else {
+        commit.setMessage(source.getCommitShortInfo().getMessage());
+      }
       commit.setAuthoredAt(DateUtil.convertToOffsetDateTime(source.getAuthoredDate()));
 
     } catch (Exception e) {

--- a/server/application-server/src/main/resources/db/migration/V6__reduce_commit_length.sql
+++ b/server/application-server/src/main/resources/db/migration/V6__reduce_commit_length.sql
@@ -1,0 +1,4 @@
+-- First, truncate existing messages that are longer than 255 characters
+UPDATE public.commit SET message = substring(message from 1 for 255) WHERE length(message) > 255;
+-- Then alter the column to reduce its maximum length
+ALTER TABLE public.commit ALTER COLUMN message TYPE character varying(255);


### PR DESCRIPTION
Currently we have a limit of 1023 characters for commit messages in the database, while the recommendation from github is somewhere around 70.
However there was currently a commit submitted to Artemis with a total length of over 2400 characters. 
This PR will truncate the commit messages longer than 255 and also applying it for already existing ones in the db