### PR TITLE
feat: Failure rates for all branches 

### DIFF
--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -181,13 +181,11 @@
                                 </p-tag>
                               }
                               @if (testCase.status === 'FAILED' || testCase.status === 'ERROR') {
-                                @if (testCase.isFlaky) {
-                                  <p-tag
-                                    severity="warn"
-                                    value="Flaky"
-                                    styleClass="mt-2 text-xs"
-                                    pTooltip="Failure rate of this test in default branch exceeds 50%. This test is unstable and should be investigated."
-                                  >
+                                @if (testCase.flakinessScore && testCase.flakinessScore > 0.0) {
+                                  <p-tag severity="warn" styleClass="mt-2 text-xs" pTooltip="Score between 0 and 100, where 0 is not flaky and 100 is highly flaky">
+                                    Flakiness Score: {{ formatFlakinessScore(testCase.flakinessScore) }}
+                                    <span class="mx-1 text-gray-400">|</span>
+                                    <i-tabler (click)="showFlakinessScoreInfo = true" name="info-circle" class="text-xs cursor-pointer hover:text-gray-600" />
                                   </p-tag>
                                 }
                                 @if (testCase.defaultBranchFailureRate && testCase.defaultBranchFailureRate > 0) {
@@ -294,4 +292,39 @@
       }
     </div>
   }
+</p-dialog>
+
+<!-- Flakiness score calculation info pop-up -->
+<p-dialog [(visible)]="showFlakinessScoreInfo" [style]="{ width: '50vw' }" [modal]="true">
+  <ng-template #header>
+    <div class="font-bold text-xl">Flakiness Score Calculation</div>
+  </ng-template>
+  <div class="flex flex-col gap-4">
+    <p>
+      The <b>flakiness score</b> shows how unpredictable a test is, ranging from <b>0</b> (not flaky) to <b>100</b> (highly flaky). It’s based on failure rates from the default
+      branch and all branches combined.
+    </p>
+    <p>
+      <b>How It Works:</b>
+    </p>
+    <ol>
+      <li>
+        <b>Flakiness per Branch:</b><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;If the failure rate is between 0% and 50%, we calculate:<br />
+        &nbsp;&nbsp;&nbsp;&nbsp;<code>flakiness = (50% - failure rate) / 50%</code><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;If it’s 0% or over 50%, flakiness is 0.
+      </li>
+      <li>
+        <b>Weighted Score:</b><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;Combine the flakiness values with weights (e.g., 70% default branch, 30% all branches) and scale to 0–100.
+      </li>
+    </ol>
+    <p>
+      <b>Quick Example:</b><br />
+      - <b>Failure rates:</b> 5% (default), 10% (all branches)<br />
+      - <b>Flakiness:</b> 0.9 (default), 0.8 (all branches)<br />
+      - <b>Score:</b> (0.9 × 0.7) + (0.8 × 0.3) = 0.87 → <b>87</b>
+    </p>
+    <p>This highlights tests that fail rarely but unexpectedly, helping you spot potential issues fast.</p>
+  </div>
 </p-dialog>

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -162,40 +162,54 @@
                           }
                         }
 
-                        <div class="flex flex-1 items-center justify-between min-w-0">
-                          <div class="flex flex-col items-start min-w-0">
-                            <div class="flex items-center gap-2">
+                        <div class="flex flex-1 items-center justify-between min-w-0 gap-2">
+                          <div class="basis-10/12 flex flex-col items-start min-w-0">
+                            <div class="flex items-center gap-2 min-w-0 w-full">
                               @if (testCase.previousStatus !== testCase.status && testCase.previousStatus) {
                                 <span class="text-xs text-blue-400 font-medium flex-shrink-0">previously {{ testCase.previousStatus.toLowerCase() }}</span>
                               }
-                              <span class="text-sm truncate whitespace-nowrap overflow-hidden w-full">{{ testCase.name }} </span>
+                              <span class="text-sm truncate overflow-hidden flex-1 min-w-0" [pTooltip]="testCase.name">{{ testCase.name }}</span>
                             </div>
                             @if (testCase.message) {
                               <p-tag [severity]="testCase.status === 'FAILED' ? 'danger' : 'info'" [value]="testCase.message" styleClass="mt-2 text-xs"> </p-tag>
                             }
                           </div>
