### PR TITLE
fix: Add real db pagination for test results

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,5 @@
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "always"
-  },
-  "java.compile.nullAnalysis.mode": "disabled",
+  }
 }

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -80,7 +80,7 @@
             <i-tabler name="filter-plus" />
           }
         </p-button>
-        <input pInputText [(ngModel)]="searchValue" type="text" pSize="small" placeholder="Search" class="w-full" />
+        <input pInputText [ngModel]="searchValue()" (ngModelChange)="onSearchChange($event)" type="text" pSize="small" placeholder="Search" class="w-full" />
       </div>
 
       <!-- Workflow Stats Summary -->
@@ -109,7 +109,7 @@
         </div>
       </p-popover>
 
-      @if (filteredTestSuites(); as testSuites) {
+      @if (testSuites(); as testSuites) {
         @if (testSuites.length === 0) {
           <!-- No Results State -->
           <div class="flex flex-col items-center p-4 border rounded-lg">
@@ -118,7 +118,7 @@
         } @else {
           <!-- Test Results -->
           <div class="flex flex-col gap-4">
-            @for (suite of testSuites.slice(testSuiteFirst(), testSuiteFirst() + testSuiteRows()); track suite.id) {
+            @for (suite of testSuites; track suite.id) {
               @defer {
                 <p-panel [toggleable]="true" [collapsed]="true" [styleClass]="suiteHasUpdates(suite) ? 'border-blue-400 border-2 relative' : ''">
                   <ng-template pTemplate="header">
@@ -226,7 +226,7 @@
             (onPageChange)="onPageChange($event)"
             [first]="testSuiteFirst()"
             [rows]="testSuiteRows()"
-            [totalRecords]="filteredTestSuites().length || 0"
+            [totalRecords]="activeTestTypeStats()?.total || 0"
             [rowsPerPageOptions]="[10, 20, 30]"
           />
         }
@@ -256,7 +256,7 @@
         <div>
           <h4 class="font-medium mb-2">Stack Trace</h4>
           <div class="bg-gray-50 p-4 rounded overflow-auto max-h-[400px]">
-            <pre class="font-mono text-sm">{{ selectedTestCase()?.stackTrace }}</pre>
+            <pre class="font-mono text-sm">{{ selectedTestCase()?.stackTrace?.trimStart() }}</pre>
           </div>
         </div>
       }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/branch/BranchRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/branch/BranchRepository.java
@@ -16,4 +16,6 @@ public interface BranchRepository extends JpaRepository<Branch, BranchId> {
   List<Branch> findByRepositoryRepositoryId(Long repositoryId);
 
   Optional<Branch> findByRepositoryRepositoryIdAndName(Long repositoryId, String name);
+
+  Optional<Branch> findFirstByRepositoryRepositoryIdAndIsDefaultTrue(Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
@@ -77,6 +77,12 @@ public class TestCase {
   /** Transient field indicating whether this test also fails in the default branch. */
   @Transient private boolean failsInDefaultBranch;
 
+  /**
+   * Transient field indicating the previous status of this test case. Used for change detection
+   * purposes.
+   */
+  @Transient TestStatus previousStatus;
+
   public static enum TestStatus {
     PASSED,
     FAILED,

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseRepository.java
@@ -1,7 +1,34 @@
 package de.tum.cit.aet.helios.tests;
 
+import java.util.Collection;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TestCaseRepository extends JpaRepository<TestCase, Long> {}
+public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
+  @Query(
+      "SELECT tc FROM TestCase tc "
+          + "JOIN tc.testSuite ts "
+          + "WHERE ts.workflowRun.id = :workflowRunId "
+          + "AND ts.name IN :classNames "
+          + "AND ts.testType.id = :testTypeId")
+  List<TestCase> findByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
+      @Param("workflowRunId") Long workflowId,
+      @Param("classNames") Collection<String> classNames,
+      @Param("testTypeId") Long testTypeId);
+
+  @Query(
+      "SELECT tc FROM TestCase tc "
+          + "JOIN tc.testSuite ts "
+          + "WHERE ts.workflowRun.id = :workflowRunId "
+          + "AND ts.name IN :classNames "
+          + "AND ts.testType.id = :testTypeId "
+          + "AND (tc.status = 'FAILED' OR tc.status = 'ERROR')")
+  List<TestCase> findFailedByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
+      @Param("workflowRunId") Long workflowId,
+      @Param("classNames") Collection<String> classNames,
+      @Param("testTypeId") Long testTypeId);
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.tests;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -60,4 +61,16 @@ public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStat
    * @return list of flaky or non-flaky test statistics
    */
   List<TestCaseStatistics> findByBranchNameAndIsFlaky(String branchName, boolean isFlaky);
+
+  /**
+   * Find all statistics for test cases that belong to specific test suites on a branch in a
+   * repository.
+   *
+   * @param testSuiteNames collection of test suite names to search for
+   * @param branchName the branch name
+   * @param repositoryId the repository ID
+   * @return list of statistics for matching test cases
+   */
+  List<TestCaseStatistics> findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+      Collection<String> testSuiteNames, String branchName, Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
@@ -29,7 +29,9 @@ public class TestResultController {
       @RequestParam(required = false) String search,
       @RequestParam(defaultValue = "false") boolean onlyFailed) {
     return ResponseEntity.ok(
-        testResultService.getLatestTestResultsForPr(pullRequestId, page, size, search, onlyFailed));
+        testResultService.getLatestTestResultsForPr(
+            pullRequestId,
+            new TestResultService.TestSearchCriteria(page, size, search, onlyFailed)));
   }
 
   /**
@@ -47,6 +49,7 @@ public class TestResultController {
       @RequestParam(required = false) String search,
       @RequestParam(defaultValue = "false") boolean onlyFailed) {
     return ResponseEntity.ok(
-        testResultService.getLatestTestResultsForBranch(branch, page, size, search, onlyFailed));
+        testResultService.getLatestTestResultsForBranch(
+            branch, new TestResultService.TestSearchCriteria(page, size, search, onlyFailed)));
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -1,37 +1,47 @@
 package de.tum.cit.aet.helios.tests;
 
-import de.tum.cit.aet.helios.branch.Branch;
 import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
-import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.tests.TestCase.TestStatus;
+import de.tum.cit.aet.helios.tests.TestResultsDto.TestCaseDto;
+import de.tum.cit.aet.helios.tests.TestResultsDto.TestCaseStatisticsInfo;
 import de.tum.cit.aet.helios.tests.TestResultsDto.TestTypeResults;
 import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Log4j2
 public class TestResultService {
   private final WorkflowRunRepository workflowRunRepository;
   private final BranchRepository branchRepository;
   private final PullRequestRepository pullRequestRepository;
-  private final TestCaseStatisticsService statisticsService;
-  private final GitRepoRepository gitRepoRepository;
+  private final TestSuiteRepository testSuiteRepository;
+  private final TestCaseRepository testCaseRepository;
+  private final TestCaseStatisticsRepository testCaseStatisticsRepository;
 
-  private List<TestSuite> getTestSuitesForWorkflowRuns(List<WorkflowRun> runs) {
-    return runs.stream().flatMap(run -> run.getTestSuites().stream()).toList();
-  }
+  public static record TestSearchCriteria(int page, int size, String search, boolean onlyFailed) {}
+
+  private record TestRunContext(
+      List<WorkflowRun> latestRuns,
+      List<WorkflowRun> previousRuns,
+      String defaultBranchName,
+      Map<TestType, Long> defaultWorkflowRunByTestType) {}
 
   /**
    * Sort test cases with the following priority: 1. Test cases with updated status 2. Failed or
@@ -41,15 +51,14 @@ public class TestResultService {
    * @param previousStatusProvider function to get previous status
    * @return sorted list of test cases
    */
-  private List<TestCase> sortTestCases(
-      List<TestCase> testCases, Function<TestCase, Optional<TestStatus>> previousStatusProvider) {
+  private List<TestCase> sortTestCases(List<TestCase> testCases) {
 
     return testCases.stream()
         .sorted(
             (a, b) -> {
               // Get previous statuses
-              Optional<TestStatus> prevStatusA = previousStatusProvider.apply(a);
-              Optional<TestStatus> prevStatusB = previousStatusProvider.apply(b);
+              Optional<TestStatus> prevStatusA = Optional.ofNullable(a.getPreviousStatus());
+              Optional<TestStatus> prevStatusB = Optional.ofNullable(b.getPreviousStatus());
 
               // Check for status changes
               boolean statusChangedA =
@@ -109,52 +118,26 @@ public class TestResultService {
         .collect(Collectors.toList());
   }
 
-  /**
-   * Sort test suites with the following priority: 1. Test suites with updates 2. Test suites with
-   * failures or errors 3. Alphabetical order by name for stable sorting
-   */
-  private List<TestSuite> sortTestSuites(
-      List<TestSuite> testSuites, Function<TestCase, Optional<TestStatus>> previousStatusProvider) {
+  private TestRunContext getDefaultBranchContext(GitRepository repository) {
+    var defaultBranch =
+        branchRepository
+            .findFirstByRepositoryRepositoryIdAndIsDefaultTrue(repository.getRepositoryId())
+            .orElseThrow();
 
-    return testSuites.stream()
-        .sorted(
-            (a, b) -> {
-              // 1. First priority: Has updates
-              boolean hasUpdatesA = hasTestSuiteUpdates(a, previousStatusProvider);
-              boolean hasUpdatesB = hasTestSuiteUpdates(b, previousStatusProvider);
+    var defaultRuns =
+        workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
+            defaultBranch.getName(), defaultBranch.getCommitSha(), repository.getRepositoryId());
 
-              if (hasUpdatesA && !hasUpdatesB) {
-                return -1;
-              }
-              if (!hasUpdatesA && hasUpdatesB) {
-                return 1;
-              }
+    Map<TestType, Long> defaultWorkflowRunByTestType =
+        defaultRuns.stream()
+            .flatMap(
+                run ->
+                    run.getWorkflow().getTestTypes().stream()
+                        .map(type -> Map.entry(type, run.getId())))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
-              // 2. Second priority: Has failures or errors
-              boolean hasFailuresA = a.getFailures() > 0 || a.getErrors() > 0;
-              boolean hasFailuresB = b.getFailures() > 0 || b.getErrors() > 0;
-
-              if (hasFailuresA && !hasFailuresB) {
-                return -1;
-              }
-              if (!hasFailuresA && hasFailuresB) {
-                return 1;
-              }
-
-              // 3. Third priority: Alphabetical by name for stable sorting
-              return a.getName().compareTo(b.getName());
-            })
-        .collect(Collectors.toList());
-  }
-
-  private boolean hasTestSuiteUpdates(
-      TestSuite suite, Function<TestCase, Optional<TestStatus>> previousStatusProvider) {
-    return suite.getTestCases().stream()
-        .anyMatch(
-            testCase -> {
-              Optional<TestStatus> previousStatus = previousStatusProvider.apply(testCase);
-              return previousStatus.isPresent() && testCase.getStatus() != previousStatus.get();
-            });
+    return new TestRunContext(
+        defaultRuns, List.of(), defaultBranch.getName(), defaultWorkflowRunByTestType);
   }
 
   /**
@@ -165,28 +148,38 @@ public class TestResultService {
    * @return the grouped test results
    */
   public TestResultsDto getLatestTestResultsForBranch(
-      String branchName, int page, int size, String search, boolean onlyFailed) {
+      String branchName, TestSearchCriteria criteria) {
     final Long repositoryId = RepositoryContext.getRepositoryId();
 
     var branch =
         branchRepository
             .findByNameAndRepositoryRepositoryId(branchName, repositoryId)
             .orElseThrow();
-    var latestTestRuns =
-        workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryIdWithTestSuites(
+
+    var defaultContext = getDefaultBranchContext(branch.getRepository());
+
+    var latestRuns =
+        workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
             branchName, branch.getCommitSha(), repositoryId);
+
     var previousCommitSha =
         workflowRunRepository.findNthLatestCommitShaBehindHeadByBranchAndRepoId(
             branchName, repositoryId, 0, branch.getCommitSha());
 
-    List<WorkflowRun> previousTestRuns =
+    List<WorkflowRun> previousRuns =
         previousCommitSha.isEmpty()
             ? List.of()
-            : workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryIdWithTestSuites(
+            : workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
                 branchName, previousCommitSha.get(), repositoryId);
 
-    return this.getResultsFromRuns(
-        latestTestRuns, previousTestRuns, page, size, search, onlyFailed);
+    var context =
+        new TestRunContext(
+            latestRuns,
+            previousRuns,
+            defaultContext.defaultBranchName(),
+            defaultContext.defaultWorkflowRunByTestType());
+
+    return processTestResults(context, criteria);
   }
 
   /**
@@ -196,168 +189,120 @@ public class TestResultService {
    * @param pullRequestId the pull request ID
    * @return the grouped test results
    */
-  public TestResultsDto getLatestTestResultsForPr(
-      Long pullRequestId, int page, int size, String search, boolean onlyFailed) {
+  public TestResultsDto getLatestTestResultsForPr(Long pullRequestId, TestSearchCriteria criteria) {
     var pullRequest = pullRequestRepository.findById(pullRequestId).orElseThrow();
+    var defaultContext = getDefaultBranchContext(pullRequest.getRepository());
 
-    var latestTestRuns =
-        workflowRunRepository.findByPullRequestsIdAndHeadShaWithTestSuites(
+    var latestRuns =
+        workflowRunRepository.findByPullRequestsIdAndHeadSha(
             pullRequestId, pullRequest.getHeadSha());
 
     var previousCommitSha =
         workflowRunRepository.findNthLatestCommitShaBehindHeadByPullRequestId(
             pullRequestId, 0, pullRequest.getHeadSha());
 
-    List<WorkflowRun> previousTestRuns =
+    List<WorkflowRun> previousRuns =
         previousCommitSha.isEmpty()
             ? List.of()
-            : workflowRunRepository.findByPullRequestsIdAndHeadShaWithTestSuites(
+            : workflowRunRepository.findByPullRequestsIdAndHeadSha(
                 pullRequestId, previousCommitSha.get());
 
-    return this.getResultsFromRuns(
-        latestTestRuns, previousTestRuns, page, size, search, onlyFailed);
+    var context =
+        new TestRunContext(
+            latestRuns,
+            previousRuns,
+            defaultContext.defaultBranchName(),
+            defaultContext.defaultWorkflowRunByTestType());
+
+    return processTestResults(context, criteria);
   }
 
-  /**
-   * Filter test suites based on search criteria and failed tests flag. Returns only test suites
-   * that have matching test cases.
-   */
-  private List<TestResultsDto.TestSuiteDto> filterAndTransformTestSuites(
-      List<TestSuite> suites,
-      Function<TestCase, Optional<TestStatus>> previousStatusProvider,
-      Function<TestCase, TestResultsDto.TestCaseStatisticsInfo> statisticsProvider,
-      String search,
-      boolean onlyFailed) {
+  private TestResultsDto processTestResults(TestRunContext context, TestSearchCriteria criteria) {
+    Map<TestType, Long> previousWorkflowRunByTestType = new HashMap<>();
 
-    // First sort the test suites
-    List<TestSuite> sortedSuites = sortTestSuites(suites, previousStatusProvider);
+    for (WorkflowRun run : context.previousRuns()) {
+      for (TestType type : run.getWorkflow().getTestTypes()) {
+        previousWorkflowRunByTestType.put(type, run.getId());
+      }
+    }
 
-    return sortedSuites.stream()
-        .map(
-            suite -> {
-              // First sort the test cases
-              List<TestCase> sortedTestCases =
-                  sortTestCases(suite.getTestCases(), previousStatusProvider);
+    List<TestTypeResults> results = new LinkedList<>();
 
-              // Then filter the test cases based on search and onlyFailed criteria
-              List<TestCase> filteredTestCases =
-                  sortedTestCases.stream()
-                      .filter(testCase -> matchesFilterCriteria(testCase, search, onlyFailed))
-                      .collect(Collectors.toList());
+    for (WorkflowRun run : context.latestRuns()) {
+      for (TestType type : run.getWorkflow().getTestTypes()) {
+        var testTypeResults =
+            getTestTypeResultsForRun(
+                type,
+                run,
+                previousWorkflowRunByTestType.get(type),
+                PageRequest.of(criteria.page(), criteria.size()),
+                context.defaultBranchName(),
+                context.defaultWorkflowRunByTestType().get(type),
+                criteria.search(),
+                criteria.onlyFailed());
+        results.add(testTypeResults);
+      }
+    }
 
-              // Only create suite DTO if it has matching test cases
-              if (filteredTestCases.isEmpty()) {
-                return null;
+    var anyProcessing = results.stream().anyMatch(TestTypeResults::isProcessing);
+    return new TestResultsDto(results, anyProcessing);
+  }
+
+  private List<TestCase> filterTestCases(
+      List<TestCase> testCases, String search, boolean onlyFailed) {
+    return testCases.stream()
+        .filter(
+            testCase -> {
+              // Filter by failed status if onlyFailed is true
+              if (onlyFailed) {
+                if (testCase.getStatus() != TestStatus.FAILED
+                    && testCase.getStatus() != TestStatus.ERROR) {
+                  return false;
+                }
               }
 
-              // Create new suite with filtered test cases
-              suite.setTestCases(filteredTestCases);
-              return TestResultsDto.TestSuiteDto.fromTestSuite(
-                  suite, previousStatusProvider, statisticsProvider);
+              // Filter by search term if search is not null or empty
+              if (search != null && !search.trim().isEmpty()) {
+                String searchLower = search.toLowerCase();
+                return testCase.getName().toLowerCase().contains(searchLower)
+                    || testCase.getClassName().toLowerCase().contains(searchLower);
+              }
+
+              return true;
             })
-        .filter(suiteDto -> suiteDto != null) // Remove empty suites
         .collect(Collectors.toList());
   }
 
-  private boolean matchesFilterCriteria(TestCase testCase, String search, boolean onlyFailed) {
-    boolean matchesSearch =
-        search == null
-            || search.isEmpty()
-            || testCase.getName().toLowerCase().contains(search.toLowerCase())
-            || testCase.getClassName().toLowerCase().contains(search.toLowerCase());
-
-    boolean matchesFailedFilter =
-        !onlyFailed
-            || testCase.getStatus() == TestStatus.FAILED
-            || testCase.getStatus() == TestStatus.ERROR;
-
-    return matchesSearch && matchesFailedFilter;
-  }
-
-  private List<TestResultsDto.TestSuiteDto> paginateTestSuites(
-      List<TestResultsDto.TestSuiteDto> suites, int page, int size) {
-    int start = page * size;
-    int end = Math.min(start + size, suites.size());
-
-    return start < suites.size() ? suites.subList(start, end) : List.of();
-  }
-
-  /**
-   * Create a TestResultsDto from the given workflow runs. Test suites are grouped by test type.
-   *
-   * @param latestWorkflowRuns the latest workflow runs
-   * @param previousWorkflowRuns the previous workflow runs for comparison
-   * @return the grouped test results
-   */
-  private TestResultsDto getResultsFromRuns(
-      List<WorkflowRun> latestWorkflowRuns,
-      List<WorkflowRun> previousWorkflowRuns,
-      int page,
-      int size,
+  private TestTypeResults getTestTypeResultsForRun(
+      TestType type,
+      WorkflowRun run,
+      Long prevWorkflowRunId,
+      Pageable pageable,
+      String defaultBranch,
+      Long defaultWorkflowRunId,
       String search,
       boolean onlyFailed) {
 
-    var latestTestRuns =
-        latestWorkflowRuns.stream()
-            .filter(run -> run.getWorkflow().getTestTypes().size() > 0)
-            .toList();
+    var suites =
+        testSuiteRepository.findByWorkflowRunIdAndTestTypeId(
+            run.getId(), type.getId(), prevWorkflowRunId, search, onlyFailed, pageable);
 
-    var previousTestRuns =
-        previousWorkflowRuns.stream()
-            .filter(run -> run.getWorkflow().getTestTypes().size() > 0)
-            .toList();
+    var summary =
+        testSuiteRepository.findSummaryByWorkflowRunIdAndTestTypeId(
+            run.getId(), type.getId(), prevWorkflowRunId);
 
-    var testSuites = getTestSuitesForWorkflowRuns(latestTestRuns);
+    var suiteClassNames = suites.stream().map(TestSuite::getName).distinct().toList();
 
-    var previousTestCases =
-        getTestSuitesForWorkflowRuns(previousTestRuns).stream()
-            .flatMap(testSuite -> testSuite.getTestCases().stream())
-            .toList();
+    var failedTestsInDefault =
+        testCaseRepository.findFailedByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
+            defaultWorkflowRunId, suiteClassNames, type.getId());
 
-    boolean isProcessing =
-        latestTestRuns.stream()
-            .anyMatch(
-                run ->
-                    run.getTestProcessingStatus() == WorkflowRun.TestProcessingStatus.PROCESSING);
-
-    Function<TestCase, Optional<TestStatus>> previousStatusProvider =
-        (testCase) -> {
-          return previousTestCases.stream()
-              .filter(
-                  previousTestCase ->
-                      previousTestCase.getName().equals(testCase.getName())
-                          && previousTestCase.getClassName().equals(testCase.getClassName()))
-              .findFirst()
-              .map(TestCase::getStatus);
-        };
-
-    Map<TestType, List<TestSuite>> groupedByTestType =
-        testSuites.stream()
-            .filter(suite -> suite.getTestType() != null)
-            .collect(Collectors.groupingBy(TestSuite::getTestType));
-
-    // Get repository ID from context
-    final Long repositoryId = RepositoryContext.getRepositoryId();
-
-    // Get repository by ID
-    Optional<GitRepository> repositoryOpt = gitRepoRepository.findById(repositoryId);
-    GitRepository repository = repositoryOpt.orElse(null);
-
-    // Get statistics for the default branch if repository is available
     List<TestCaseStatistics> defaultBranchStats =
-        repository != null
-            ? statisticsService.getStatisticsForDefaultBranch(repository)
-            : List.of();
+        testCaseStatisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            suiteClassNames, defaultBranch, RepositoryContext.getRepositoryId());
 
-    // Create a function to check if a test case with similar name exists in the default branch test
-    // runs
-    // and if it fails in the default branch
-    Map<String, Boolean> defaultBranchFailures = getLatestDefaultBranchResults(repository);
-
-    // Create statistics provider function
     Function<TestCase, TestResultsDto.TestCaseStatisticsInfo> statisticsProvider =
         testCase -> {
-          // Check if test is flaky from statistics
           Optional<TestCaseStatistics> stats =
               defaultBranchStats.stream()
                   .filter(
@@ -369,126 +314,65 @@ public class TestResultService {
           boolean isFlaky = stats.map(TestCaseStatistics::isFlaky).orElse(false);
           double failureRate = stats.map(TestCaseStatistics::getFailureRate).orElse(0.0);
 
-          // Check if test fails in default branch latest run
-          String key = testCase.getClassName() + "." + testCase.getName();
-          boolean failsInDefaultBranch = defaultBranchFailures.getOrDefault(key, false);
+          boolean failsInDefaultBranch =
+              failedTestsInDefault.stream()
+                  .anyMatch(
+                      failedTest ->
+                          failedTest.getName().equals(testCase.getName())
+                              && failedTest.getClassName().equals(testCase.getClassName()));
 
           return new TestResultsDto.TestCaseStatisticsInfo(
               isFlaky, failureRate, failsInDefaultBranch);
         };
 
-    List<TestTypeResults> testResults =
-        groupedByTestType.entrySet().stream()
-            .map(
-                entry -> {
-                  TestType testType = entry.getKey();
-                  List<TestSuite> suites = entry.getValue();
+    var prevStateCandidates =
+        testCaseRepository.findByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
+            prevWorkflowRunId, suiteClassNames, type.getId());
 
-                  // Calculate stats for this test type
-                  int totalTests = 0;
-                  int totalFailures = 0;
-                  int totalErrors = 0;
-                  int totalSkipped = 0;
-                  double totalTime = 0;
-                  int totalUpdates = 0;
-
-                  for (TestSuite suite : suites) {
-                    totalTests += suite.getTests();
-                    totalFailures += suite.getFailures();
-                    totalErrors += suite.getErrors();
-                    totalSkipped += suite.getSkipped();
-                    totalTime += suite.getTime();
-                    totalUpdates +=
-                        suite.getTestCases().stream()
-                            .filter(
-                                testCase -> {
-                                  Optional<TestStatus> previousStatus =
-                                      previousStatusProvider.apply(testCase);
-                                  return previousStatus.isPresent()
-                                      && testCase.getStatus() != previousStatus.get();
-                                })
-                            .count();
-                  }
-
-                  // Convert suites to DTOs with pagination
-                  List<TestResultsDto.TestSuiteDto> filteredSuiteDtos =
-                      filterAndTransformTestSuites(
-                          suites, previousStatusProvider, statisticsProvider, search, onlyFailed);
-
-                  // Disable pagination for now
-                  //   List<TestResultsDto.TestSuiteDto> paginatedSuites =
-                  //       paginateTestSuites(filteredSuiteDtos, page, size);
-
-                  // Check if this test type has any runs still processing
-                  boolean testTypeProcessing =
-                      latestTestRuns.stream()
-                          .filter(
-                              run ->
-                                  run.getTestSuites().stream()
-                                      .anyMatch(suite -> testType.equals(suite.getTestType())))
-                          .anyMatch(
-                              run ->
-                                  run.getTestProcessingStatus()
-                                      == WorkflowRun.TestProcessingStatus.PROCESSING);
-
-                  return new TestTypeResults(
-                      testType.getId(),
-                      testType.getName(),
-                      filteredSuiteDtos,
-                      testTypeProcessing,
-                      new TestResultsDto.TestTypeStats(
-                          suites.size(),
-                          totalTests,
-                          totalTests - (totalFailures + totalErrors),
-                          totalFailures,
-                          totalErrors,
-                          totalSkipped,
-                          totalTime,
-                          totalUpdates));
-                })
-            .collect(Collectors.toList());
-
-    return new TestResultsDto(testResults, isProcessing);
-  }
-
-  /**
-   * Gets the latest test results from the default branch of a repository.
-   *
-   * @param repository the repository
-   * @return map of test case keys to failure status
-   */
-  private Map<String, Boolean> getLatestDefaultBranchResults(GitRepository repository) {
-    if (repository == null) {
-      return Map.of();
-    }
-    // Get default branch name
-    String defaultBranchName = repository.getDefaultBranch();
-    // Find the default branch
-    Optional<Branch> defaultBranch =
-        branchRepository.findAll().stream()
-            .filter(branch -> branch.getRepository().equals(repository) && branch.isDefault())
-            .findFirst();
-    if (defaultBranch.isEmpty()) {
-      return Map.of();
-    }
-    // Get the latest workflow runs with test suites from the default branch
-    List<WorkflowRun> defaultBranchRuns =
-        workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryIdWithTestSuites(
-            defaultBranchName, defaultBranch.get().getCommitSha(), repository.getRepositoryId());
-
-    // Collect test cases and their status
-    Map<String, Boolean> defaultBranchFailures = new HashMap<>();
-    List<TestSuite> defaultBranchTestSuites = getTestSuitesForWorkflowRuns(defaultBranchRuns);
-
-    for (TestSuite suite : defaultBranchTestSuites) {
+    for (TestSuite suite : suites) {
       for (TestCase testCase : suite.getTestCases()) {
-        String key = testCase.getClassName() + "." + testCase.getName();
-        boolean isFailed =
-            testCase.getStatus() == TestStatus.FAILED || testCase.getStatus() == TestStatus.ERROR;
-        defaultBranchFailures.put(key, isFailed);
+        TestCaseStatisticsInfo statistics = statisticsProvider.apply(testCase);
+        testCase.setFlaky(statistics.isFlaky());
+        testCase.setFailsInDefaultBranch(statistics.failsInDefaultBranch());
+        testCase.setFailureRate(statistics.failureRate());
+        testCase.setPreviousStatus(
+            prevStateCandidates.stream()
+                .filter(
+                    prevTestCase ->
+                        prevTestCase.getName().equals(testCase.getName())
+                            && prevTestCase.getClassName().equals(testCase.getClassName()))
+                .findFirst()
+                .map(TestCase::getStatus)
+                .orElse(null));
       }
     }
 
-    return defaultBranchFailures;
+    var suiteDtos =
+        suites.stream()
+            .map(
+                suite -> {
+                  var filteredTestCases = filterTestCases(suite.getTestCases(), search, onlyFailed);
+                  var testCases = sortTestCases(filteredTestCases);
+                  var testCaseDtos = testCases.stream().map(TestCaseDto::fromTestCase).toList();
+
+                  return TestResultsDto.TestSuiteDto.fromTestSuite(suite, testCaseDtos);
+                })
+            .toList();
+
+    return new TestTypeResults(
+        type.getId(),
+        type.getName(),
+        suiteDtos,
+        run.getTestProcessingStatus() == WorkflowRun.TestProcessingStatus.PROCESSING,
+        new TestResultsDto.TestTypeStats(
+            (int) suites.getTotalElements(),
+            summary.getTests(),
+            summary.getTests()
+                - (summary.getFailures() + summary.getErrors() + summary.getSkipped()),
+            summary.getFailures(),
+            summary.getErrors(),
+            summary.getSkipped(),
+            summary.getTime(),
+            summary.getHasUpdates() ? 1 : 0));
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuite.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuite.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.validation.constraints.Min;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -63,6 +64,7 @@ public class TestSuite {
   private Double time;
 
   @OneToMany(mappedBy = "testSuite", cascade = CascadeType.ALL)
+  @OrderBy("id DESC")
   private List<TestCase> testCases = new ArrayList<>();
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuiteRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuiteRepository.java
@@ -1,10 +1,116 @@
 package de.tum.cit.aet.helios.tests;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TestSuiteRepository extends JpaRepository<TestSuite, Long> {
   List<TestSuite> findByWorkflowRunId(long workflowRunId);
+
+  /**
+   * Retrieves test suites for a specific workflow run and test type, ordered by significance.
+   *
+   * <p>The ordering is determined by three criteria (in order of priority): 1. Test suites
+   * containing test cases whose status changed compared to the previous run appear first 2. Test
+   * suites are then ordered by the total number of failures and errors (descending) 3. Finally,
+   * test suites are ordered alphabetically by name
+   *
+   * @param workflowRunId The ID of the current workflow run
+   * @param testTypeId The ID of the test type to filter by
+   * @param prevWorkflowRunId The ID of the previous workflow run for status change comparison. This
+   *     can be null if no previous run is available.
+   * @param pageable Pagination information
+   * @return A page of TestSuite objects meeting the specified criteria and ordering
+   */
+  @Query(
+      """
+      SELECT ts
+      FROM TestSuite ts
+      WHERE ts.workflowRun.id = :workflowRunId
+      AND ts.testType.id = :testTypeId
+      AND (:search IS NULL OR EXISTS (
+          SELECT 1
+          FROM TestCase tc
+          WHERE tc.testSuite = ts
+          AND (LOWER(tc.name) LIKE LOWER(CONCAT('%', :search, '%'))
+               OR LOWER(tc.className) LIKE LOWER(CONCAT('%', :search, '%')))
+      ))
+      AND (:onlyFailed = false OR ts.failures > 0 OR ts.errors > 0)
+      ORDER BY
+          CASE WHEN (:prevWorkflowRunId IS NOT NULL AND EXISTS (
+              SELECT 1
+              FROM TestCase tc
+              WHERE tc.testSuite = ts
+              AND EXISTS (
+                  SELECT 1
+                  FROM TestCase tcPrev
+                  WHERE tcPrev.name = tc.name
+                  AND tcPrev.className = tc.className
+                  AND tcPrev.testSuite.testType = ts.testType
+                  AND tcPrev.testSuite.workflowRun.id = :prevWorkflowRunId
+                  AND tcPrev.status != tc.status
+              )
+          )) THEN 1 ELSE 0 END DESC,
+          (ts.failures + ts.errors) DESC,
+          ts.name ASC
+      """)
+  Page<TestSuite> findByWorkflowRunIdAndTestTypeId(
+      @Param("workflowRunId") long workflowRunId,
+      @Param("testTypeId") long testTypeId,
+      @Param("prevWorkflowRunId") Long prevWorkflowRunId,
+      @Param("search") String search,
+      @Param("onlyFailed") boolean onlyFailed,
+      Pageable pageable);
+
+  /**
+   * Retrieves a summary of test suite results for a specific workflow run and test type. The
+   * summary includes aggregated test statistics and change detection compared to a previous run.
+   *
+   * @param workflowRunId The ID of the current workflow run
+   * @param testTypeId The ID of the test type to filter results
+   * @param prevWorkflowRunId The ID of the previous workflow run for comparison (can be null)
+   * @return TestSuiteSummaryDto containing some aggregated test statistics and change detection
+   *     information
+   */
+  @Query(
+      """
+          SELECT new de.tum.cit.aet.helios.tests.TestSuiteSummaryDto(
+              SUM(ts.tests),
+              SUM(ts.failures),
+              SUM(ts.errors),
+              SUM(ts.skipped),
+              SUM(ts.time),
+              BOOL_OR(
+                CASE
+                    WHEN :prevWorkflowRunId IS NOT NULL AND (EXISTS (
+                        SELECT 1
+                        FROM TestCase tc
+                        WHERE tc.testSuite = ts
+                        AND EXISTS (
+                            SELECT 1
+                            FROM TestCase tcPrev
+                            WHERE tcPrev.name = tc.name
+                            AND tcPrev.className = tc.className
+                            AND tcPrev.testSuite.testType = ts.testType
+                            AND tcPrev.testSuite.workflowRun.id = :prevWorkflowRunId
+                            AND tcPrev.status != tc.status
+                        )
+                    )) THEN TRUE
+                    ELSE FALSE
+                END
+              )
+          )
+          FROM TestSuite ts
+          WHERE ts.workflowRun.id = :workflowRunId
+          AND ts.testType.id = :testTypeId
+      """)
+  TestSuiteSummaryDto findSummaryByWorkflowRunIdAndTestTypeId(
+      @Param("workflowRunId") long workflowRunId,
+      @Param("testTypeId") long testTypeId,
+      @Param("prevWorkflowRunId") Long prevWorkflowRunId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuiteSummaryDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestSuiteSummaryDto.java
@@ -1,0 +1,25 @@
+package de.tum.cit.aet.helios.tests;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TestSuiteSummaryDto {
+  private Integer tests;
+  private Integer failures;
+  private Integer errors;
+  private Integer skipped;
+  private Double time;
+  private Boolean hasUpdates;
+
+  public TestSuiteSummaryDto(
+      Long tests, Long failures, Long errors, Long skipped, Double time, Boolean hasUpdates) {
+    this.tests = tests == null ? 0 : tests.intValue();
+    this.failures = failures == null ? 0 : failures.intValue();
+    this.errors = errors == null ? 0 : errors.intValue();
+    this.skipped = skipped == null ? 0 : skipped.intValue();
+    this.time = time == null ? 0 : time;
+    this.hasUpdates = hasUpdates == null ? false : hasUpdates;
+  }
+}

--- a/server/application-server/src/main/resources/db/migration/V26__add_indices_tests.sql
+++ b/server/application-server/src/main/resources/db/migration/V26__add_indices_tests.sql
@@ -1,0 +1,3 @@
+CREATE INDEX idx_test_suite_workflow_type ON test_suite(workflow_run_id, test_type_id);
+CREATE INDEX idx_test_case_name_class ON test_case(name, class_name);
+CREATE INDEX idx_test_case_status ON test_case(status);


### PR DESCRIPTION
### Motivation
Right now, the test result loading is extremely slow as we're not using pagination yet but loading all test cases into the server memory and sending it to the client.

### Description
Adds pagination to the client-side and the server-side. That involved a lot of refactoring to optimize queries for test statistics, previous tests, etc. There might still be some issues, but as the test results are not usable right now, I guess that's still better.

### Testing Instructions
You should test the functionalities of search, changing the page, showing only failed tests, showing updated/changed tests and testing the test statistics.
