### PR TITLE
feat: Add filter for failed tests + search

### DIFF
--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -78,10 +78,6 @@
                   <div class="absolute left-[-5px] -top-1 w-2.5 h-2.5 bg-blue-400 rounded-full flex items-center justify-center" pTooltip="Changed"></div>
                 }
                 <div class="flex items-center gap-2 overflow-hidden">
-                @if (suiteHasUpdates(suite)) {
-                  <div class="absolute left-[-5px] -top-1 w-2.5 h-2.5 bg-blue-400 rounded-full flex items-center justify-center" pTooltip="Changed"></div>
-                }
-                <div class="flex items-center gap-2 overflow-hidden">
                   @switch (overallSuiteState(suite)) {
                     @case ('SUCCESS') {
                       <i-tabler name="circle-check" class="text-green-500 flex-shrink-0"></i-tabler>

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -35,7 +35,34 @@
   </button>
 
   @if (!isTestResultsCollapsed) {
-    @if (testSuites(); as testSuites) {
+    <div class="flex items-center gap-2 w-full max-w-sm mb-2">
+      <p-button type="button" outlined (onClick)="toggleFilterMenu($event)" size="small">
+        @if (showOnlyFailed()) {
+          <i-tabler name="filter" />
+        } @else {
+          <i-tabler name="filter-plus" />
+        }
+      </p-button>
+      <input pInputText [(ngModel)]="searchValue" type="text" pSize="small" placeholder="Search" class="w-full" />
+    </div>
+
+    <p-popover #op>
+      <div class="flex flex-col gap-4">
+        <div>
+          <ul class="list-none p-0 m-0 flex flex-col gap-1">
+            @if (showOnlyFailed()) {
+              <li class="flex items-center gap-2 p-2 hover:bg-gray-300 cursor-pointer rounded-border" (click)="toggleShowOnlyFailed()">All tests</li>
+              <li class="flex items-center gap-2 p-2 bg-gray-700 text-gray-200 cursor-pointer rounded-border">Only failed tests</li>
+            } @else {
+              <li class="flex items-center gap-2 p-2 bg-gray-700 text-gray-200 cursor-pointer rounded-border">All tests</li>
+              <li class="flex items-center gap-2 p-2 hover:bg-gray-300 cursor-pointer rounded-border" (click)="toggleShowOnlyFailed()">Only failed tests</li>
+            }
+          </ul>
+        </div>
+      </div>
+    </p-popover>
+
+    @if (filteredTestSuites(); as testSuites) {
       @if (testSuites.length === 0) {
         <!-- No Results State -->
         <div class="flex flex-col items-center p-4 border rounded-lg">
@@ -50,20 +77,20 @@
                 @if (suiteHasUpdates(suite)) {
                   <div class="absolute left-[-5px] -top-1 w-2.5 h-2.5 bg-blue-400 rounded-full flex items-center justify-center" pTooltip="Changed"></div>
                 }
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 overflow-hidden">
                   @switch (overallSuiteState(suite)) {
                     @case ('SUCCESS') {
-                      <i-tabler name="circle-check" class="text-green-500"></i-tabler>
+                      <i-tabler name="circle-check" class="text-green-500 flex-shrink-0"></i-tabler>
                     }
                     @case ('FAILURE') {
-                      <i-tabler name="circle-x" class="text-red-500"></i-tabler>
+                      <i-tabler name="circle-x" class="text-red-500 flex-shrink-0"></i-tabler>
                     }
                     @case ('SKIPPED') {
-                      <i-tabler name="circle-chevrons-right" class="text-yellow-500"></i-tabler>
+                      <i-tabler name="circle-chevrons-right" class="text-yellow-500 flex-shrink-0"></i-tabler>
                     }
                   }
-                  <span class="font-medium">{{ suite.name }}</span>
-                  <span class="text-sm text-gray-500 ml-2"> ({{ suite.tests }} tests, {{ suite.failures + suite.errors }} failed, {{ suite.skipped }} skipped) </span>
+                  <span class="font-medium truncate">{{ suite.name }}</span>
+                  <span class="text-sm text-gray-500 ml-2 flex-shrink-0"> ({{ suite.tests }} tests, {{ suite.failures + suite.errors }} failed, {{ suite.skipped }} skipped) </span>
                 </div>
               </ng-template>
 

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -78,6 +78,10 @@
                   <div class="absolute left-[-5px] -top-1 w-2.5 h-2.5 bg-blue-400 rounded-full flex items-center justify-center" pTooltip="Changed"></div>
                 }
                 <div class="flex items-center gap-2 overflow-hidden">
+                @if (suiteHasUpdates(suite)) {
+                  <div class="absolute left-[-5px] -top-1 w-2.5 h-2.5 bg-blue-400 rounded-full flex items-center justify-center" pTooltip="Changed"></div>
+                }
+                <div class="flex items-center gap-2 overflow-hidden">
                   @switch (overallSuiteState(suite)) {
                     @case ('SUCCESS') {
                       <i-tabler name="circle-check" class="text-green-500 flex-shrink-0"></i-tabler>

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, signal } from '@angular/core';
+import { Component, computed, input, signal, viewChild } from '@angular/core';
 import { TableModule } from 'primeng/table';
 import { ProgressSpinnerModule } from 'primeng/progressspinner';
 import { PanelModule } from 'primeng/panel';
@@ -12,10 +12,29 @@ import { CommonModule, DatePipe } from '@angular/common';
 import { TestSuiteDto } from '@app/core/modules/openapi';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getLatestTestResultsByBranchOptions, getLatestTestResultsByPullRequestIdOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { Popover, PopoverModule } from 'primeng/popover';
+import { ButtonModule } from 'primeng/button';
+import { InputTextModule } from 'primeng/inputtext';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-pipeline-test-results',
-  imports: [TableModule, ProgressSpinnerModule, PanelModule, IconsModule, TooltipModule, SkeletonModule, TagModule, PaginatorModule, DatePipe, CommonModule],
+  imports: [
+    TableModule,
+    ProgressSpinnerModule,
+    PanelModule,
+    IconsModule,
+    TooltipModule,
+    SkeletonModule,
+    TagModule,
+    PaginatorModule,
+    DatePipe,
+    CommonModule,
+    PopoverModule,
+    ButtonModule,
+    InputTextModule,
+    FormsModule,
+  ],
   templateUrl: './pipeline-test-results.component.html',
 })
 export class PipelineTestResultsComponent {
@@ -53,6 +72,17 @@ export class PipelineTestResultsComponent {
   resultsQuery = computed(() => {
     return this.branchName() ? this.branchQuery : this.pullRequestQuery;
   });
+  op = viewChild.required<Popover>('op');
+  searchValue = signal<string>('');
+  showOnlyFailed = signal<boolean>(false);
+
+  toggleFilterMenu(event: Event) {
+    this.op().toggle(event);
+  }
+
+  toggleShowOnlyFailed() {
+    this.showOnlyFailed.set(!this.showOnlyFailed());
+  }
 
   testSuites = computed(() => {
     const suites = this.resultsQuery().data()?.testSuites || [];
@@ -72,6 +102,24 @@ export class PipelineTestResultsComponent {
         return 1;
       }
       return 0;
+    });
+  });
+
+  filteredTestSuites = computed(() => {
+    const testSuites = this.testSuites();
+    const searchValue = this.searchValue().toLowerCase();
+    const showOnlyFailed = this.showOnlyFailed();
+
+    return testSuites.filter(suite => {
+      if (showOnlyFailed && suite.failures + suite.errors === 0) {
+        return false;
+      }
+
+      if (searchValue) {
+        return suite.name.toLowerCase().includes(searchValue) || suite.testCases.some(testCase => testCase.name.toLowerCase().includes(searchValue));
+      }
+
+      return true;
     });
   });
 

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -10,8 +10,6 @@ import { TagModule } from 'primeng/tag';
 import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 import { CommonModule, DatePipe } from '@angular/common';
 import { TestSuiteDto } from '@app/core/modules/openapi';
-import { injectQuery } from '@tanstack/angular-query-experimental';
-import { getLatestTestResultsByBranchOptions, getLatestTestResultsByPullRequestIdOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { ButtonModule } from 'primeng/button';
 import { InputTextModule } from 'primeng/inputtext';
@@ -74,6 +72,7 @@ export class PipelineTestResultsComponent {
   resultsQuery = computed(() => {
     return this.branchName() ? this.branchQuery : this.pullRequestQuery;
   });
+
   op = viewChild.required<Popover>('op');
   searchValue = signal<string>('');
   showOnlyFailed = signal<boolean>(false);
@@ -85,33 +84,6 @@ export class PipelineTestResultsComponent {
   toggleShowOnlyFailed() {
     this.showOnlyFailed.set(!this.showOnlyFailed());
   }
-  branchName = computed(() => {
-    const selector = this.selector();
-    if (!selector) return null;
-    return 'branchName' in selector ? selector.branchName : null;
-  });
-
-  pullRequestId = computed(() => {
-    const selector = this.selector();
-    if (!selector) return null;
-    return 'pullRequestId' in selector ? selector.pullRequestId : null;
-  });
-
-  branchQuery = injectQuery(() => ({
-    ...getLatestTestResultsByBranchOptions({ query: { branch: this.branchName()! } }),
-    enabled: this.branchName() !== null,
-    refetchInterval: 15000,
-  }));
-
-  pullRequestQuery = injectQuery(() => ({
-    ...getLatestTestResultsByPullRequestIdOptions({ path: { pullRequestId: this.pullRequestId() || 0 } }),
-    enabled: this.pullRequestId() !== null,
-    refetchInterval: 15000,
-  }));
-
-  resultsQuery = computed(() => {
-    return this.branchName() ? this.branchQuery : this.pullRequestQuery;
-  });
 
   testSuites = computed(() => {
     const suites = this.resultsQuery().data()?.testSuites || [];


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Right now, developers cannot filter specific test cases. Implements #407.


### Description
This PR enhances the test results view by introducing two new features:

- **Filter for Failed Tests:** Users can now toggle a filter to display only failed tests, making it easier to focus on issues.
- **Search Input for Failed Tests:** A search bar has been added to allow users to quickly find specific failed tests by name of the class or method

It also fixes the styling of the results in case the class name of a suite is too long.

### Testing Instructions
Within the test results, set the filter to only include failed tests and/or filter by a suite/class name using the search input.

### Screenshots
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/cfe4d375-f8bc-4098-9e6e-bd68dbe706d1" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

### Todos
I'd still like to unify the logic with the table search component before this is not a draft PR anymore.
