### PR TITLE
Fix request param

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -18,7 +18,7 @@ public interface WorkflowRunRepository extends JpaRepository<WorkflowRun, Long> 
           + "WHERE pr.id = :pullRequestId "
           + "AND wr.headSha = :headSha")
   List<WorkflowRun> findByPullRequestsIdAndHeadShaWithTestSuites(
-      Long pullRequestsId, String headSha);
+      Long pullRequestId, String headSha);
 
   // This loads the test suites for the workflow run eagerly
   @Query(


### PR DESCRIPTION
Fixes the following error:

```
Caused by: org.hibernate.QueryParameterException: No argument for named parameter ':pullRequestId'

      at de.tum.cit.aet.helios.workflow.WorkflowRunService$$SpringCGLIB$$0.getLatestWorkflowRunsByPullRequestIdAndHeadCommit(<generated>) ~[main/:na]
        at de.tum.cit.aet.helios.workflow.WorkflowRunController.getLatestWorkflowRunsByPullRequestIdAndHeadCommit(WorkflowRunController.java:23) ~[main/:na]
```