### PR TITLE
chore: enable feature preview for keycloak

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -151,7 +151,7 @@ services:
       - postgres
     volumes:
       - ./helios-realm.json:/opt/keycloak/data/import/prod-realm-export.json
-    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true
+    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true --features=preview
     networks:
       - helios-network
 

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -151,7 +151,7 @@ services:
       - postgres
     volumes:
       - ./helios-realm.json:/opt/keycloak/data/import/prod-realm-export.json
-    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true --features=preview
+    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true --features="token-exchange,admin-fine-grained-authz"
     networks:
       - helios-network
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,7 +49,7 @@ services:
       - postgres
     volumes:
       - ./helios-example-realm.json:/opt/keycloak/data/import/dev-realm-export.json
-    command: start-dev --import-realm --http-port=8081
+    command: start-dev --import-realm --http-port=8081 --features=preview
     networks:
       - helios-network
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -49,7 +49,7 @@ services:
       - postgres
     volumes:
       - ./helios-example-realm.json:/opt/keycloak/data/import/dev-realm-export.json
-    command: start-dev --import-realm --http-port=8081 --features=preview
+    command: start-dev --import-realm --http-port=8081 --features="token-exchange,admin-fine-grained-authz"
     networks:
       - helios-network
 


### PR DESCRIPTION
In order to be able to configure the keycloak for user impersonation we have to start the container with the flag `--features="token-exchange,admin-fine-grained-authz"`
