### PR TITLE
chore: set pr title validation to follow conventional commits

### DIFF
--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -17,10 +17,10 @@ jobs:
       pull-requests: write
     steps:
       - name: validate conventional commit message
-        id: lint
-        uses: amannn/action-semantic-pull-request@v5
+        uses:  ytanikin/pr-conventional-commits@8267db1bacc237419f9ed0228bb9d94e94271a1d
         with:
-          subjectPattern: ^[A-Z].+[^. ]$ # subject must start with uppercase letter and may not end with a dot/space
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          add_label: 'false'
         env:
           GITHUB_TOKEN: ${{ github.token }}
       - name: post comment about invalid PR title


### PR DESCRIPTION
Currently it is not allowed to have a lowercase letter after the `:`, but this does not align with the conventional commit spec: https://www.conventionalcommits.org/en/v1.0.0/

I changed the gh action to a better one that has this functionality without setting a custom regex.