### PR TITLE
fix: Release candidates sorting order

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoService.java
@@ -63,7 +63,7 @@ public class ReleaseInfoService {
   private final GitHubReleaseSyncService gitHubReleaseSyncService;
 
   public List<ReleaseInfoListDto> getAllReleaseInfos() {
-    return releaseCandidateRepository.findAllByOrderByNameAsc().stream()
+    return releaseCandidateRepository.findAllByOrderByCreatedAtDesc().stream()
         .map(ReleaseInfoListDto::fromReleaseCandidate)
         .toList();
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/releasecandidate/ReleaseCandidateRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/releasecandidate/ReleaseCandidateRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReleaseCandidateRepository
     extends JpaRepository<ReleaseCandidate, ReleaseCandidateId> {
-  List<ReleaseCandidate> findAllByOrderByNameAsc();
+  List<ReleaseCandidate> findAllByOrderByCreatedAtDesc();
 
   List<ReleaseCandidate> findByRepository(GitRepository repository);
 


### PR DESCRIPTION
release candidates were sorted by name in asc order which were showing the latest release last. Changed it to sort by createdAt date in desc order