### PR TITLE
feat: show all environments everywhere

### DIFF
--- a/client/src/app/components/deployment-selection/deployment-selection.component.html
+++ b/client/src/app/components/deployment-selection/deployment-selection.component.html
@@ -5,4 +5,4 @@
   </p>
 </div>
 
-<app-environment-list-view [deployable]="true" [showTestEnvironmentsOnly]="true" (deploy)="handleDeploy($event)" />
+<app-environment-list-view [deployable]="true" (deploy)="handleDeploy($event)" />

--- a/client/src/app/components/environments/deployment-state-tag/deployment-state-tag.component.ts
+++ b/client/src/app/components/environments/deployment-state-tag/deployment-state-tag.component.ts
@@ -47,7 +47,7 @@ export class DeploymentStateTagComponent {
   icon = this.timingService.timeAwareComputed(() => {
     const iconMap: Record<ExtendedDeploymentState, string> = {
       SUCCESS: 'check',
-      WAITING: 'progress',
+      WAITING: 'clock',
       PENDING: 'progress',
       IN_PROGRESS: 'progress',
       QUEUED: 'progress',
@@ -63,7 +63,7 @@ export class DeploymentStateTagComponent {
   });
 
   iconClass = this.timingService.timeAwareComputed(() => {
-    const spinStates: ExtendedDeploymentState[] = ['REQUESTED', 'WAITING', 'PENDING', 'IN_PROGRESS', 'QUEUED'];
+    const spinStates: ExtendedDeploymentState[] = ['REQUESTED', 'PENDING', 'IN_PROGRESS', 'QUEUED'];
     return `!size-5 ${spinStates.includes(this.internalState()) ? 'animate-spin' : ''}`;
   });
 
@@ -88,7 +88,7 @@ export class DeploymentStateTagComponent {
   tooltip = this.timingService.timeAwareComputed(() => {
     const tooltipMap: Record<ExtendedDeploymentState, string> = {
       SUCCESS: 'Latest Deployment Successful',
-      WAITING: 'Waiting deployment',
+      WAITING: 'Waiting for approval',
       PENDING: 'Deployment pending',
       IN_PROGRESS: 'Deployment in progress',
       QUEUED: 'Deployment queued',
@@ -104,7 +104,7 @@ export class DeploymentStateTagComponent {
   });
 
   shouldShowRemainingTime = this.timingService.timeAwareComputed(() => {
-    const inProgressStates: ExtendedDeploymentState[] = ['REQUESTED', 'WAITING', 'PENDING', 'IN_PROGRESS', 'QUEUED'];
+    const inProgressStates: ExtendedDeploymentState[] = ['REQUESTED', 'PENDING', 'IN_PROGRESS', 'QUEUED'];
     return inProgressStates.includes(this.internalState()) && !!this.deployment();
   });
 

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
@@ -4,11 +4,11 @@
 
     <div class="flex gap-4 items-center mb-4 mt-2">
       <span class="font-semibold text-lg">
-        @if (deployment && deployment.state === 'SUCCESS') {
+        @if (deployment() && deployment()?.state === 'SUCCESS') {
           Deployment Completed
-        } @else if (deployment && isErrorState()) {
+        } @else if (deployment() && isErrorState()) {
           Deployment Failed
-        } @else if (deployment && isUnknownState()) {
+        } @else if (deployment() && isUnknownState()) {
           Deployment Status Unknown
         } @else {
           Deployment in Progress
@@ -17,17 +17,17 @@
       <span class="text-gray-300">|</span>
 
       <!-- Integrated Time Display -->
-      @if (deployment && deployment.state === 'SUCCESS') {
+      @if (deployment() && deployment()?.state === 'SUCCESS') {
         <div class="inline-flex items-center bg-green-50 px-2 py-0.5 rounded-full text-sm">
           <i-tabler name="clock" class="w-4 h-4 text-green-600 mr-1"></i-tabler>
           <span class="font-medium text-green-600">{{ getDeploymentDuration() }}</span>
         </div>
-      } @else if (deployment && isErrorState()) {
+      } @else if (deployment() && isErrorState()) {
         <div class="inline-flex items-center bg-red-50 px-2 py-0.5 rounded-full text-sm">
           <i-tabler name="clock" class="w-4 h-4 text-red-600 mr-1"></i-tabler>
           <span class="font-medium text-red-600">{{ getDeploymentDuration() }}</span>
         </div>
-      } @else if (deployment && isUnknownState()) {
+      } @else if (deployment() && isUnknownState()) {
         <div class="inline-flex items-center bg-gray-50 px-2 py-0.5 rounded-full text-sm">
           <i-tabler name="clock" class="w-4 h-4 text-gray-600 mr-1"></i-tabler>
           <span class="font-medium text-gray-600">0m 0s</span>

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.ts
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit, signal, input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IconsModule } from 'icons.module';
 import { ProgressBarModule } from 'primeng/progressbar';
@@ -21,19 +21,17 @@ export class DeploymentStepperComponent implements OnInit {
   private _deployment = signal<EnvironmentDeployment | undefined>(undefined);
   private timingService = inject(DeploymentTimingService);
 
-  @Input()
-  set deployment(value: EnvironmentDeployment | undefined) {
-    // Update the deployment signal
-    this._deployment.set(value);
+  readonly deployment = input<EnvironmentDeployment | undefined, EnvironmentDeployment | undefined>(undefined, {
+    transform: (value: EnvironmentDeployment | undefined) => {
+      this._deployment.set(value);
 
-    // Update timing service with new deployment state
-    if (value?.id && value?.state) {
-      this.timingService.updateDeploymentState(value);
-    }
-  }
-  get deployment(): EnvironmentDeployment | undefined {
-    return this._deployment();
-  }
+      if (value?.id && value?.state) {
+        this.timingService.updateDeploymentState(value);
+      }
+
+      return value;
+    },
+  });
 
   steps = this.timingService.steps;
 

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
@@ -1,32 +1,32 @@
-<p-accordion-panel [value]="environment.id">
+<p-accordion-panel [value]="environment().id">
   <p-accordion-header>
     <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
       <div class="flex flex-col gap-1 flex-wrap">
         <div class="flex gap-1 items-center mr-3">
-          <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment.serverUrl)">
-            {{ environment.name }}
+          <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment().serverUrl)">
+            {{ environment().name }}
           </span>
 
-          <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
+          <app-lock-tag [isLocked]="!!environment().locked"></app-lock-tag>
 
-          @if (environment.latestStatus; as status) {
+          @if (environment().latestStatus; as status) {
             <app-environment-status-tag [status]="status" />
           }
 
-          @if (environment.type) {
-            <p-tag [value]="formatEnvironmentType(environment.type)" severity="secondary" rounded="true" />
+          @if (environment().type) {
+            <p-tag [value]="formatEnvironmentType(environment().type || '')" severity="secondary" rounded="true" />
           }
         </div>
 
-        @if (environment.latestDeployment; as deployment) {
+        @if (environment().latestDeployment; as deployment) {
           <div class="flex gap-1 items-center text-sm mt-2 flex-wrap">
-            <app-user-avatar [user]="environment.latestDeployment.user" tooltipPosition="top" />
-            @if (environment.latestDeployment.user?.name) {
-              {{ environment.latestDeployment.user?.name }} deployed
+            <app-user-avatar [user]="environment().latestDeployment?.user" tooltipPosition="top" />
+            @if (environment().latestDeployment?.user?.name) {
+              {{ environment().latestDeployment?.user?.name }} deployed
             }
-            @if (environment.latestDeployment.updatedAt) {
-              <span [pTooltip]="getDeploymentTime(environment) || ''">
-                {{ environment.latestDeployment.updatedAt | timeAgo }}
+            @if (environment().latestDeployment?.updatedAt) {
+              <span [pTooltip]="getDeploymentTime(environment()) || ''">
+                {{ environment().latestDeployment?.updatedAt || '' | timeAgo }}
               </span>
             }
             <app-deployment-state-tag [state]="deployment.state" [deployment]="deployment" />
@@ -70,10 +70,10 @@
 
       <!-- Environment Actions Component -->
       <app-environment-actions
-        [environment]="environment"
-        [deployable]="deployable"
-        [canViewAllEnvironments]="canViewAllEnvironments"
-        [timeUntilReservationExpires]="timeUntilReservationExpires"
+        [environment]="environment()"
+        [deployable]="deployable()"
+        [canViewAllEnvironments]="canViewAllEnvironments()"
+        [timeUntilReservationExpires]="timeUntilReservationExpires()"
         (deploy)="onDeploy($event)"
         (unlock)="onUnlock($event)"
         (extend)="onExtend($event)"
@@ -101,11 +101,11 @@
 
       <!-- Content container div that wraps both details and deployment views -->
       <div class="flex w-full">
-        @if (showLatestDeployment) {
+        @if (showLatestDeployment()) {
           <!-- Direct use of deployment stepper -->
-          <app-deployment-stepper [deployment]="environment.latestDeployment" class="w-full" />
+          <app-deployment-stepper [deployment]="environment().latestDeployment" class="w-full" />
         } @else {
-          <app-environment-details [environment]="environment"></app-environment-details>
+          <app-environment-details [environment]="environment()"></app-environment-details>
         }
       </div>
 
@@ -114,7 +114,7 @@
         <div class="flex gap-1 mt-2 items-center">
           <a
             icon
-            [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/history'"
+            [routerLink]="'/repo/' + environment().repository?.id + '/environment/' + environment().id + '/history'"
             class="p-button p-button-text text-gray-500 py-2 flex items-center"
           >
             <i-tabler class="mr-1" name="history" />
@@ -123,7 +123,7 @@
         </div>
         <div class="flex flex-grow"></div>
         <div class="flex gap-2">
-          @for (installedApp of environment.installedApps; track installedApp) {
+          @for (installedApp of environment().installedApps; track installedApp) {
             <p-tag class="bg-gray-300 gap-0">{{ installedApp }}</p-tag>
           }
         </div>

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
@@ -43,8 +43,6 @@
             >
               @if (isRelease(deployment)) {
                 <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
-              } @else {
-                <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
               }
               <span class="truncate flex-1">{{ deployment.ref }}</span>
             </p-tag>

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
@@ -1,0 +1,135 @@
+<p-accordion-panel [value]="environment.id">
+  <p-accordion-header>
+    <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
+      <div class="flex flex-col gap-1 flex-wrap">
+        <div class="flex gap-1 items-center mr-3">
+          <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment.serverUrl)">
+            {{ environment.name }}
+          </span>
+
+          <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
+
+          @if (environment.latestStatus; as status) {
+            <app-environment-status-tag [status]="status" />
+          }
+
+          @if (environment.type) {
+            <p-tag [value]="formatEnvironmentType(environment.type)" severity="secondary" rounded="true" />
+          }
+        </div>
+
+        @if (environment.latestDeployment; as deployment) {
+          <div class="flex gap-1 items-center text-sm mt-2 flex-wrap">
+            <app-user-avatar [user]="environment.latestDeployment.user" tooltipPosition="top" />
+            @if (environment.latestDeployment.user?.name) {
+              {{ environment.latestDeployment.user?.name }} deployed
+            }
+            @if (environment.latestDeployment.updatedAt) {
+              <span [pTooltip]="getDeploymentTime(environment) || ''">
+                {{ environment.latestDeployment.updatedAt | timeAgo }}
+              </span>
+            }
+            <app-deployment-state-tag [state]="deployment.state" [deployment]="deployment" />
+
+            <!-- Branch or Release Tag -->
+            <p-tag
+              severity="secondary"
+              rounded="true"
+              class="max-w-[250px] flex items-center"
+              [pTooltip]="isRelease(deployment) ? '' : 'Go to ' + deployment.ref"
+              tooltipPosition="top"
+              (click)="$event.stopPropagation()"
+              [routerLink]="isRelease(deployment) ? null : getBranchLink()"
+            >
+              @if (isRelease(deployment)) {
+                <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
+              } @else {
+                <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
+              }
+              <span class="truncate flex-1">{{ deployment.ref }}</span>
+            </p-tag>
+
+            @if (deployment.pullRequestNumber) {
+              <!-- PR Tag -->
+              <p-tag
+                severity="secondary"
+                rounded="true"
+                class="max-w-[350px] flex items-center"
+                [pTooltip]="'Go to ' + (deployment.prName || 'Pull Request #' + deployment.pullRequestNumber)"
+                tooltipPosition="top"
+                (click)="$event.stopPropagation()"
+                [routerLink]="getPrLink()"
+              >
+                <i-tabler name="git-pull-request" class="!size-5 flex-shrink-0"></i-tabler>
+                <span class="truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
+              </p-tag>
+            }
+          </div>
+        }
+      </div>
+
+      <div class="flex-grow"></div>
+
+      <!-- Environment Actions Component -->
+      <app-environment-actions
+        [environment]="environment"
+        [deployable]="deployable"
+        [canViewAllEnvironments]="canViewAllEnvironments"
+        [timeUntilReservationExpires]="timeUntilReservationExpires"
+        (deploy)="onDeploy($event)"
+        (unlock)="onUnlock($event)"
+        (extend)="onExtend($event)"
+        (lock)="onLock($event)"
+      >
+      </app-environment-actions>
+    </div>
+  </p-accordion-header>
+
+  <p-accordion-content>
+    <div class="flex w-full flex-col gap-4">
+      <!-- Toggle Button -->
+      <div class="flex justify-start gap-2">
+        <p-selectbutton
+          [options]="[
+            { label: 'Details', value: false },
+            { label: 'Deployment', value: true },
+          ]"
+          [(ngModel)]="showLatestDeployment"
+          optionLabel="label"
+          optionValue="value"
+          aria-labelledby="basic"
+        />
+      </div>
+
+      <!-- Content container div that wraps both details and deployment views -->
+      <div class="flex w-full">
+        @if (showLatestDeployment) {
+          <!-- Direct use of deployment stepper -->
+          <app-deployment-stepper [deployment]="environment.latestDeployment" class="w-full" />
+        } @else {
+          <app-environment-details [environment]="environment"></app-environment-details>
+        }
+      </div>
+
+      <!-- Footer links and tags -->
+      <div class="flex gap-4 items-center justify-between">
+        <div class="flex gap-1 mt-2 items-center">
+          <a
+            icon
+            [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/history'"
+            class="p-button p-button-text text-gray-500 py-2 flex items-center"
+          >
+            <i-tabler class="mr-1" name="history" />
+            View Activity History
+          </a>
+        </div>
+        <div class="flex flex-grow"></div>
+        <div class="flex gap-2">
+          @for (installedApp of environment.installedApps; track installedApp) {
+            <p-tag class="bg-gray-300 gap-0">{{ installedApp }}</p-tag>
+          }
+        </div>
+      </div>
+    </div>
+  </p-accordion-content>
+</p-accordion-panel>

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
@@ -1,0 +1,109 @@
+import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
+import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
+import { DeploymentStepperComponent } from '../deployment-stepper/deployment-stepper.component';
+import { EnvironmentActionsComponent } from '../environment-actions/environment-actions.component';
+import { DeploymentStateTagComponent } from '../deployment-state-tag/deployment-state-tag.component';
+import { UserAvatarComponent } from '@app/components/user-avatar/user-avatar.component';
+import { LockTagComponent } from '../lock-tag/lock-tag.component';
+import { AccordionModule } from 'primeng/accordion';
+import { TagModule } from 'primeng/tag';
+import { CommonModule, DatePipe } from '@angular/common';
+import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
+import { TooltipModule } from 'primeng/tooltip';
+import { IconsModule } from 'icons.module';
+import { EnvironmentDetailsComponent } from '../environment-details/environment-details.component';
+import { SelectButtonModule } from 'primeng/selectbutton';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { EnvironmentStatusTagComponent } from '../environment-status-tag/environment-status-tag.component';
+
+@Component({
+  selector: 'app-environment-accordion',
+  imports: [
+    CommonModule,
+    AccordionModule,
+    LockTagComponent,
+    TagModule,
+    UserAvatarComponent,
+    TimeAgoPipe,
+    DeploymentStateTagComponent,
+    TooltipModule,
+    IconsModule,
+    EnvironmentActionsComponent,
+    EnvironmentDetailsComponent,
+    DeploymentStepperComponent,
+    SelectButtonModule,
+    FormsModule,
+    RouterLink,
+    EnvironmentStatusTagComponent,
+  ],
+  templateUrl: './environment-accordion.component.html',
+})
+export class EnvironmentAccordionComponent {
+  @Input() environment!: EnvironmentDto;
+  @Input() deployable: boolean = false;
+  @Input() canViewAllEnvironments: boolean = false;
+  @Input() timeUntilReservationExpires: number | undefined;
+
+  @Output() deploy = new EventEmitter<EnvironmentDto>();
+  @Output() unlock = new EventEmitter<{ event: Event; environment: EnvironmentDto }>();
+  @Output() extend = new EventEmitter<{ event: Event; environment: EnvironmentDto }>();
+  @Output() lock = new EventEmitter<EnvironmentDto>();
+
+  showLatestDeployment: boolean = true;
+
+  private datePipe = inject(DatePipe);
+
+  onDeploy(event: Event) {
+    event.stopPropagation();
+    this.deploy.emit(this.environment);
+  }
+
+  onUnlock(event: Event) {
+    this.unlock.emit({ event, environment: this.environment });
+  }
+
+  onExtend(event: Event) {
+    this.extend.emit({ event, environment: this.environment });
+  }
+
+  onLock(event: Event) {
+    event.stopPropagation();
+    this.lock.emit(this.environment);
+  }
+
+  formatEnvironmentType(type: string): string {
+    return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
+  }
+
+  getDeploymentTime(environment: EnvironmentDto) {
+    const date = environment.latestDeployment?.updatedAt;
+    return date ? this.datePipe.transform(date, 'd MMMM y, h:mm a') : null;
+  }
+
+  openExternalLink(event: MouseEvent, link?: string): void {
+    event.stopPropagation();
+    if (link) {
+      window.open(this.getFullUrl(link), '_blank');
+    }
+  }
+
+  getFullUrl(url: string): string {
+    if (url && !url.startsWith('http') && !url.startsWith('https')) {
+      return 'http://' + url;
+    }
+    return url;
+  }
+
+  isRelease(deployment: EnvironmentDeployment): boolean {
+    return !!deployment.releaseCandidateName || (!!deployment.ref && /^v?\d+\.\d+\.\d+/.test(deployment.ref));
+  }
+
+  getPrLink() {
+    return ['/repo', this.environment.repository?.id, 'ci-cd', 'pr', this.environment.latestDeployment?.pullRequestNumber?.toString()];
+  }
+
+  getBranchLink() {
+    return ['/repo', this.environment.repository?.id, 'ci-cd', 'branch', this.environment.latestDeployment?.ref];
+  }
+}

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
 import { DeploymentStepperComponent } from '../deployment-stepper/deployment-stepper.component';
 import { EnvironmentActionsComponent } from '../environment-actions/environment-actions.component';
@@ -16,6 +16,7 @@ import { SelectButtonModule } from 'primeng/selectbutton';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { EnvironmentStatusTagComponent } from '../environment-status-tag/environment-status-tag.component';
+import { signal } from '@angular/core';
 
 @Component({
   selector: 'app-environment-accordion',
@@ -40,36 +41,36 @@ import { EnvironmentStatusTagComponent } from '../environment-status-tag/environ
   templateUrl: './environment-accordion.component.html',
 })
 export class EnvironmentAccordionComponent {
-  @Input() environment!: EnvironmentDto;
-  @Input() deployable: boolean = false;
-  @Input() canViewAllEnvironments: boolean = false;
-  @Input() timeUntilReservationExpires: number | undefined;
+  readonly environment = input.required<EnvironmentDto>();
+  readonly deployable = input<boolean>(false);
+  readonly canViewAllEnvironments = input<boolean>(false);
+  readonly timeUntilReservationExpires = input<number | undefined>(undefined);
 
-  @Output() deploy = new EventEmitter<EnvironmentDto>();
-  @Output() unlock = new EventEmitter<{ event: Event; environment: EnvironmentDto }>();
-  @Output() extend = new EventEmitter<{ event: Event; environment: EnvironmentDto }>();
-  @Output() lock = new EventEmitter<EnvironmentDto>();
+  readonly deploy = output<EnvironmentDto>();
+  readonly unlock = output<{ event: Event; environment: EnvironmentDto }>();
+  readonly extend = output<{ event: Event; environment: EnvironmentDto }>();
+  readonly lock = output<EnvironmentDto>();
 
-  showLatestDeployment: boolean = true;
+  showLatestDeployment = signal<boolean>(true);
 
   private datePipe = inject(DatePipe);
 
   onDeploy(event: Event) {
     event.stopPropagation();
-    this.deploy.emit(this.environment);
+    this.deploy.emit(this.environment());
   }
 
   onUnlock(event: Event) {
-    this.unlock.emit({ event, environment: this.environment });
+    this.unlock.emit({ event, environment: this.environment() });
   }
 
   onExtend(event: Event) {
-    this.extend.emit({ event, environment: this.environment });
+    this.extend.emit({ event, environment: this.environment() });
   }
 
   onLock(event: Event) {
     event.stopPropagation();
-    this.lock.emit(this.environment);
+    this.lock.emit(this.environment());
   }
 
   formatEnvironmentType(type: string): string {
@@ -100,10 +101,10 @@ export class EnvironmentAccordionComponent {
   }
 
   getPrLink() {
-    return ['/repo', this.environment.repository?.id, 'ci-cd', 'pr', this.environment.latestDeployment?.pullRequestNumber?.toString()];
+    return ['/repo', this.environment().repository?.id, 'ci-cd', 'pr', this.environment().latestDeployment?.pullRequestNumber?.toString()];
   }
 
   getBranchLink() {
-    return ['/repo', this.environment.repository?.id, 'ci-cd', 'branch', this.environment.latestDeployment?.ref];
+    return ['/repo', this.environment().repository?.id, 'ci-cd', 'branch', this.environment().latestDeployment?.ref];
   }
 }

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.html
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.html
@@ -1,16 +1,16 @@
 <div class="flex gap-2 items-center self-end md:self-center">
-  @if (environment.locked) {
+  @if (environment().locked) {
     <div class="flex gap-1 items-center">
-      <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
+      <app-user-avatar [user]="environment().lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
     </div>
-    @if (environment.lockedAt) {
-      <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
+    @if (environment().lockedAt) {
+      <app-lock-time [timeLockWillExpire]="environment().lockWillExpireAt"></app-lock-time>
     }
   }
 
   <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
     <!-- Deploy Button -->
-    @if (deployable) {
+    @if (deployable()) {
       <p-button outlined (click)="onDeploy($event)" [disabled]="!canUserDeploy()" [pTooltip]="getDeployTooltip()" tooltipPosition="top">
         <div class="flex items-center">
           <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
@@ -21,10 +21,10 @@
     }
 
     <!-- Lock/Unlock Controls -->
-    @if (environment.enabled && environment.type === 'TEST') {
+    @if (environment().enabled && environment().type === 'TEST') {
       <p-buttongroup>
-        @if (!environment.locked) {
-          @if (deployable) {
+        @if (!environment().locked) {
+          @if (deployable()) {
             <p-button outlined (click)="onLock($event)" [disabled]="!canUserDeploy()" [pTooltip]="getLockTooltip()" tooltipPosition="top">
               <div class="flex items-center">
                 <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
@@ -49,10 +49,10 @@
     }
 
     <!-- Approve Button -->
-    @if (environment.latestDeployment?.state === 'WAITING') {
+    @if (environment().latestDeployment?.state === 'WAITING') {
       <p-button
         severity="success"
-        (click)="openExternalLink($event, environment.latestDeployment?.workflowRunHtmlUrl)"
+        (click)="openExternalLink($event, environment().latestDeployment?.workflowRunHtmlUrl)"
         pTooltip="Approve deployment on GitHub"
         tooltipPosition="top"
       >
@@ -64,13 +64,13 @@
   </div>
 
   <!-- Edit & Disabled Tag -->
-  @if (canViewAllEnvironments) {
-    @if (!environment.enabled) {
+  @if (canViewAllEnvironments()) {
+    @if (!environment().enabled) {
       <p-tag value="Disabled" severity="danger" rounded="true" />
     }
     <a
       icon
-      [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
+      [routerLink]="'/repo/' + environment().repository?.id + '/environment/' + environment().id + '/edit'"
       class="p-button p-button-secondary p-2"
       (click)="$event.stopPropagation()"
     >

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.html
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.html
@@ -1,0 +1,81 @@
+<div class="flex gap-2 items-center self-end md:self-center">
+  @if (environment.locked) {
+    <div class="flex gap-1 items-center">
+      <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
+    </div>
+    @if (environment.lockedAt) {
+      <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
+    }
+  }
+
+  <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
+    <!-- Deploy Button -->
+    @if (deployable) {
+      <p-button outlined (click)="onDeploy($event)" [disabled]="!canUserDeploy()" [pTooltip]="getDeployTooltip()" tooltipPosition="top">
+        <div class="flex items-center">
+          <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
+          <span>Deploy</span>
+        </div>
+      </p-button>
+      <div class="w-px bg-gray-300 self-stretch"></div>
+    }
+
+    <!-- Lock/Unlock Controls -->
+    @if (environment.enabled && environment.type === 'TEST') {
+      <p-buttongroup>
+        @if (!environment.locked) {
+          @if (deployable) {
+            <p-button outlined (click)="onLock($event)" [disabled]="!canUserDeploy()" [pTooltip]="getLockTooltip()" tooltipPosition="top">
+              <div class="flex items-center">
+                <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
+              </div>
+            </p-button>
+          }
+        } @else {
+          @if (canUnlockShow()) {
+            <p-button severity="danger" class="[&>*]:!rounded-none" (click)="onUnlock($event)" [disabled]="!canUnlock()" [pTooltip]="getUnlockToolTip()" tooltipPosition="top">
+              <div class="flex items-center">
+                <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
+              </div>
+            </p-button>
+            @if (isCurrentUserLocked()) {
+              <p-button outlined (click)="onExtend($event)" [disabled]="!canUnlock()" [pTooltip]="'Extend my lock expiration'" tooltipPosition="top">
+                <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
+              </p-button>
+            }
+          }
+        }
+      </p-buttongroup>
+    }
+
+    <!-- Approve Button -->
+    @if (environment.latestDeployment?.state === 'WAITING') {
+      <p-button
+        severity="success"
+        (click)="openExternalLink($event, environment.latestDeployment?.workflowRunHtmlUrl)"
+        pTooltip="Approve deployment on GitHub"
+        tooltipPosition="top"
+      >
+        <div class="flex items-center">
+          <i-tabler name="check" class="w-4 h-4 flex-shrink-0" />
+        </div>
+      </p-button>
+    }
+  </div>
+
+  <!-- Edit & Disabled Tag -->
+  @if (canViewAllEnvironments) {
+    @if (!environment.enabled) {
+      <p-tag value="Disabled" severity="danger" rounded="true" />
+    }
+    <a
+      icon
+      [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
+      class="p-button p-button-secondary p-2"
+      (click)="$event.stopPropagation()"
+    >
+      <i-tabler name="pencil" />
+    </a>
+  }
+  <span class="w-2"></span>
+</div>

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.ts
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.ts
@@ -1,0 +1,139 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, inject, Input, Output } from '@angular/core';
+import { UserAvatarComponent } from '@app/components/user-avatar/user-avatar.component';
+import { EnvironmentDto } from '@app/core/modules/openapi';
+import { LockTimeComponent } from '../lock-time/lock-time.component';
+import { ButtonModule } from 'primeng/button';
+import { ButtonGroupModule } from 'primeng/buttongroup';
+import { TooltipModule } from 'primeng/tooltip';
+import { TagModule } from 'primeng/tag';
+import { RouterLink } from '@angular/router';
+import { IconsModule } from 'icons.module';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { PermissionService } from '@app/core/services/permission.service';
+
+@Component({
+  selector: 'app-environment-actions',
+  imports: [CommonModule, UserAvatarComponent, LockTimeComponent, ButtonModule, ButtonGroupModule, TooltipModule, TagModule, RouterLink, IconsModule],
+  templateUrl: './environment-actions.component.html',
+})
+export class EnvironmentActionsComponent {
+  @Input() environment!: EnvironmentDto;
+  @Input() deployable: boolean = false;
+  @Input() canViewAllEnvironments: boolean = false;
+  @Input() timeUntilReservationExpires: number | undefined;
+
+  @Output() deploy = new EventEmitter<Event>();
+  @Output() unlock = new EventEmitter<Event>();
+  @Output() extend = new EventEmitter<Event>();
+  @Output() lock = new EventEmitter<Event>();
+
+  // Inject required services
+  private keycloakService = inject(KeycloakService);
+  private permissionService = inject(PermissionService);
+
+  isLoggedIn() {
+    return this.keycloakService.isLoggedIn();
+  }
+
+  hasDeployPermissions() {
+    return this.permissionService.hasWritePermission();
+  }
+
+  hasUnlockPermissions() {
+    return this.permissionService.isAtLeastMaintainer();
+  }
+
+  isCurrentUserLocked() {
+    const currentUserGithubId = Number(this.keycloakService.getUserGithubId());
+    const environmentLockedById = Number(this.environment.lockedBy?.id);
+    return environmentLockedById === currentUserGithubId;
+  }
+
+  canUserDeploy(): boolean {
+    return !!(this.isLoggedIn() && (!this.environment.locked || this.isCurrentUserLocked()) && this.hasDeployPermissions());
+  }
+
+  canUnlockShow(): boolean {
+    return !!(this.isLoggedIn() && (this.environment.lockReservationWillExpireAt !== null || this.isCurrentUserLocked() || this.hasUnlockPermissions()));
+  }
+
+  canUnlock(): boolean {
+    if (this.hasUnlockPermissions() || this.isCurrentUserLocked()) {
+      return true;
+    } else if (!this.isCurrentUserLocked() && (this.timeUntilReservationExpires ?? -1) === 0) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getLockTooltip(): string {
+    return this.canUserDeploy() ? 'This will only lock the environment without any deployment.' : 'You do not have permission to lock this environment.';
+  }
+
+  getDeployTooltip(): string {
+    if (!this.canUserDeploy()) {
+      return 'You do not have permission to deploy to this environment.';
+    }
+    return this.environment.locked ? 'This will deploy to the server.' : 'This will lock the environment then deploy.';
+  }
+
+  getUnlockToolTip(): string {
+    if (!this.canUnlock()) {
+      return 'You do not have permission to unlock this environment.';
+    }
+
+    const timeLeft = this.timeUntilReservationExpires;
+    const timeLeftMinutes = timeLeft !== undefined ? Math.ceil(timeLeft / 60000) : 0;
+
+    if (this.isCurrentUserLocked() || this.hasUnlockPermissions()) {
+      if (timeLeft !== undefined) {
+        if (timeLeft > 0) {
+          return timeLeftMinutes > 1 ? `Other users can unlock this environment in ${timeLeftMinutes} minutes` : 'Other users can unlock this environment in 1 minute';
+        } else if (timeLeft === 0) {
+          return 'Reservation has expired. Any user can unlock this environment.';
+        }
+      }
+      return 'Unlock Environment';
+    }
+
+    if (timeLeft === undefined) {
+      return 'You can not unlock this environment';
+    } else if (timeLeft === 0) {
+      return 'Reservation Expired. You can unlock this environment.';
+    } else {
+      return timeLeftMinutes > 1 ? `You can unlock this environment in ${timeLeftMinutes} minutes` : 'You can unlock this environment in 1 minute';
+    }
+  }
+
+  openExternalLink(event: MouseEvent, link?: string): void {
+    event.stopPropagation();
+    if (link) {
+      window.open(this.getFullUrl(link), '_blank');
+    }
+  }
+
+  getFullUrl(url: string): string {
+    if (url && !url.startsWith('http') && !url.startsWith('https')) {
+      return 'http://' + url;
+    }
+    return url;
+  }
+
+  onDeploy(event: Event) {
+    this.deploy.emit(event);
+  }
+
+  onUnlock(event: Event) {
+    this.unlock.emit(event);
+  }
+
+  onExtend(event: Event) {
+    this.extend.emit(event);
+  }
+
+  onLock(event: Event) {
+    this.lock.emit(event);
+  }
+}

--- a/client/src/app/components/environments/environment-details/environment-details.component.html
+++ b/client/src/app/components/environments/environment-details/environment-details.component.html
@@ -1,0 +1,11 @@
+<div class="flex flex-col gap-1">
+  @if (environment.latestDeployment; as deployment) {
+    <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment.repository?.id || 0" />
+  }
+</div>
+<div class="flex-grow"></div>
+<div class="flex flex-col gap-1">
+  @if (environment.latestStatus; as status) {
+    <app-environment-status-info class="max-w-xs mt-2 ml-14" [status]="status" />
+  }
+</div>

--- a/client/src/app/components/environments/environment-details/environment-details.component.html
+++ b/client/src/app/components/environments/environment-details/environment-details.component.html
@@ -1,11 +1,11 @@
 <div class="flex flex-col gap-1">
-  @if (environment.latestDeployment; as deployment) {
-    <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment.repository?.id || 0" />
+  @if (environment().latestDeployment; as deployment) {
+    <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment().repository?.id || 0" />
   }
 </div>
 <div class="flex-grow"></div>
 <div class="flex flex-col gap-1">
-  @if (environment.latestStatus; as status) {
+  @if (environment().latestStatus; as status) {
     <app-environment-status-info class="max-w-xs mt-2 ml-14" [status]="status" />
   }
 </div>

--- a/client/src/app/components/environments/environment-details/environment-details.component.ts
+++ b/client/src/app/components/environments/environment-details/environment-details.component.ts
@@ -1,0 +1,14 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { EnvironmentDto } from '@app/core/modules/openapi';
+import { EnvironmentDeploymentInfoComponent } from '../deployment-info/environment-deployment-info.component';
+import { EnvironmentStatusInfoComponent } from '../environment-status-info/environment-status-info.component';
+
+@Component({
+  selector: 'app-environment-details',
+  imports: [CommonModule, EnvironmentDeploymentInfoComponent, EnvironmentStatusInfoComponent],
+  templateUrl: './environment-details.component.html',
+})
+export class EnvironmentDetailsComponent {
+  @Input() environment!: EnvironmentDto;
+}

--- a/client/src/app/components/environments/environment-details/environment-details.component.ts
+++ b/client/src/app/components/environments/environment-details/environment-details.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, Input } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { EnvironmentDto } from '@app/core/modules/openapi';
 import { EnvironmentDeploymentInfoComponent } from '../deployment-info/environment-deployment-info.component';
 import { EnvironmentStatusInfoComponent } from '../environment-status-info/environment-status-info.component';
@@ -10,5 +10,5 @@ import { EnvironmentStatusInfoComponent } from '../environment-status-info/envir
   templateUrl: './environment-details.component.html',
 })
 export class EnvironmentDetailsComponent {
-  @Input() environment!: EnvironmentDto;
+  readonly environment = input.required<EnvironmentDto>();
 }

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -24,7 +24,7 @@
                   <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
                     <div class="flex flex-col gap-1 flex-wrap">
                       <div class="flex gap-1 items-center mr-3">
-                        <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment)">
+                        <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment.serverUrl)">
                           {{ environment.name }}
                         </span>
 
@@ -114,7 +114,7 @@
                           <div class="w-px bg-gray-300 self-stretch"></div>
                         }
 
-                        @if (environment.enabled) {
+                        @if (environment.enabled && environment.type === 'TEST') {
                           <p-buttongroup>
                             @if (!environment.locked) {
                               @if (deployable()) {
@@ -159,7 +159,21 @@
                             }
                           </p-buttongroup>
                         }
+
+                        @if (environment.latestDeployment?.state === 'WAITING') {
+                          <p-button
+                            severity="success"
+                            (click)="openExternalLink($event, environment.latestDeployment?.workflowRunHtmlUrl)"
+                            pTooltip="Approve deployment on GitHub"
+                            tooltipPosition="top"
+                          >
+                            <div class="flex items-center">
+                              <i-tabler name="check" class="w-4 h-4 flex-shrink-0" />
+                            </div>
+                          </p-button>
+                        }
                       </div>
+
                       @if (canViewAllEnvironments()) {
                         <!-- Show the disabled tag -->
                         @if (!environment.enabled) {

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -17,8 +17,9 @@
   } @else {
     @for (group of environmentGroups(); track group[0]) {
       @if (group[1].length > 0) {
-        <div class="mb-4">
-          <h3 class="text-lg font-semibold mb-2">{{ capitalizeFirstLetter(group[0]) }}</h3>
+        <div>
+          <h3 class="text-lg font-semibold p-2 bg-slate-100">{{ capitalizeFirstLetter(group[0]) }}</h3>
+          <p-divider class="mt-0" />
           <p-accordion [multiple]="true">
             @for (environment of group[1]; track environment.id) {
               <p-accordion-panel [value]="environment.id">

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -1,244 +1,222 @@
 <div class="flex items-center justify-between mb-3">
   <input pInputText id="commit-hash" (input)="onSearch($event)" [value]="searchInput()" type="text" placeholder="Search for installed systems" class="w-1/3" />
   @if (!hideLinkToList()) {
-    <p-button [routerLink]="'../../../environment'" class="self-end"
-      >{{
-        isAdmin()
-          ? 'Manage Environments'
-          : 'Go to
-    Environments'
-      }}
+    <p-button [routerLink]="'../../../environment'" class="self-end">
+      {{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }}
     </p-button>
   }
 </div>
 
-<p-accordion [multiple]="true">
-  @if (!environmentQuery.isPending() && filteredEnvironments().length === 0) {
+@if (!environmentQuery.isPending()) {
+  @if (filteredEnvironments().length === 0) {
     @if (searchInput().length === 0) {
       <p>No environments found. Create a new environment to get started.</p>
     } @else {
       <p>No environments found for the search term, try something else.</p>
     }
-  }
+  } @else {
+    @for (group of environmentGroups(); track group[0]) {
+      @if (group[1].length > 0) {
+        <div class="mb-4">
+          <h3 class="text-lg font-semibold mb-2">{{ capitalizeFirstLetter(group[0]) }}</h3>
+          <p-accordion [multiple]="true">
+            @for (environment of group[1]; track environment.id) {
+              <p-accordion-panel [value]="environment.id">
+                <p-accordion-header>
+                  <div class="flex gap-2 items-center w-full">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex gap-1 items-center mr-3">
+                        <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment)">
+                          {{ environment.name }}
+                        </span>
+                        <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
 
-  @for (environment of filteredEnvironments(); track environment.id) {
-    <p-accordion-panel [value]="environment.id">
-      <p-accordion-header>
-        <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
-          <div class="flex flex-col gap-1 flex-wrap">
-            <div class="flex gap-1 items-center mr-3">
-              <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment)">
-                {{ environment.name }}
-              </span>
+                        @if (environment.latestStatus; as status) {
+                          <app-environment-status-tag [status]="status" />
+                        }
 
-              <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
-
-              @if (environment.latestStatus; as status) {
-                <app-environment-status-tag [status]="status" />
-              }
-
-              @if (environment.type) {
-                <p-tag [value]="formatEnvironmentType(environment.type)" severity="secondary" rounded="true" />
-              }
-            </div>
-            @if (environment.latestDeployment; as deployment) {
-              <div class="flex gap-1 items-center text-sm mt-2 flex-wrap">
-                <app-user-avatar [user]="environment?.latestDeployment?.user" tooltipPosition="top" />
-                @if (environment.latestDeployment.user?.name) {
-                  {{ environment.latestDeployment.user?.name }} deployed
-                }
-                @if (environment.latestDeployment.updatedAt) {
-                  <span [pTooltip]="getDeploymentTime(environment) || ''">{{ environment.latestDeployment.updatedAt || '' | timeAgo }}</span>
-                }
-                <app-deployment-state-tag [state]="deployment.state" [deployment]="deployment" />
-                <!-- Branch or Release Tag -->
-                <p-tag
-                  severity="secondary"
-                  rounded="true"
-                  class="max-w-[250px] flex items-center"
-                  [pTooltip]="isRelease(deployment) ? '' : 'Go to ' + deployment.ref"
-                  tooltipPosition="top"
-                  (click)="$event.stopPropagation()"
-                  [routerLink]="isRelease(deployment) ? null : getBranchLink(environment)"
-                >
-                  @if (isRelease(deployment)) {
-                    <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
-                  } @else {
-                    <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
-                  }
-                  <span class="truncate flex-1">{{ deployment.ref }}</span>
-                </p-tag>
-                @if (deployment.pullRequestNumber) {
-                  <!-- PR Tag -->
-                  <p-tag
-                    severity="secondary"
-                    rounded="true"
-                    class="max-w-[350px] flex items-center"
-                    [pTooltip]="'Go to ' + (deployment.prName || 'Pull Request #' + deployment.pullRequestNumber)"
-                    tooltipPosition="top"
-                    (click)="$event.stopPropagation()"
-                    [routerLink]="getPrLink(environment)"
-                  >
-                    <i-tabler name="git-pull-request" class="!size-5 flex-shrink-0"></i-tabler>
-                    <span class="truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
-                  </p-tag>
-                }
-              </div>
-            }
-          </div>
-
-          <div class="flex-grow"></div>
-
-          <!-- TODO: Refactor button rendering -->
-          <div class="flex gap-2 items-center self-end md:self-center">
-            @if (environment.locked) {
-              <div class="flex gap-1 items-center">
-                <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
-              </div>
-              @if (environment.lockedAt) {
-                <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
-              }
-            }
-
-            <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
-              @if (deployable()) {
-                <p-button
-                  outlined
-                  (click)="deployEnvironment(environment); $event.stopPropagation()"
-                  [disabled]="!canUserDeploy(environment)"
-                  [pTooltip]="getDeployTooltip(environment)"
-                  tooltipPosition="top"
-                >
-                  <div class="flex items-center">
-                    <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
-                    <span>Deploy</span>
-                  </div>
-                </p-button>
-                <div class="w-px bg-gray-300 self-stretch"></div>
-              }
-
-              @if (environment.enabled) {
-                <p-buttongroup>
-                  @if (!environment.locked) {
-                    @if (deployable()) {
-                      <p-button
-                        outlined
-                        (click)="lockEnvironment(environment); $event.stopPropagation()"
-                        [disabled]="!canUserDeploy(environment)"
-                        [pTooltip]="getLockTooltip(environment)"
-                        tooltipPosition="top"
-                      >
-                        <div class="flex items-center">
-                          <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
+                        @if (environment.type) {
+                          <p-tag [value]="formatEnvironmentType(environment.type)" severity="secondary" rounded="true" />
+                        }
+                      </div>
+                      @if (environment.latestDeployment; as deployment) {
+                        <div class="flex gap-1 items-center text-sm mt-2">
+                          <app-user-avatar [user]="environment?.latestDeployment?.user" tooltipPosition="top" />
+                          @if (environment.latestDeployment.user?.name) {
+                            {{ environment.latestDeployment.user?.name }} deployed
+                          }
+                          @if (environment.latestDeployment.updatedAt) {
+                            <span [pTooltip]="getDeploymentTime(environment) || ''">{{ environment.latestDeployment.updatedAt || '' | timeAgo }}</span>
+                          }
+                          <app-deployment-state-tag [state]="deployment.state" />
+                          <p-tag severity="secondary" rounded="true" class="max-w-[350px] flex items-center" [pTooltip]="tooltipTemplate" tooltipPosition="top">
+                            <i-tabler name="git-branch" class="!size-5 mr-0.5 flex-shrink-0"></i-tabler>
+                            <span class="ml-1 truncate flex-1">{{ deployment.ref }}</span>
+                            <ng-template #tooltipTemplate>
+                              <div class="flex items-center">{{ deployment.ref }}</div>
+                            </ng-template>
+                          </p-tag>
                         </div>
-                      </p-button>
-                    }
-                  } @else {
-                    @if (isLoggedIn() && (environment.lockReservationWillExpireAt !== null || isCurrentUserLocked(environment) || hasUnlockPermissions())) {
-                      <p-button
-                        severity="danger"
-                        class="[&>*]:!rounded-none"
-                        (click)="onUnlockEnvironment($event, environment)"
-                        [disabled]="!canUnlock(environment)"
-                        [pTooltip]="getUnlockToolTip(environment)"
-                        tooltipPosition="top"
-                      >
-                        <div class="flex items-center">
-                          <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
-                        </div>
-                      </p-button>
-                      @if (isCurrentUserLocked(environment)) {
-                        <p-button
-                          outlined
-                          (click)="extendLock($event, environment)"
-                          [disabled]="!canUnlock(environment)"
-                          [pTooltip]="'Extend my lock expiration'"
-                          tooltipPosition="top"
-                        >
-                          <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
-                        </p-button>
                       }
+                    </div>
+
+                    <div class="flex-grow"></div>
+
+                    <!-- TODO: Refactor button rendering -->
+                    <div class="flex gap-2 items-center self-end md:self-center">
+                      @if (environment.locked) {
+                        <div class="flex gap-1 items-center">
+                          <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
+                        </div>
+                        @if (environment.lockedAt) {
+                          <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
+                        }
+                      }
+
+                      <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
+                        @if (deployable()) {
+                          <p-button
+                            outlined
+                            (click)="deployEnvironment(environment); $event.stopPropagation()"
+                            [disabled]="!canUserDeploy(environment)"
+                            [pTooltip]="getDeployTooltip(environment)"
+                            tooltipPosition="top"
+                          >
+                            <div class="flex items-center">
+                              <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
+                              <span>Deploy</span>
+                            </div>
+                          </p-button>
+                          <div class="w-px bg-gray-300 self-stretch"></div>
+                        }
+
+                        @if (environment.enabled) {
+                          <p-buttongroup>
+                            @if (!environment.locked) {
+                              @if (deployable()) {
+                                <p-button
+                                  outlined
+                                  (click)="lockEnvironment(environment); $event.stopPropagation()"
+                                  [disabled]="!canUserDeploy(environment)"
+                                  [pTooltip]="getLockTooltip(environment)"
+                                  tooltipPosition="top"
+                                >
+                                  <div class="flex items-center">
+                                    <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
+                                  </div>
+                                </p-button>
+                              }
+                            } @else {
+                              @if (isLoggedIn() && (environment.lockReservationWillExpireAt !== null || isCurrentUserLocked(environment) || hasUnlockPermissions())) {
+                                <p-button
+                                  severity="danger"
+                                  class="[&>*]:!rounded-none"
+                                  (click)="onUnlockEnvironment($event, environment)"
+                                  [disabled]="!canUnlock(environment)"
+                                  [pTooltip]="getUnlockToolTip(environment)"
+                                  tooltipPosition="top"
+                                >
+                                  <div class="flex items-center">
+                                    <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
+                                  </div>
+                                </p-button>
+                                @if (isCurrentUserLocked(environment)) {
+                                  <p-button
+                                    outlined
+                                    (click)="extendLock($event, environment)"
+                                    [disabled]="!canUnlock(environment)"
+                                    [pTooltip]="'Extend my lock expiration'"
+                                    tooltipPosition="top"
+                                  >
+                                    <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
+                                  </p-button>
+                                }
+                              }
+                            }
+                          </p-buttongroup>
+                        }
+                      </div>
+                      @if (canViewAllEnvironments()) {
+                        <!-- Show the disabled tag -->
+                        @if (!environment.enabled) {
+                          <p-tag value="Disabled" severity="danger" rounded="true" />
+                        }
+                        <a
+                          icon
+                          [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
+                          class="p-button p-button-secondary p-2"
+                          (click)="$event.stopPropagation()"
+                        >
+                          <i-tabler name="pencil" />
+                        </a>
+                      }
+                      <span class="w-2"></span>
+                    </div>
+                  </div>
+                </p-accordion-header>
+                <p-accordion-content>
+                  <div class="flex w-full flex-col gap-4">
+                    <!-- Toggle Button -->
+                    <div class="flex justify-start gap-2">
+                      <p-selectbutton
+                        [options]="[
+                          { label: 'Details', value: false },
+                          { label: 'Deployment', value: true },
+                        ]"
+                        [(ngModel)]="showLatestDeployment"
+                        optionLabel="label"
+                        optionValue="value"
+                        aria-labelledby="basic"
+                      />
+                    </div>
+
+                    <!-- Conditionally display information based on the toggle -->
+                    @if (showLatestDeployment) {
+                      <div class="flex w-full">
+                        <app-deployment-stepper [deployment]="environment.latestDeployment" class="w-full" />
+                      </div>
+                    } @else {
+                      <div class="flex w-full">
+                        <div class="flex flex-col gap-1">
+                          @if (environment.latestDeployment; as deployment) {
+                            <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment.repository?.id || 0" />
+                          }
+                        </div>
+                        <div class="flex-grow"></div>
+                        <div class="flex flex-col gap-1">
+                          @if (environment.latestStatus; as status) {
+                            <app-environment-status-info class="max-w-xs mt-2 ml-14" [status]="status" />
+                          }
+                        </div>
+                      </div>
                     }
-                  }
-                </p-buttongroup>
-              }
-            </div>
-            @if (canViewAllEnvironments()) {
-              <!-- Show the disabled tag -->
-              @if (!environment.enabled) {
-                <p-tag value="Disabled" severity="danger" rounded="true" />
-              }
-              <a
-                icon
-                [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
-                class="p-button p-button-secondary p-2"
-                (click)="$event.stopPropagation()"
-              >
-                <i-tabler name="pencil" />
-              </a>
+
+                    <!-- Footer links and tags -->
+                    <div class="flex gap-4 items-center justify-between">
+                      <div class="flex gap-1 mt-2 items-center">
+                        <a
+                          icon
+                          [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/history'"
+                          class="p-button p-button-text text-gray-500 py-2 flex items-center"
+                        >
+                          <i-tabler class="mr-1" name="history" />
+                          View Activity History
+                        </a>
+                      </div>
+                      <div class="flex flex-grow"></div>
+                      <div class="flex gap-2">
+                        @for (installedApp of environment.installedApps; track installedApp) {
+                          <p-tag class="bg-gray-300 gap-0">{{ installedApp }}</p-tag>
+                        }
+                      </div>
+                    </div>
+                  </div>
+                </p-accordion-content>
+              </p-accordion-panel>
             }
-            <span class="w-2"></span>
-          </div>
+          </p-accordion>
         </div>
-      </p-accordion-header>
-      <p-accordion-content>
-        <div class="flex w-full flex-col gap-4">
-          <!-- Toggle Button -->
-          <div class="flex justify-start gap-2">
-            <p-selectbutton
-              [options]="[
-                { label: 'Details', value: false },
-                { label: 'Deployment', value: true },
-              ]"
-              [(ngModel)]="showLatestDeployment"
-              optionLabel="label"
-              optionValue="value"
-              aria-labelledby="basic"
-            />
-          </div>
-
-          <!-- Conditionally display information based on the toggle -->
-          @if (showLatestDeployment) {
-            <div class="flex w-full">
-              <app-deployment-stepper [deployment]="environment.latestDeployment" class="w-full" />
-            </div>
-          } @else {
-            <div class="flex w-full">
-              <div class="flex flex-col gap-1">
-                @if (environment.latestDeployment; as deployment) {
-                  <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment.repository?.id || 0" />
-                }
-              </div>
-              <div class="flex-grow"></div>
-              <div class="flex flex-col gap-1">
-                @if (environment.latestStatus; as status) {
-                  <app-environment-status-info class="max-w-xs mt-2 ml-14" [status]="status" />
-                }
-              </div>
-            </div>
-          }
-
-          <!-- Footer links and tags -->
-          <div class="flex gap-4 items-center justify-between">
-            <div class="flex gap-1 mt-2 items-center">
-              <a
-                icon
-                [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/history'"
-                class="p-button p-button-text text-gray-500 py-2 flex items-center"
-              >
-                <i-tabler class="mr-1" name="history" />
-                View Activity History
-              </a>
-            </div>
-            <div class="flex flex-grow"></div>
-            <div class="flex gap-2">
-              @for (installedApp of environment.installedApps; track installedApp) {
-                <p-tag class="bg-gray-300 gap-0">{{ installedApp }}</p-tag>
-              }
-            </div>
-          </div>
-        </div>
-      </p-accordion-content>
-    </p-accordion-panel>
+      }
+    }
   }
-</p-accordion>
+}

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -1,7 +1,9 @@
 <div class="flex items-center justify-between mb-3">
   <input pInputText id="commit-hash" (input)="onSearch($event)" [value]="searchInput()" type="text" placeholder="Search for installed systems" class="w-1/3" />
   @if (!hideLinkToList()) {
-    <p-button [routerLink]="'../../../environment'" class="self-end">{{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }} </p-button>
+    <p-button [routerLink]="'../../../environment'" class="self-end">
+      {{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }}
+    </p-button>
   }
 </div>
 
@@ -19,238 +21,17 @@
           <h3 class="text-lg font-semibold mb-2">{{ capitalizeFirstLetter(group[0]) }}</h3>
           <p-accordion [multiple]="true">
             @for (environment of group[1]; track environment.id) {
-              <p-accordion-panel [value]="environment.id">
-                <p-accordion-header>
-                  <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
-                    <div class="flex flex-col gap-1 flex-wrap">
-                      <div class="flex gap-1 items-center mr-3">
-                        <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment.serverUrl)">
-                          {{ environment.name }}
-                        </span>
-
-                        <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
-
-                        @if (environment.latestStatus; as status) {
-                          <app-environment-status-tag [status]="status" />
-                        }
-
-                        @if (environment.type) {
-                          <p-tag [value]="formatEnvironmentType(environment.type)" severity="secondary" rounded="true" />
-                        }
-                      </div>
-                      @if (environment.latestDeployment; as deployment) {
-                        <div class="flex gap-1 items-center text-sm mt-2 flex-wrap">
-                          <app-user-avatar [user]="environment?.latestDeployment?.user" tooltipPosition="top" />
-                          @if (environment.latestDeployment.user?.name) {
-                            {{ environment.latestDeployment.user?.name }} deployed
-                          }
-                          @if (environment.latestDeployment.updatedAt) {
-                            <span [pTooltip]="getDeploymentTime(environment) || ''">{{ environment.latestDeployment.updatedAt || '' | timeAgo }}</span>
-                          }
-                          <app-deployment-state-tag [state]="deployment.state" [deployment]="deployment" />
-                          <!-- Branch or Release Tag -->
-                          <p-tag
-                            severity="secondary"
-                            rounded="true"
-                            class="max-w-[250px] flex items-center"
-                            [pTooltip]="isRelease(deployment) ? '' : 'Go to ' + deployment.ref"
-                            tooltipPosition="top"
-                            (click)="$event.stopPropagation()"
-                            [routerLink]="isRelease(deployment) ? null : getBranchLink(environment)"
-                          >
-                            @if (isRelease(deployment)) {
-                              <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
-                            } @else {
-                              <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
-                            }
-                            <span class="truncate flex-1">{{ deployment.ref }}</span>
-                          </p-tag>
-                          @if (deployment.pullRequestNumber) {
-                            <!-- PR Tag -->
-                            <p-tag
-                              severity="secondary"
-                              rounded="true"
-                              class="max-w-[350px] flex items-center"
-                              [pTooltip]="'Go to ' + (deployment.prName || 'Pull Request #' + deployment.pullRequestNumber)"
-                              tooltipPosition="top"
-                              (click)="$event.stopPropagation()"
-                              [routerLink]="getPrLink(environment)"
-                            >
-                              <i-tabler name="git-pull-request" class="!size-5 flex-shrink-0"></i-tabler>
-                              <span class="truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
-                            </p-tag>
-                          }
-                        </div>
-                      }
-                    </div>
-
-                    <div class="flex-grow"></div>
-
-                    <!-- TODO: Refactor button rendering -->
-                    <div class="flex gap-2 items-center self-end md:self-center">
-                      @if (environment.locked) {
-                        <div class="flex gap-1 items-center">
-                          <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
-                        </div>
-                        @if (environment.lockedAt) {
-                          <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
-                        }
-                      }
-
-                      <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
-                        @if (deployable()) {
-                          <p-button
-                            outlined
-                            (click)="deployEnvironment(environment); $event.stopPropagation()"
-                            [disabled]="!canUserDeploy(environment)"
-                            [pTooltip]="getDeployTooltip(environment)"
-                            tooltipPosition="top"
-                          >
-                            <div class="flex items-center">
-                              <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
-                              <span>Deploy</span>
-                            </div>
-                          </p-button>
-                          <div class="w-px bg-gray-300 self-stretch"></div>
-                        }
-
-                        @if (environment.enabled && environment.type === 'TEST') {
-                          <p-buttongroup>
-                            @if (!environment.locked) {
-                              @if (deployable()) {
-                                <p-button
-                                  outlined
-                                  (click)="lockEnvironment(environment); $event.stopPropagation()"
-                                  [disabled]="!canUserDeploy(environment)"
-                                  [pTooltip]="getLockTooltip(environment)"
-                                  tooltipPosition="top"
-                                >
-                                  <div class="flex items-center">
-                                    <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
-                                  </div>
-                                </p-button>
-                              }
-                            } @else {
-                              @if (isLoggedIn() && (environment.lockReservationWillExpireAt !== null || isCurrentUserLocked(environment) || hasUnlockPermissions())) {
-                                <p-button
-                                  severity="danger"
-                                  class="[&>*]:!rounded-none"
-                                  (click)="onUnlockEnvironment($event, environment)"
-                                  [disabled]="!canUnlock(environment)"
-                                  [pTooltip]="getUnlockToolTip(environment)"
-                                  tooltipPosition="top"
-                                >
-                                  <div class="flex items-center">
-                                    <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
-                                  </div>
-                                </p-button>
-                                @if (isCurrentUserLocked(environment)) {
-                                  <p-button
-                                    outlined
-                                    (click)="extendLock($event, environment)"
-                                    [disabled]="!canUnlock(environment)"
-                                    [pTooltip]="'Extend my lock expiration'"
-                                    tooltipPosition="top"
-                                  >
-                                    <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
-                                  </p-button>
-                                }
-                              }
-                            }
-                          </p-buttongroup>
-                        }
-
-                        @if (environment.latestDeployment?.state === 'WAITING') {
-                          <p-button
-                            severity="success"
-                            (click)="openExternalLink($event, environment.latestDeployment?.workflowRunHtmlUrl)"
-                            pTooltip="Approve deployment on GitHub"
-                            tooltipPosition="top"
-                          >
-                            <div class="flex items-center">
-                              <i-tabler name="check" class="w-4 h-4 flex-shrink-0" />
-                            </div>
-                          </p-button>
-                        }
-                      </div>
-
-                      @if (canViewAllEnvironments()) {
-                        <!-- Show the disabled tag -->
-                        @if (!environment.enabled) {
-                          <p-tag value="Disabled" severity="danger" rounded="true" />
-                        }
-                        <a
-                          icon
-                          [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
-                          class="p-button p-button-secondary p-2"
-                          (click)="$event.stopPropagation()"
-                        >
-                          <i-tabler name="pencil" />
-                        </a>
-                      }
-                      <span class="w-2"></span>
-                    </div>
-                  </div>
-                </p-accordion-header>
-                <p-accordion-content>
-                  <div class="flex w-full flex-col gap-4">
-                    <!-- Toggle Button -->
-                    <div class="flex justify-start gap-2">
-                      <p-selectbutton
-                        [options]="[
-                          { label: 'Details', value: false },
-                          { label: 'Deployment', value: true },
-                        ]"
-                        [(ngModel)]="showLatestDeployment"
-                        optionLabel="label"
-                        optionValue="value"
-                        aria-labelledby="basic"
-                      />
-                    </div>
-
-                    <!-- Conditionally display information based on the toggle -->
-                    @if (showLatestDeployment) {
-                      <div class="flex w-full">
-                        <app-deployment-stepper [deployment]="environment.latestDeployment" class="w-full" />
-                      </div>
-                    } @else {
-                      <div class="flex w-full">
-                        <div class="flex flex-col gap-1">
-                          @if (environment.latestDeployment; as deployment) {
-                            <app-environment-deployment-info class="max-w-2xl" [deployment]="deployment" [repositoryId]="environment.repository?.id || 0" />
-                          }
-                        </div>
-                        <div class="flex-grow"></div>
-                        <div class="flex flex-col gap-1">
-                          @if (environment.latestStatus; as status) {
-                            <app-environment-status-info class="max-w-xs mt-2 ml-14" [status]="status" />
-                          }
-                        </div>
-                      </div>
-                    }
-
-                    <!-- Footer links and tags -->
-                    <div class="flex gap-4 items-center justify-between">
-                      <div class="flex gap-1 mt-2 items-center">
-                        <a
-                          icon
-                          [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/history'"
-                          class="p-button p-button-text text-gray-500 py-2 flex items-center"
-                        >
-                          <i-tabler class="mr-1" name="history" />
-                          View Activity History
-                        </a>
-                      </div>
-                      <div class="flex flex-grow"></div>
-                      <div class="flex gap-2">
-                        @for (installedApp of environment.installedApps; track installedApp) {
-                          <p-tag class="bg-gray-300 gap-0">{{ installedApp }}</p-tag>
-                        }
-                      </div>
-                    </div>
-                  </div>
-                </p-accordion-content>
-              </p-accordion-panel>
+              <app-environment-accordion
+                [environment]="environment"
+                [deployable]="!!deployable()"
+                [canViewAllEnvironments]="!!canViewAllEnvironments()"
+                [timeUntilReservationExpires]="timeUntilReservationExpires().get(environment.id)"
+                (deploy)="deployEnvironment($event)"
+                (unlock)="onUnlockEnvironment($event.event, $event.environment)"
+                (extend)="extendLock($event.event, $event.environment)"
+                (lock)="lockEnvironment($event)"
+              >
+              </app-environment-accordion>
             }
           </p-accordion>
         </div>

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -1,9 +1,7 @@
 <div class="flex items-center justify-between mb-3">
   <input pInputText id="commit-hash" (input)="onSearch($event)" [value]="searchInput()" type="text" placeholder="Search for installed systems" class="w-1/3" />
   @if (!hideLinkToList()) {
-    <p-button [routerLink]="'../../../environment'" class="self-end">
-      {{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }}
-    </p-button>
+    <p-button [routerLink]="'../../../environment'" class="self-end">{{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }} </p-button>
   }
 </div>
 
@@ -17,19 +15,19 @@
   } @else {
     @for (group of environmentGroups(); track group[0]) {
       @if (group[1].length > 0) {
-        <div>
-          <h3 class="text-lg font-semibold p-2 bg-slate-100">{{ capitalizeFirstLetter(group[0]) }}</h3>
-          <p-divider class="mt-0" />
+        <div class="mb-4">
+          <h3 class="text-lg font-semibold mb-2">{{ capitalizeFirstLetter(group[0]) }}</h3>
           <p-accordion [multiple]="true">
             @for (environment of group[1]; track environment.id) {
               <p-accordion-panel [value]="environment.id">
                 <p-accordion-header>
-                  <div class="flex gap-2 items-center w-full">
-                    <div class="flex flex-col gap-1">
+                  <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
+                    <div class="flex flex-col gap-1 flex-wrap">
                       <div class="flex gap-1 items-center mr-3">
                         <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment)">
                           {{ environment.name }}
                         </span>
+
                         <app-lock-tag [isLocked]="!!environment.locked"></app-lock-tag>
 
                         @if (environment.latestStatus; as status) {
@@ -41,7 +39,7 @@
                         }
                       </div>
                       @if (environment.latestDeployment; as deployment) {
-                        <div class="flex gap-1 items-center text-sm mt-2">
+                        <div class="flex gap-1 items-center text-sm mt-2 flex-wrap">
                           <app-user-avatar [user]="environment?.latestDeployment?.user" tooltipPosition="top" />
                           @if (environment.latestDeployment.user?.name) {
                             {{ environment.latestDeployment.user?.name }} deployed
@@ -49,14 +47,39 @@
                           @if (environment.latestDeployment.updatedAt) {
                             <span [pTooltip]="getDeploymentTime(environment) || ''">{{ environment.latestDeployment.updatedAt || '' | timeAgo }}</span>
                           }
-                          <app-deployment-state-tag [state]="deployment.state" />
-                          <p-tag severity="secondary" rounded="true" class="max-w-[350px] flex items-center" [pTooltip]="tooltipTemplate" tooltipPosition="top">
-                            <i-tabler name="git-branch" class="!size-5 mr-0.5 flex-shrink-0"></i-tabler>
-                            <span class="ml-1 truncate flex-1">{{ deployment.ref }}</span>
-                            <ng-template #tooltipTemplate>
-                              <div class="flex items-center">{{ deployment.ref }}</div>
-                            </ng-template>
+                          <app-deployment-state-tag [state]="deployment.state" [deployment]="deployment" />
+                          <!-- Branch or Release Tag -->
+                          <p-tag
+                            severity="secondary"
+                            rounded="true"
+                            class="max-w-[250px] flex items-center"
+                            [pTooltip]="isRelease(deployment) ? '' : 'Go to ' + deployment.ref"
+                            tooltipPosition="top"
+                            (click)="$event.stopPropagation()"
+                            [routerLink]="isRelease(deployment) ? null : getBranchLink(environment)"
+                          >
+                            @if (isRelease(deployment)) {
+                              <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
+                            } @else {
+                              <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
+                            }
+                            <span class="truncate flex-1">{{ deployment.ref }}</span>
                           </p-tag>
+                          @if (deployment.pullRequestNumber) {
+                            <!-- PR Tag -->
+                            <p-tag
+                              severity="secondary"
+                              rounded="true"
+                              class="max-w-[350px] flex items-center"
+                              [pTooltip]="'Go to ' + (deployment.prName || 'Pull Request #' + deployment.pullRequestNumber)"
+                              tooltipPosition="top"
+                              (click)="$event.stopPropagation()"
+                              [routerLink]="getPrLink(environment)"
+                            >
+                              <i-tabler name="git-pull-request" class="!size-5 flex-shrink-0"></i-tabler>
+                              <span class="truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
+                            </p-tag>
+                          }
                         </div>
                       }
                     </div>

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -2,8 +2,7 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { Component, computed, inject, input, OnDestroy, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { UserAvatarComponent } from '@app/components/user-avatar/user-avatar.component';
-import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
+import { EnvironmentDto } from '@app/core/modules/openapi';
 import {
   extendEnvironmentLockMutation,
   getAllEnabledEnvironmentsOptions,
@@ -16,7 +15,6 @@ import {
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 import { PermissionService } from '@app/core/services/permission.service';
-import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
 import { injectMutation, injectQuery, QueryClient } from '@tanstack/angular-query-experimental';
 import { IconsModule } from 'icons.module';
 import { AccordionModule } from 'primeng/accordion';
@@ -31,41 +29,27 @@ import { TagModule } from 'primeng/tag';
 import { ToggleButtonModule } from 'primeng/togglebutton';
 import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
-import { EnvironmentDeploymentInfoComponent } from '../deployment-info/environment-deployment-info.component';
-import { DeploymentStateTagComponent } from '../deployment-state-tag/deployment-state-tag.component';
-import { DeploymentStepperComponent } from '../deployment-stepper/deployment-stepper.component';
-import { EnvironmentStatusInfoComponent } from '../environment-status-info/environment-status-info.component';
-import { EnvironmentStatusTagComponent } from '../environment-status-tag/environment-status-tag.component';
-import { LockTagComponent } from '../lock-tag/lock-tag.component';
-import { LockTimeComponent } from '../lock-time/lock-time.component';
+import { EnvironmentAccordionComponent } from '../environment-accordion/environment-accordion.component';
 
 @Component({
   selector: 'app-environment-list-view',
   imports: [
     InputTextModule,
     AccordionModule,
-    LockTagComponent,
     RouterLink,
     TagModule,
     IconsModule,
     ButtonModule,
     TooltipModule,
-    DeploymentStateTagComponent,
-    DeploymentStepperComponent,
-    EnvironmentStatusTagComponent,
-    EnvironmentDeploymentInfoComponent,
-    EnvironmentStatusInfoComponent,
-    LockTimeComponent,
     AvatarModule,
     CommonModule,
     ButtonGroupModule,
-    TimeAgoPipe,
-    UserAvatarComponent,
     ToggleButtonModule,
     FormsModule,
     SelectButtonModule,
     ToggleSwitchModule,
     DividerModule,
+    EnvironmentAccordionComponent,
   ],
   providers: [DatePipe],
   templateUrl: './environment-list-view.component.html',
@@ -74,7 +58,6 @@ export class EnvironmentListViewComponent implements OnDestroy {
   private queryClient = inject<QueryClient>(QueryClient);
   private confirmationService = inject(ConfirmationService);
   private keycloakService = inject(KeycloakService);
-  private datePipe = inject(DatePipe);
   private permissionService = inject(PermissionService);
   private currentTime = signal(Date.now());
   private intervalId: number | undefined;
@@ -86,7 +69,6 @@ export class EnvironmentListViewComponent implements OnDestroy {
   deployable = input<boolean | undefined>();
   hideLinkToList = input<boolean | undefined>();
 
-  groupByType = computed(() => this.deployable());
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
   isAdmin = computed(() => this.permissionService.isAdmin());
   hasUnlockPermissions = computed(() => this.permissionService.isAtLeastMaintainer());
@@ -262,94 +244,6 @@ export class EnvironmentListViewComponent implements OnDestroy {
       })
     );
   });
-
-  getFullUrl(url: string): string {
-    if (url && !url.startsWith('http') && !url.startsWith('https')) {
-      return 'http://' + url;
-    }
-    return url;
-  }
-
-  openExternalLink(event: MouseEvent, link?: string): void {
-    // Prevent the click event from propagating
-    event.stopPropagation();
-
-    // Only proceed if the server URL is available
-    if (link) {
-      window.open(this.getFullUrl(link), '_blank');
-    }
-  }
-
-  getDeploymentTime(environment: EnvironmentDto) {
-    const date = environment.latestDeployment?.updatedAt;
-    return date ? this.datePipe.transform(date, 'd MMMM y, h:mm a') : null; // Format date
-  }
-
-  canUnlock(environment: EnvironmentDto) {
-    if (this.hasUnlockPermissions() || this.isCurrentUserLocked(environment)) {
-      return true;
-    } else if (!this.isCurrentUserLocked(environment) && (this.timeUntilReservationExpires()?.get(environment.id) ?? -1) === 0) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  getUnlockToolTip(environment: EnvironmentDto) {
-    if (!this.canUnlock(environment)) return 'You do not have permission to unlock this environment.';
-    const timeLeft = this.timeUntilReservationExpires().get(environment.id);
-    const timeLeftMinutes = timeLeft !== undefined && timeLeft !== null ? Math.ceil(timeLeft / 60000) : 0;
-    if (this.isCurrentUserLocked(environment) || this.hasUnlockPermissions()) {
-      if (timeLeft !== undefined && timeLeft !== null) {
-        if (timeLeft > 0) {
-          // if the user is locked and the time has not expired, show the time left
-          return timeLeftMinutes > 1 ? `Other users can unlock this environment in ${timeLeftMinutes} minutes` : 'Other users can unlock this environment in 1 minute';
-        } else if (timeLeft === 0) {
-          // If the user is locked and the time has expired, show only unlock environment
-          return 'Reservation has expired. Any user can unlock this environment.';
-        }
-      }
-      // If the user is locked and the time has expired, show only unlock environment
-      return 'Unlock Environment';
-    }
-    if (timeLeft === undefined || timeLeft === null) {
-      // If the user is not locked and the time is not set, then user can not unlock
-      return 'You can not unlock this environment';
-    } else if (timeLeft === 0) {
-      // If the user is not locked and the time has expired, show reservation expired
-      return 'Reservation Expired. You can unlock this environment.';
-    } else {
-      // If the user is not locked and the time has not expired, show the time left
-      return timeLeftMinutes > 1 ? `You can unlock this environment in ${timeLeftMinutes} minutes` : 'You can unlock this environment in 1 minute';
-    }
-  }
-
-  formatEnvironmentType(type: string): string {
-    return type.charAt(0).toUpperCase() + type.slice(1).toLowerCase();
-  }
-
-  isDeploymentOngoing(environment: EnvironmentDto) {
-    if (!environment.latestDeployment) {
-      return false;
-    } else if (environment.latestDeployment.state && ['SUCCESS', 'FAILURE', 'ERROR', 'INACTIVE', 'UNKNOWN'].includes(environment.latestDeployment.state)) {
-      return false;
-    }
-    return true;
-  }
-
-  isRelease(deployment: EnvironmentDeployment): boolean {
-    // TODO: This is a temporary solution to check if a deployment is a release
-    // until Paul's PR is merged which enables syncing of releases from GitHub to find a corresponding release
-    return !!deployment.releaseCandidateName || (!!deployment.ref && /^v?\d+\.\d+\.\d+/.test(deployment.ref));
-  }
-
-  getPrLink(env: EnvironmentDto) {
-    return ['/repo', env.repository?.id, 'ci-cd', 'pr', env.latestDeployment?.pullRequestNumber?.toString()];
-  }
-
-  getBranchLink(env: EnvironmentDto) {
-    return ['/repo', env.repository?.id, 'ci-cd', 'branch', env.latestDeployment?.ref];
-  }
 
   capitalizeFirstLetter(str: string): string {
     return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1);

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -81,7 +81,6 @@ export class EnvironmentListViewComponent implements OnDestroy {
   editable = input<boolean | undefined>();
   deployable = input<boolean | undefined>();
   hideLinkToList = input<boolean | undefined>();
-  showTestEnvironmentsOnly = input<boolean | undefined>();
 
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
   isAdmin = computed(() => this.permissionService.isAdmin());
@@ -215,9 +214,6 @@ export class EnvironmentListViewComponent implements OnDestroy {
 
   filteredEnvironments = computed(() => {
     let environments = this.environmentQuery.data();
-    if (this.showTestEnvironmentsOnly()) {
-      environments = environments?.filter(environment => environment.type === 'TEST');
-    }
 
     const search = this.searchInput();
 

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -270,13 +270,13 @@ export class EnvironmentListViewComponent implements OnDestroy {
     return url;
   }
 
-  openExternalLink(event: MouseEvent, environment: EnvironmentDto): void {
+  openExternalLink(event: MouseEvent, link?: string): void {
     // Prevent the click event from propagating
     event.stopPropagation();
 
     // Only proceed if the server URL is available
-    if (environment.serverUrl) {
-      window.open(this.getFullUrl(environment.serverUrl), '_blank');
+    if (link) {
+      window.open(this.getFullUrl(link), '_blank');
     }
   }
 

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -24,10 +24,12 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
 import { ButtonGroupModule } from 'primeng/buttongroup';
+import { DividerModule } from 'primeng/divider';
 import { InputTextModule } from 'primeng/inputtext';
 import { SelectButtonModule } from 'primeng/selectbutton';
 import { TagModule } from 'primeng/tag';
 import { ToggleButtonModule } from 'primeng/togglebutton';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
 import { TooltipModule } from 'primeng/tooltip';
 import { EnvironmentDeploymentInfoComponent } from '../deployment-info/environment-deployment-info.component';
 import { DeploymentStateTagComponent } from '../deployment-state-tag/deployment-state-tag.component';
@@ -62,6 +64,8 @@ import { LockTimeComponent } from '../lock-time/lock-time.component';
     ToggleButtonModule,
     FormsModule,
     SelectButtonModule,
+    ToggleSwitchModule,
+    DividerModule,
   ],
   providers: [DatePipe],
   templateUrl: './environment-list-view.component.html',

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -227,10 +227,13 @@ export class EnvironmentListViewComponent implements OnDestroy {
     });
   });
 
+  private readonly environmentTypeOrder = ['test', 'staging'];
+
   environmentGroups = computed(() => {
     const environments = this.filteredEnvironments();
     const groups = new Map<string, EnvironmentDto[]>();
 
+    // Group environments
     environments.forEach(environment => {
       const type = environment.type || 'Other';
       if (!groups.has(type)) {
@@ -239,7 +242,21 @@ export class EnvironmentListViewComponent implements OnDestroy {
       groups.get(type)?.push(environment);
     });
 
-    return groups;
+    // Sort by predefined order
+    return new Map(
+      Array.from(groups.entries()).sort(([a], [b]) => {
+        const indexA = this.environmentTypeOrder.indexOf(a.toLowerCase());
+        const indexB = this.environmentTypeOrder.indexOf(b.toLowerCase());
+
+        // If both types are not in the order array, sort alphabetically
+        if (indexA === -1 && indexB === -1) return a.localeCompare(b);
+        // If one type is not in the order array, it goes last
+        if (indexA === -1) return 1;
+        if (indexB === -1) return -1;
+        // Otherwise, sort by the predefined order
+        return indexA - indexB;
+      })
+    );
   });
 
   getFullUrl(url: string): string {

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -239,7 +239,7 @@ export class EnvironmentListViewComponent implements OnDestroy {
 
     // Group environments
     environments.forEach(environment => {
-      const type = environment.type || 'Other';
+      const type = environment.type || 'Ungrouped';
       if (!groups.has(type)) {
         groups.set(type, []);
       }

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -82,6 +82,7 @@ export class EnvironmentListViewComponent implements OnDestroy {
   deployable = input<boolean | undefined>();
   hideLinkToList = input<boolean | undefined>();
 
+  groupByType = computed(() => this.deployable());
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
   isAdmin = computed(() => this.permissionService.isAdmin());
   hasUnlockPermissions = computed(() => this.permissionService.isAtLeastMaintainer());
@@ -226,6 +227,21 @@ export class EnvironmentListViewComponent implements OnDestroy {
     });
   });
 
+  environmentGroups = computed(() => {
+    const environments = this.filteredEnvironments();
+    const groups = new Map<string, EnvironmentDto[]>();
+
+    environments.forEach(environment => {
+      const type = environment.type || 'Other';
+      if (!groups.has(type)) {
+        groups.set(type, []);
+      }
+      groups.get(type)?.push(environment);
+    });
+
+    return groups;
+  });
+
   getFullUrl(url: string): string {
     if (url && !url.startsWith('http') && !url.startsWith('https')) {
       return 'http://' + url;
@@ -312,5 +328,9 @@ export class EnvironmentListViewComponent implements OnDestroy {
 
   getBranchLink(env: EnvironmentDto) {
     return ['/repo', env.repository?.id, 'ci-cd', 'branch', env.latestDeployment?.ref];
+  }
+
+  capitalizeFirstLetter(str: string): string {
+    return str.charAt(0).toUpperCase() + str.toLowerCase().slice(1);
   }
 }

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -222,6 +222,12 @@ export class EnvironmentListViewComponent implements OnDestroy {
     // Group environments
     environments.forEach(environment => {
       const type = environment.type || 'Ungrouped';
+
+      // Skip ungrouped environments if deployable is true
+      if (this.deployable() && type === 'Ungrouped') {
+        return;
+      }
+
       if (!groups.has(type)) {
         groups.set(type, []);
       }

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
@@ -21,7 +21,7 @@
     </ng-template>
   </p-table>
 } @else {
-  <p-table #table [rowHover]="true" [value]="deployableEnvironments() || []" [paginator]="true" [rows]="20">
+  <p-table #table [rowHover]="true" [value]="environmentQuery.data() || []" rowGroupMode="subheader" groupRowsBy="type">
     <ng-template #header>
       <tr>
         <th class="w-[30%]">Name</th>
@@ -30,6 +30,16 @@
         <th class="w-[15%]">Actions</th>
       </tr>
     </ng-template>
+    <ng-template #groupheader let-environment>
+      <tr pRowGroupHeader class="bg-gray-100">
+        <td colspan="4">
+          <div class="flex gap-2">
+            <span class="font-bold">{{ capitalizeFirstLetter(environment.type) }}</span>
+          </div>
+        </td>
+      </tr>
+    </ng-template>
+
     <ng-template pTemplate="body" let-environment>
       <tr>
         <td>

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
@@ -63,7 +63,7 @@
           }
         </td>
         <td>
-          @if (userCanDeploy() && deploymentStatus(environment) === 'WAITING' && environment.latestDeployment?.workflowRunHtmlUrl) {
+          @if (userCanDeploy() && environment.latestDeployment?.state === 'WAITING') {
             <p-button styleClass="p-button-success" (onClick)="openWorkflowUrl(environment.latestDeployment.workflowRunHtmlUrl)">
               <ng-template pTemplate="content">
                 <div class="flex items-center gap-2">

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
@@ -31,7 +31,7 @@
       </tr>
     </ng-template>
     <ng-template #groupheader let-environment>
-      <tr pRowGroupHeader class="bg-gray-100">
+      <tr pRowGroupHeader class="bg-slate-100">
         <td colspan="4">
           <div class="flex gap-2">
             <span class="font-bold">{{ capitalizeFirstLetter(environment.type) }}</span>

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
@@ -21,7 +21,7 @@
     </ng-template>
   </p-table>
 } @else {
-  <p-table #table [rowHover]="true" [value]="environmentQuery.data() || []" rowGroupMode="subheader" groupRowsBy="type">
+  <p-table #table [rowHover]="true" [value]="groupedEnvironments()" rowGroupMode="subheader" groupRowsBy="type">
     <ng-template #header>
       <tr>
         <th class="w-[30%]">Name</th>

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
@@ -40,6 +40,11 @@ export class ReleaseCandidateDeploymentTableComponent {
 
   environmentQuery = injectQuery(() => ({ ...getAllEnabledEnvironmentsOptions(), refetchInterval: 3000 }));
 
+  groupedEnvironments = computed(() => {
+    const environments = this.environmentQuery.data() || [];
+    return environments.map(env => ({ ...env, type: env.type || 'Ungrouped' }));
+  });
+
   deployToEnvironment = injectMutation(() => ({
     ...deployToEnvironmentMutation(),
     onSuccess: (_, variables) => {

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
@@ -40,8 +40,6 @@ export class ReleaseCandidateDeploymentTableComponent {
 
   environmentQuery = injectQuery(() => ({ ...getAllEnabledEnvironmentsOptions(), refetchInterval: 3000 }));
 
-  deployableEnvironments = computed(() => this.environmentQuery.data()?.filter(environment => environment.type === 'STAGING' || environment.type === 'PRODUCTION'));
-
   deployToEnvironment = injectMutation(() => ({
     ...deployToEnvironmentMutation(),
     onSuccess: (_, variables) => {
@@ -110,6 +108,10 @@ export class ReleaseCandidateDeploymentTableComponent {
     if (environment.serverUrl) {
       window.open(this.getFullUrl(environment.serverUrl), '_blank');
     }
+  }
+
+  capitalizeFirstLetter(string: string): string {
+    return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
   }
 
   private getFullUrl(url: string): string {

--- a/client/src/icons.module.ts
+++ b/client/src/icons.module.ts
@@ -54,6 +54,7 @@ import {
   IconRepeat,
   IconRocket,
   IconServerCog,
+  IconServer,
   IconSettings,
   IconSun,
   IconUser,
@@ -71,6 +72,7 @@ import {
 const icons = {
   IconHeart,
   IconServerCog,
+  IconServer,
   IconSun,
   IconSettings,
   IconRocket,

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -87,7 +87,8 @@ public class DeploymentService {
 
     HeliosDeployment heliosDeployment =
         createHeliosDeployment(environment, deployRequest, commitSha, optionalPullRequest);
-    Map<String, Object> workflowParams = createWorkflowParams(deployRequest, environment);
+    Map<String, Object> workflowParams =
+        createWorkflowParams(deployRequest, environment, commitSha);
 
     dispatchWorkflow(
         environment, deploymentWorkflow, deployRequest, workflowParams, heliosDeployment);
@@ -161,12 +162,12 @@ public class DeploymentService {
   }
 
   private Map<String, Object> createWorkflowParams(
-      DeployRequest deployRequest, Environment environment) {
+      DeployRequest deployRequest, Environment environment, String commitSha) {
     Map<String, Object> workflowParams = new HashMap<>();
 
     workflowParams.put("branch_name", deployRequest.branchName());
     workflowParams.put("environment_name", environment.getName());
-    workflowParams.put("commit_sha", deployRequest.commitSha());
+    workflowParams.put("commit_sha", commitSha);
     workflowParams.put("triggered_by", authService.getPreferredUsername());
 
     return workflowParams;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -179,10 +179,7 @@ public class DeploymentService {
         case PRODUCTION -> {
           return authService.hasRole("ROLE_ADMIN");
         }
-        case STAGING -> {
-          return authService.hasRole("ROLE_ADMIN");
-        }
-        case TEST -> {
+        case STAGING, TEST -> {
           return authService.hasRole("ROLE_WRITE")
               || authService.hasRole("ROLE_MAINTAINER")
               || authService.hasRole("ROLE_ADMIN");

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
@@ -233,7 +233,7 @@ public class DeploymentServiceTest {
     when(authService.hasRole("ROLE_WRITE")).thenReturn(true);
 
     assertFalse(deploymentService.canDeployToEnvironment(Environment.Type.PRODUCTION));
-    assertFalse(deploymentService.canDeployToEnvironment(Environment.Type.STAGING));
+    assertTrue(deploymentService.canDeployToEnvironment(Environment.Type.STAGING));
     assertTrue(deploymentService.canDeployToEnvironment(Environment.Type.TEST));
   }
 
@@ -243,7 +243,7 @@ public class DeploymentServiceTest {
     when(authService.hasRole("ROLE_MAINTAINER")).thenReturn(true);
 
     assertFalse(deploymentService.canDeployToEnvironment(Environment.Type.PRODUCTION));
-    assertFalse(deploymentService.canDeployToEnvironment(Environment.Type.STAGING));
+    assertTrue(deploymentService.canDeployToEnvironment(Environment.Type.STAGING));
     assertTrue(deploymentService.canDeployToEnvironment(Environment.Type.TEST));
   }
 


### PR DESCRIPTION
Stephan wanted that students can also see staging environment in the pr/branch details view, but it is ok, that he still needs to approve it. (he said)

### Features
- Grouped environments by type
- Users with WRITE permissions can trigger staging deployment
- Added ugly approve button to navigate to GitHub, will be removed with auto approvals
- No locking for staging environments
- I didn't touch on deployment progress bar logic because it will change again once we have auto approvals
- In the current implementation, student can start deployment to staging environment, and Stephan and open Helios go to the environment list view and follow the link for the approval

### Refactor
- Split environment-list-view in several components that can be refactored individually


### Screenshots

1. Student starts deployment in PR/branch view
<img width="1721" alt="Screenshot 2025-03-20 at 15 20 14" src="https://github.com/user-attachments/assets/98e17a02-85c8-4fef-a6c4-2862eead0be2" />
<img width="1727" alt="Screenshot 2025-03-20 at 15 21 17" src="https://github.com/user-attachments/assets/58fb25fe-0cf3-4ad5-a80d-ad68a3e6f58a" />

2. Stephan can approve in PR/branch view or directly in environment view
<img width="1727" alt="Screenshot 2025-03-20 at 15 21 24" src="https://github.com/user-attachments/assets/11086e42-041c-4a7e-ba37-8a93cf88dacc" />
<img width="1728" alt="Screenshot 2025-03-20 at 15 24 25" src="https://github.com/user-attachments/assets/f2fdcf24-a6b1-4b9d-9a8e-e4152e8855b4" />

3. Deployment continues after approval
<img width="1722" alt="Screenshot 2025-03-20 at 15 23 24" src="https://github.com/user-attachments/assets/fecec525-3be4-410d-a386-3c5ca423b6da" />

#### Grouped environments in the release candidate view
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/20b9d622-93ea-4879-80b1-ac804ba5dfdf" />

