### PR TITLE
feat: Truncate pipeline names + fix wrap in environment list

### DIFF
--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -55,18 +55,18 @@
                 <p-tag
                   severity="secondary"
                   rounded="true"
-                  class="max-w-[350px] flex items-center"
+                  class="max-w-[250px] flex items-center"
                   [pTooltip]="isRelease(deployment) ? '' : 'Go to ' + deployment.ref"
                   tooltipPosition="top"
                   (click)="$event.stopPropagation()"
                   [routerLink]="isRelease(deployment) ? null : getBranchLink(environment)"
                 >
                   @if (isRelease(deployment)) {
-                    <i-tabler name="tag" class="!size-5 mr-0.5 flex-shrink-0"></i-tabler>
+                    <i-tabler name="tag" class="!size-5 flex-shrink-0"></i-tabler>
                   } @else {
-                    <i-tabler name="git-branch" class="!size-5 mr-0.5 flex-shrink-0"></i-tabler>
+                    <i-tabler name="git-branch" class="!size-5 flex-shrink-0"></i-tabler>
                   }
-                  <span class="ml-1 truncate flex-1">{{ deployment.ref }}</span>
+                  <span class="truncate flex-1">{{ deployment.ref }}</span>
                 </p-tag>
                 @if (deployment.pullRequestNumber) {
                   <!-- PR Tag -->
@@ -79,8 +79,8 @@
                     (click)="$event.stopPropagation()"
                     [routerLink]="getPrLink(environment)"
                   >
-                    <i-tabler name="git-pull-request" class="!size-5 mr-0.5 flex-shrink-0"></i-tabler>
-                    <span class="ml-1 truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
+                    <i-tabler name="git-pull-request" class="!size-5 flex-shrink-0"></i-tabler>
+                    <span class="truncate flex-1">#{{ deployment.pullRequestNumber }}</span>
                   </p-tag>
                 }
               </div>

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -1,7 +1,14 @@
 <div class="flex items-center justify-between mb-3">
   <input pInputText id="commit-hash" (input)="onSearch($event)" [value]="searchInput()" type="text" placeholder="Search for installed systems" class="w-1/3" />
   @if (!hideLinkToList()) {
-    <p-button [routerLink]="'../../../environment'" class="self-end">{{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }} </p-button>
+    <p-button [routerLink]="'../../../environment'" class="self-end"
+      >{{
+        isAdmin()
+          ? 'Manage Environments'
+          : 'Go to
+    Environments'
+      }}
+    </p-button>
   }
 </div>
 
