### PR TITLE
fix: include Git LFS assets in builds

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          lfs: true
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: FelixTJDietrich/sphinx-action@java
         with:
           docs-folder: "docs/"


### PR DESCRIPTION
### Motivation
Ensures that assets managed by Git LFS are properly included in both documentation and application builds by enabling LFS support in checkout actions.

Fixes #532