### PR TITLE
fix: Transaction warning because of a migration script

### DIFF
--- a/server/application-server/src/main/resources/db/migration/V10__add_on_delete_cascade.sql
+++ b/server/application-server/src/main/resources/db/migration/V10__add_on_delete_cascade.sql
@@ -3,8 +3,6 @@
 -- will also be automatically removed. This ensures a single DELETE statement on 'repository'
 -- will cascade and remove all referencing data (branches, commits, issues, etc.).
 
-BEGIN;
-
 -------------------------------------------------------------------------------
 -- branch -> repository
 -------------------------------------------------------------------------------
@@ -319,4 +317,3 @@ ALTER TABLE public.release_candidate_evaluation
             REFERENCES public.release_candidate(name, repository_id)
             ON DELETE CASCADE;
 
-COMMIT;


### PR DESCRIPTION
### Motivation
`DB: there is already a transaction in progress (SQL State: 25001 - Error Code: 0)`

![image](https://github.com/user-attachments/assets/d3ea4300-1879-4086-850c-0cb9d6d0a9ca)


Use `./gradlew flywayClean flywayMigrate` after a new migration is created
