### PR TITLE
chore: Fix codacy exclude paths

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,5 +1,6 @@
 ---
 exclude_paths:
-  - "**.spec.ts"
-  - "**/test/**"
-  - "**/test-setup.ts"
+  - "*.spec.ts"
+  - "*.gen.ts"
+  - "test/**"
+  - "test-setup.ts"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,6 +1,4 @@
 ---
 exclude_paths:
-  - "*.spec.ts"
   - "*.gen.ts"
-  - "test/**"
   - "test-setup.ts"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches: [staging]
     types: [opened, reopened, edited, synchronize]
+  push:
+    branches: [staging]
 
 jobs:
     client-tests:

--- a/client/vite.config.mts
+++ b/client/vite.config.mts
@@ -1,5 +1,6 @@
 // / <reference types="vitest" />
 import { defineConfig } from 'vite';
+import { coverageConfigDefaults } from 'vitest/config';
 
 import angular from '@analogjs/vite-plugin-angular';
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -14,6 +15,7 @@ export default defineConfig(({ mode }) => ({
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'],
+      exclude: ['**/*.config.*', '**/*.gen.*', ...coverageConfigDefaults.exclude],
     }
   },
   define: {


### PR DESCRIPTION
The exclude paths from codacy do not work correctly. Hopefully this will work. I removed the ** prefix, because that is not documented in codacy to work.