@@ -17,7 +24,7 @@
   @for (environment of filteredEnvironments(); track environment.id) {
     <p-accordion-panel [value]="environment.id">
       <p-accordion-header>
-        <div class="flex gap-2 items-center w-full flex-wrap">
+        <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
           <div class="flex flex-col gap-1 flex-wrap">
             <div class="flex gap-1 items-center mr-3">
               <span [pTooltip]="'Open Environment'" class="cursor-pointer hover:bg-gray-200 px-2 py-1 rounded" (click)="openExternalLink($event, environment)">
@@ -83,93 +90,95 @@
           <div class="flex-grow"></div>
 
           <!-- TODO: Refactor button rendering -->
-
-          @if (environment.locked) {
-            <div class="flex gap-1 items-center">
-              <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
-            </div>
-            @if (environment.lockedAt) {
-              <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
-            }
-          }
-          <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
-            @if (deployable()) {
-              <p-button
-                outlined
-                (click)="deployEnvironment(environment); $event.stopPropagation()"
-                [disabled]="!canUserDeploy(environment)"
-                [pTooltip]="getDeployTooltip(environment)"
-                tooltipPosition="top"
-              >
-                <div class="flex items-center">
-                  <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
-                  <span>Deploy</span>
-                </div>
-              </p-button>
-              <div class="w-px bg-gray-300 self-stretch"></div>
+          <div class="flex gap-2 items-center self-end md:self-center">
+            @if (environment.locked) {
+              <div class="flex gap-1 items-center">
+                <app-user-avatar [user]="environment.lockedBy" [toolTipText]="'Locked By'" tooltipPosition="top" />
+              </div>
+              @if (environment.lockedAt) {
+                <app-lock-time [timeLockWillExpire]="environment.lockWillExpireAt"></app-lock-time>
+              }
             }
 
-            @if (environment.enabled) {
-              <p-buttongroup>
-                @if (!environment.locked) {
-                  @if (deployable()) {
-                    <p-button
-                      outlined
-                      (click)="lockEnvironment(environment); $event.stopPropagation()"
-                      [disabled]="!canUserDeploy(environment)"
-                      [pTooltip]="getLockTooltip(environment)"
-                      tooltipPosition="top"
-                    >
-                      <div class="flex items-center">
-                        <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
-                      </div>
-                    </p-button>
-                  }
-                } @else {
-                  @if (isLoggedIn() && (environment.lockReservationWillExpireAt !== null || isCurrentUserLocked(environment) || hasUnlockPermissions())) {
-                    <p-button
-                      severity="danger"
-                      class="[&>*]:!rounded-none"
-                      (click)="onUnlockEnvironment($event, environment)"
-                      [disabled]="!canUnlock(environment)"
-                      [pTooltip]="getUnlockToolTip(environment)"
-                      tooltipPosition="top"
-                    >
-                      <div class="flex items-center">
-                        <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
-                      </div>
-                    </p-button>
-                    @if (isCurrentUserLocked(environment)) {
+            <div class="flex items-center border border-gray-300 rounded-md overflow-hidden">
+              @if (deployable()) {
+                <p-button
+                  outlined
+                  (click)="deployEnvironment(environment); $event.stopPropagation()"
+                  [disabled]="!canUserDeploy(environment)"
+                  [pTooltip]="getDeployTooltip(environment)"
+                  tooltipPosition="top"
+                >
+                  <div class="flex items-center">
+                    <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0 text-primary-700" />
+                    <span>Deploy</span>
+                  </div>
+                </p-button>
+                <div class="w-px bg-gray-300 self-stretch"></div>
+              }
+
+              @if (environment.enabled) {
+                <p-buttongroup>
+                  @if (!environment.locked) {
+                    @if (deployable()) {
                       <p-button
                         outlined
-                        (click)="extendLock($event, environment)"
-                        [disabled]="!canUnlock(environment)"
-                        [pTooltip]="'Extend my lock expiration'"
+                        (click)="lockEnvironment(environment); $event.stopPropagation()"
+                        [disabled]="!canUserDeploy(environment)"
+                        [pTooltip]="getLockTooltip(environment)"
                         tooltipPosition="top"
                       >
-                        <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
+                        <div class="flex items-center">
+                          <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-700" />
+                        </div>
                       </p-button>
                     }
+                  } @else {
+                    @if (isLoggedIn() && (environment.lockReservationWillExpireAt !== null || isCurrentUserLocked(environment) || hasUnlockPermissions())) {
+                      <p-button
+                        severity="danger"
+                        class="[&>*]:!rounded-none"
+                        (click)="onUnlockEnvironment($event, environment)"
+                        [disabled]="!canUnlock(environment)"
+                        [pTooltip]="getUnlockToolTip(environment)"
+                        tooltipPosition="top"
+                      >
+                        <div class="flex items-center">
+                          <i-tabler name="lock-open" class="w-4 h-4 flex-shrink-0 text-white" />
+                        </div>
+                      </p-button>
+                      @if (isCurrentUserLocked(environment)) {
+                        <p-button
+                          outlined
+                          (click)="extendLock($event, environment)"
+                          [disabled]="!canUnlock(environment)"
+                          [pTooltip]="'Extend my lock expiration'"
+                          tooltipPosition="top"
+                        >
+                          <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0 text-green-700" />
+                        </p-button>
+                      }
+                    }
                   }
-                }
-              </p-buttongroup>
+                </p-buttongroup>
+              }
+            </div>
+            @if (canViewAllEnvironments()) {
+              <!-- Show the disabled tag -->
+              @if (!environment.enabled) {
+                <p-tag value="Disabled" severity="danger" rounded="true" />
+              }
+              <a
+                icon
+                [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
+                class="p-button p-button-secondary p-2"
+                (click)="$event.stopPropagation()"
+              >
+                <i-tabler name="pencil" />
+              </a>
             }
+            <span class="w-2"></span>
           </div>
-          @if (canViewAllEnvironments()) {
-            <!-- Show the disabled tag -->
-            @if (!environment.enabled) {
-              <p-tag value="Disabled" severity="danger" rounded="true" />
-            }
-            <a
-              icon
-              [routerLink]="'/repo/' + environment.repository?.id + '/environment/' + environment.id + '/edit'"
-              class="p-button p-button-secondary p-2"
-              (click)="$event.stopPropagation()"
-            >
-              <i-tabler name="pencil" />
-            </a>
-          }
-          <span class="w-2"></span>
         </div>
       </p-accordion-header>
       <p-accordion-content>

--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -60,8 +60,8 @@
                       }
                     </div>
                     <!-- Fixed width to ensure consistent alignment -->
-                    <span class="font-medium flex items-center justify-between w-full">
-                      <span [pTooltip]="workflowRun.name">{{ workflowRun.name }}</span>
+                    <span class="font-medium flex items-center justify-between w-full overflow-hidden">
+                      <span [pTooltip]="workflowRun.name" class="truncate">{{ workflowRun.name }}</span>
                       <a class="ml-1" [href]="workflowRun.htmlUrl" target="_new"><i-tabler name="external-link" class="w-20 h-20"></i-tabler></a>
                     </span>
                   </div>


### PR DESCRIPTION
### Motivation
The pipeline currently can look a bit crowded when the job names are long. Additionally, the deployment actions in the environment list is wrapped weirdly when there is a lot of info.

### Description
- Truncate the names to only a single line and show the full name on hover in the pipeline
- Group the deployment actions in a single div so it stays together and disable wrap for big screens

### Testing Instructions
Open a pipeline with a long enough job name and check the environment list with small and large screen sizes.

### Screenshots

**Pipeline:**
<img width="293" alt="Screenshot 2025-03-18 at 17 01 50" src="https://github.com/user-attachments/assets/652fcfae-e98c-47ce-90b8-be516f194bf4" />
<img width="717" alt="image" src="https://github.com/user-attachments/assets/b0f35586-d674-4004-9d24-b7503de4051a" />

**Environment list:**
Before:
<img width="871" alt="image" src="https://github.com/user-attachments/assets/9710005b-e594-4f81-9476-87da75112a91" />

After:
<img width="878" alt="image" src="https://github.com/user-attachments/assets/a3282df1-110e-40a8-8feb-f9209a16cfca" />


### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.