### PR TITLE
fix: Webhook-listener dependency update

### DIFF
--- a/server/webhook-listener/requirements.txt
+++ b/server/webhook-listener/requirements.txt
@@ -17,7 +17,7 @@ markdown-it-py==3.0.0
 markupsafe==3.0.2
 mdurl==0.1.2
 nats-py==2.9.0
-pydantic-core==2.29.0
+pydantic-core==2.27.2
 pydantic-settings==2.8.0
 pydantic==2.10.6
 pygments==2.19.1


### PR DESCRIPTION
newest version of pydantic depends on older version of pydantic-core: 


```
ERROR: Cannot install -r /code/requirements.txt (line 22) and pydantic-core==2.29.0 because these package versions have conflicting dependencies.
The conflict is caused by:
The user requested pydantic-core==2.29.0
pydantic 2.10.6 depends on pydantic-core==2.27.2


To fix this you could try to:



loosen the range of package versions you've specified

remove package versions to allow pip to attempt to solve the dependency conflict


[notice] A new release of pip is available: 24.3.1 -> 25.0.1
[notice] To update, run: pip install --upgrade pip
ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```