-                          <div class="flex items-center gap-2">
-                            @if (testCase.failsInDefaultBranch) {
-                              <p-tag severity="info" value="Fails in default branch" styleClass="mt-2 text-xs" pTooltip="This test is also failing in the default branch"> </p-tag>
-                            }
-                            @if (testCase.isFlaky) {
-                              <div class="flex flex-col gap-1">
-                                <p-tag
-                                  severity="warn"
-                                  value="Flaky"
-                                  styleClass="mt-2 text-xs"
-                                  pTooltip="Failure rate of this test in default branch exceeds 50%. This test is unstable and should be investigated."
-                                >
+                          <div class="basis-2/12 flex items-center justify-end gap-2">
+                            <div class="flex flex-col gap-1">
+                              @if (testCase.failsInDefaultBranch) {
+                                <p-tag severity="info" value="Fails in default branch" styleClass="mt-2 text-xs" pTooltip="This test is also failing in the default branch">
                                 </p-tag>
-                                <p-tag
-                                  severity="danger"
-                                  value="{{ formatFailureRate(testCase.failureRate) }}% Failure rate"
-                                  styleClass="mt-2 text-xs"
-                                  pTooltip="Failure rate of this test in default branch"
-                                >
-                                </p-tag>
-                              </div>
-                            }
+                              }
+                              @if (testCase.status === 'FAILED' || testCase.status === 'ERROR') {
+                                @if (testCase.isFlaky) {
+                                  <p-tag
+                                    severity="warn"
+                                    value="Flaky"
+                                    styleClass="mt-2 text-xs"
+                                    pTooltip="Failure rate of this test in default branch exceeds 50%. This test is unstable and should be investigated."
+                                  >
+                                  </p-tag>
+                                }
+                                @if (testCase.defaultBranchFailureRate && testCase.defaultBranchFailureRate > 0) {
+                                  <p-tag
+                                    severity="danger"
+                                    value="Default branch Failure rate:{{ formatFailureRate(testCase.defaultBranchFailureRate) }}%"
+                                    styleClass="mt-2 text-xs"
+                                    pTooltip="Failure rate of this test in default branch"
+                                  >
+                                  </p-tag>
+                                }
+                                @if (testCase.combinedFailureRate && testCase.combinedFailureRate > 0) {
+                                  <p-tag
+                                    severity="danger"
+                                    value="All branches Failure rate: {{ formatFailureRate(testCase.combinedFailureRate) }}%"
+                                    styleClass="mt-2 text-xs"
+                                    pTooltip="Failure rate of this test in all branches combined"
+                                  >
+                                  </p-tag>
+                                }
+                              }
+                            </div>
                           </div>
                         </div>
 

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -53,6 +53,8 @@ export class PipelineTestResultsComponent {
   showTestDetails = false;
   selectedTestCase = signal<(TestCaseDto & { suiteSystemOut: string | undefined }) | null>(null);
 
+  showFlakinessScoreInfo = false;
+
   showTestCaseDetails(testCase: TestCaseDto, testSuite: TestSuiteDto) {
     this.selectedTestCase.set({
       ...testCase,
@@ -301,5 +303,10 @@ export class PipelineTestResultsComponent {
   formatFailureRate = (failureRate: number | undefined) => {
     if (failureRate === undefined) return 'N/A';
     return Math.floor(failureRate * 100).toString();
+  };
+
+  formatFlakinessScore = (flakinessScore: number | undefined) => {
+    if (flakinessScore === undefined) return 'N/A';
+    return Math.floor(flakinessScore).toString();
   };
 }

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -573,7 +573,11 @@ export const TestCaseDtoSchema = {
     isFlaky: {
       type: 'boolean',
     },
-    failureRate: {
+    defaultBranchFailureRate: {
+      type: 'number',
+      format: 'double',
+    },
+    combinedFailureRate: {
       type: 'number',
       format: 'double',
     },

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -570,8 +570,9 @@ export const TestCaseDtoSchema = {
     errorType: {
       type: 'string',
     },
-    isFlaky: {
-      type: 'boolean',
+    flakinessScore: {
+      type: 'number',
+      format: 'double',
     },
     defaultBranchFailureRate: {
       type: 'number',

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -192,7 +192,8 @@ export type TestCaseDto = {
   systemOut?: string;
   errorType?: string;
   isFlaky?: boolean;
-  failureRate?: number;
+  defaultBranchFailureRate?: number;
+  combinedFailureRate?: number;
   failsInDefaultBranch?: boolean;
 };
 

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -191,7 +191,7 @@ export type TestCaseDto = {
   stackTrace?: string;
   systemOut?: string;
   errorType?: string;
-  isFlaky?: boolean;
+  flakinessScore?: number;
   defaultBranchFailureRate?: number;
   combinedFailureRate?: number;
   failsInDefaultBranch?: boolean;

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -1972,7 +1972,10 @@ components:
           type: string
         isFlaky:
           type: boolean
-        failureRate:
+        defaultBranchFailureRate:
+          type: number
+          format: double
+        combinedFailureRate:
           type: number
           format: double
         failsInDefaultBranch:

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -1970,8 +1970,9 @@ components:
           type: string
         errorType:
           type: string
-        isFlaky:
-          type: boolean
+        flakinessScore:
+          type: number
+          format: double
         defaultBranchFailureRate:
           type: number
           format: double

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
@@ -74,6 +74,12 @@ public class TestCase {
    */
   @Transient private double failureRate;
 
+  /**
+   * Transient field for the failure rate of this test on all branches combined. Retrieved from test
+   * case statistics.
+   */
+  @Transient private double combinedFailureRate;
+
   /** Transient field indicating whether this test also fails in the default branch. */
   @Transient private boolean failsInDefaultBranch;
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCase.java
@@ -66,7 +66,7 @@ public class TestCase {
    * Transient field indicating whether this test is flaky. Determined based on test case
    * statistics.
    */
-  @Transient private boolean isFlaky;
+  @Transient private double flakinessScore;
 
   /**
    * Transient field for the failure rate of this test on its branch. Retrieved from test case

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatistics.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatistics.java
@@ -76,12 +76,6 @@ public class TestCaseStatistics {
   @Column(nullable = false, name = "failed_runs")
   private int failedRuns;
 
-  @Column(nullable = false, name = "failure_rate")
-  private double failureRate;
-
-  @Column(nullable = false, name = "is_flaky")
-  private boolean isFlaky;
-
   @Column(nullable = false, name = "last_updated")
   private OffsetDateTime lastUpdated;
 
@@ -132,16 +126,10 @@ public class TestCaseStatistics {
     if (hasFailed) {
       this.failedRuns++;
     }
-    this.calculateFailureRate();
     this.lastUpdated = OffsetDateTime.now();
   }
 
-  /**
-   * Calculates the failure rate and updates the flakiness status based on the configured threshold.
-   */
-  private void calculateFailureRate() {
-    this.failureRate = totalRuns > 0 ? (double) failedRuns / totalRuns : 0.0;
-    // A test is considered flaky if it fails more than 50% of the time
-    this.isFlaky = this.failureRate >= 0.5;
+  public double getFailureRate() {
+    return totalRuns > 0 ? (double) failedRuns / totalRuns : 0.0;
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
@@ -54,15 +54,6 @@ public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStat
       String branchName, Long repositoryId);
 
   /**
-   * Find all flaky or non-flaky tests for a specific branch.
-   *
-   * @param branchName the branch name
-   * @param isFlaky whether to find flaky or non-flaky tests
-   * @return list of flaky or non-flaky test statistics
-   */
-  List<TestCaseStatistics> findByBranchNameAndIsFlaky(String branchName, boolean isFlaky);
-
-  /**
    * Find all statistics for test cases that belong to specific test suites on a branch in a
    * repository.
    *

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -275,13 +275,20 @@ public class TestResultProcessor {
 
       if (headBranch.equals(defaultBranch)) {
         log.debug("Updating test statistics for default branch: {}", headBranch);
-        updateTestStatistics(testSuites, headBranch, repository.get());
+        updateTestStatistics(
+            testSuites, headBranch, repository.get()); // update statistics for the default branch
       } else {
         log.debug(
             "Skipping test statistics update for non-default branch: {}, default branch: {}",
             headBranch,
             defaultBranch);
       }
+
+      updateTestStatistics(
+          testSuites,
+          "combined",
+          repository.get()); // update statistics for all the branches combined
+      log.debug("Successfully updated test statistics for all branches combined");
     } catch (Exception e) {
       log.error("Error while trying to update test statistics", e);
       // Don't fail the overall process if statistics update fails

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
@@ -72,7 +72,7 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
       String stackTrace,
       String systemOut,
       String errorType,
-      Boolean isFlaky,
+      Double flakinessScore,
       Double defaultBranchFailureRate,
       Double combinedFailureRate,
       Boolean failsInDefaultBranch) {
@@ -88,7 +88,7 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
           testCase.getStackTrace(),
           testCase.getSystemOut(),
           testCase.getErrorType(),
-          testCase.isFlaky(),
+          testCase.getFlakinessScore(),
           testCase.getFailureRate(),
           testCase.getCombinedFailureRate(),
           testCase.isFailsInDefaultBranch());
@@ -96,8 +96,7 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
   }
 
   /** Record for storing test case statistics information. */
-  record TestCaseStatisticsInfo(
-      boolean isFlaky, double failureRate, boolean failsInDefaultBranch) {}
+  record TestCaseStatisticsInfo(double failureRate, boolean failsInDefaultBranch) {}
 
   record CombinedTestCaseStatisticsInfo(double combinedFailureRate) {}
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
@@ -73,7 +73,8 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
       String systemOut,
       String errorType,
       Boolean isFlaky,
-      Double failureRate,
+      Double defaultBranchFailureRate,
+      Double combinedFailureRate,
       Boolean failsInDefaultBranch) {
     public static TestCaseDto fromTestCase(TestCase testCase) {
       return new TestCaseDto(
@@ -89,6 +90,7 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
           testCase.getErrorType(),
           testCase.isFlaky(),
           testCase.getFailureRate(),
+          testCase.getCombinedFailureRate(),
           testCase.isFailsInDefaultBranch());
     }
   }
@@ -96,4 +98,6 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
   /** Record for storing test case statistics information. */
   record TestCaseStatisticsInfo(
       boolean isFlaky, double failureRate, boolean failsInDefaultBranch) {}
+
+  record CombinedTestCaseStatisticsInfo(double combinedFailureRate) {}
 }

--- a/server/application-server/src/main/resources/db/migration/V27__remove_flakiness_fields_from_test_case_statistics.sql
+++ b/server/application-server/src/main/resources/db/migration/V27__remove_flakiness_fields_from_test_case_statistics.sql
@@ -1,0 +1,3 @@
+-- Migration script to remove is_flaky and failure_rate columns from test_case_statistics
+ALTER TABLE public.test_case_statistics DROP COLUMN IF EXISTS is_flaky;
+ALTER TABLE public.test_case_statistics DROP COLUMN IF EXISTS failure_rate; 


### PR DESCRIPTION
**Failure Rate Updates:**
![image](https://github.com/user-attachments/assets/a4fb4cb3-6d2e-4930-9931-484f5ae017b0)
**Failure Rates and Flakiness Score:**
![image](https://github.com/user-attachments/assets/aa875d0e-ecfc-4800-8369-2dc3a448debd)
**Flakiness score calculation info pop-up:**
![image](https://github.com/user-attachments/assets/8b266000-56e5-49ed-aa8d-c02082f65234)


Removed isFlaky and FailureRate fields from TestcaseStatistics Entity.
Now we are only storing total runs and failed runs for default branch and all branches combined.
Then we are using this information to calculate failure rates and flakiness score.