### PR TITLE
fix: Add repository filter to release candidate

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releasecandidate/ReleaseCandidate.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releasecandidate/ReleaseCandidate.java
@@ -19,12 +19,14 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.Filter;
 
 @Entity
 @Getter
 @Setter
 @IdClass(ReleaseCandidateId.class)
 @ToString(callSuper = true)
+@Filter(name = "gitRepositoryFilter")
 public class ReleaseCandidate {
   @Id
   @ManyToOne


### PR DESCRIPTION
Currently all release candidates from every repository are returned for a request within a repository. With this PR this is limited to only return the release candidates of the certain repository. 