### PR TITLE
chore: Validate flyway on staging

### DIFF
--- a/.github/workflows/flyway-validate.yml
+++ b/.github/workflows/flyway-validate.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches: [staging]
   workflow_call: {}
+  push:
+    branches: [staging]
 
 env:
   DATASOURCE_URL: jdbc:postgresql://localhost:5432/helios


### PR DESCRIPTION
We are only validating our Flyway migrations on the `main`-branch, this PR adds the check for the staging branch.