### PR TITLE
feat: Dispatch workflows with unified inputs

### DIFF
--- a/docs/development/production/ls1intum.rst
+++ b/docs/development/production/ls1intum.rst
@@ -13,7 +13,19 @@ Steps explain how to configure your GitHub repository, install the Helios GitHub
 
 2. **Configure Deployment Workflow**:
 
-Create a GitHub Actions workflow (example ``deploy-with-helios.yml``) with ``workflow_dispatch`` trigger:
+Create a GitHub Actions workflow (example ``deploy-with-helios.yml``) for deployments. You can have different workflows for different environments or a single workflow that can deploy to multiple environments.
+
+  **Requirements for the workflows:**
+
+  - has ``workflow_dispatch`` trigger
+  - accepts inputs for 
+
+    - ``branch_name``
+    - ``commit_sha``
+    - ``environment_name``
+    - ``triggered_by`` 
+    
+ .. note:: While some inputs can be marked as ``required: false``, all four inputs must be defined in the workflow for Helios to function properly.
 
 .. code-block:: yaml
 
@@ -22,11 +34,15 @@ Create a GitHub Actions workflow (example ``deploy-with-helios.yml``) with ``wor
   on:
     workflow_dispatch:
       inputs:
-        # The inputs below must match exactly to work with Helios
+        # These is the example of the workflow that uses 3 of 4 inputs, only 2 inputs are required
+        # The inputs names below must match exactly to work with Helios
         branch_name:
           description: "Which branch to deploy"
           required: true
           type: string
+        commit_sha:
+          description: 'Commit SHA to deploy'
+          required: false
         environment_name:
           description: "Which environment to deploy (e.g. environment defined in GitHub)"
           required: true


### PR DESCRIPTION
### Motivation
The current workflow dispatch configuration differentiates inputs based on environment types, which adds unnecessary complexity to the deployment process. Standardizing the inputs across all environments will simplify the deployment workflow and make it more maintainable.

### Description
refactor!: standardize workflow dispatch inputs for all environments

This change removes environment-specific input differentiation in the deployment workflow. Now all environments use the same standardized set of inputs:
- `branch_name`
- `commit_sha`
- `environment_name`
- `triggered_by`

BREAKING CHANGE: Environment-specific inputs have been removed. All deployments now use the same standardized input structure.

Key changes:
- Removed environment type checking logic
- Standardized workflow dispatch inputs across all environments
- Updated deployment workflow documentation
- Simplified input validation process

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
...
#### Flow:
1. Log in to Helios
2. Navigate to the CI/CD page
3. Select a branch or PR for deployment
4. Try deploying to different environments:
   - Deploy to a TEST environment
   - Deploy to a STAGING environment
5. Verify that the deployment workflow accepts the same inputs for both environments
6. Check the workflow runs in GitHub Actions to confirm inputs are properly passed
### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [ ] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes have been tested locally.
- [ ] Screenshots have been attached.

#### Server
- [ ] Code is performant and follows best practices
- [ ] I documented the Java code using JavaDoc style.

#### Client
- [ ] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes.
- [ ] I translated all newly inserted strings into English and German.
