### PR TITLE
fix: add delayed processing for GitHub `workflow_run` events

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/AsyncConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/AsyncConfig.java
@@ -38,7 +38,9 @@ public class AsyncConfig {
   @Bean("workflowRunTaskScheduler")
   public TaskScheduler workflowRunTaskScheduler() {
     ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-    scheduler.setPoolSize(5);
+    // Set the pool size to 1 to ensure tasks are executed sequentially
+    // This guarantees that webhook events are processed one at a time
+    scheduler.setPoolSize(1);
     scheduler.setThreadNamePrefix("workflow-run-scheduler-");
     scheduler.initialize();
     return scheduler;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/AsyncConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/AsyncConfig.java
@@ -1,11 +1,46 @@
 package de.tum.cit.aet.helios.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableAsync
 @EnableScheduling
 public class AsyncConfig {
+
+  /**
+   * Creates a default TaskScheduler bean. This scheduler is used for general scheduling tasks
+   * throughout the application.
+   *
+   * @return a configured ThreadPoolTaskScheduler instance
+   */
+  @Bean
+  @Primary
+  public TaskScheduler defaultTaskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(10);
+    scheduler.setThreadNamePrefix("default-scheduler-");
+    scheduler.initialize();
+    return scheduler;
+  }
+
+  /**
+   * Creates a TaskScheduler bean named "workflowRunTaskScheduler". This scheduler is used for
+   * scheduling workflow run webhook events.
+   *
+   * @return a configured ThreadPoolTaskScheduler instance
+   */
+  @Bean("workflowRunTaskScheduler")
+  public TaskScheduler workflowRunTaskScheduler() {
+    ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(5);
+    scheduler.setThreadNamePrefix("workflow-run-scheduler-");
+    scheduler.initialize();
+    return scheduler;
+  }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequest;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.util.DateUtil;
+import de.tum.cit.aet.helios.workflow.GitHubWorkflowContext;
 import de.tum.cit.aet.helios.workflow.Workflow;
 import de.tum.cit.aet.helios.workflow.WorkflowRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
@@ -15,6 +16,7 @@ import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowService;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +39,17 @@ public class GitHubWorkflowRunSyncService {
 
   @Transactional
   public WorkflowRun processRun(GHWorkflowRun ghWorkflowRun) {
+    return process(ghWorkflowRun, null);
+  }
+
+  @Transactional
+  public WorkflowRun processRunWithContext(
+      GHWorkflowRun ghWorkflowRun, GitHubWorkflowContext context) {
+    return process(ghWorkflowRun, context);
+  }
+
+  private WorkflowRun process(GHWorkflowRun ghWorkflowRun,
+                              GitHubWorkflowContext context) {
     var result =
         workflowRunRepository
             .findById(ghWorkflowRun.getId())
@@ -45,9 +58,9 @@ public class GitHubWorkflowRunSyncService {
                   try {
                     if (workflowRun.getUpdatedAt() == null
                         || workflowRun
-                            .getUpdatedAt()
-                            .isBefore(
-                                DateUtil.convertToOffsetDateTime(ghWorkflowRun.getUpdatedAt()))) {
+                        .getUpdatedAt()
+                        .isBefore(
+                            DateUtil.convertToOffsetDateTime(ghWorkflowRun.getUpdatedAt()))) {
                       return workflowRunConverter.update(ghWorkflowRun, workflowRun);
                     }
                     return workflowRun;
@@ -112,6 +125,28 @@ public class GitHubWorkflowRunSyncService {
           e.getMessage());
     }
 
+    // If we have a context, set triggeredWorkflowRunId, headBranch, headSha
+    // And find matching open PR if available.
+    if (context != null) {
+      log.info("Applying GitHubWorkflowContext: runId={}, branch={}, sha={}",
+          context.runId(), context.headBranch(), context.headSha());
+
+      result.setTriggeredWorkflowRunId(context.runId());
+      result.setHeadBranch(context.headBranch());
+      result.setHeadSha(context.headSha());
+
+      // Find a matching open PR
+      if (result.getRepository() != null) {
+        var repositoryId = result.getRepository().getRepositoryId();
+        pullRequestRepository
+            .findOpenPrByBranchNameOrSha(repositoryId, context.headBranch(), context.headSha())
+            .ifPresent(pr -> result.setPullRequests(new HashSet<>(Collections.singletonList(pr))
+
+            ));
+      }
+    }
+
+
     // Process the workflow run for HeliosDeployment
     try {
       processRunForHeliosDeployment(ghWorkflowRun);
@@ -160,13 +195,13 @@ public class GitHubWorkflowRunSyncService {
             heliosDeployment -> {
               try {
                 if (workflowRun
-                        .getUpdatedAt()
-                        .toInstant()
-                        .isAfter(heliosDeployment.getUpdatedAt().toInstant())
+                    .getUpdatedAt()
+                    .toInstant()
+                    .isAfter(heliosDeployment.getUpdatedAt().toInstant())
                     || workflowRun
-                        .getUpdatedAt()
-                        .toInstant()
-                        .equals(heliosDeployment.getUpdatedAt().toInstant())) {
+                    .getUpdatedAt()
+                    .toInstant()
+                    .equals(heliosDeployment.getUpdatedAt().toInstant())) {
                   heliosDeployment.setUpdatedAt(
                       DateUtil.convertToOffsetDateTime(workflowRun.getUpdatedAt()));
                   HeliosDeployment.Status mappedStatus =


### PR DESCRIPTION
### Motivation
We need to delay processing of GitHub `workflow_run` events by **10** (can be less or more) **seconds** so that the workflow has time to upload the `workflow-context` artifact. This artifact contains the `branch/SHA` information that triggered the workflow. Without waiting, we lose the ability to associate the run with the correct triggering branch/commit. We also need to ensure these events are processed sequentially, as our webhook processing is already sequential. 


### Description
- Added a single‐threaded TaskScheduler bean (workflowRunTaskScheduler) with poolSize(1) to guarantee tasks are handled one at a time.
- Refactored the workflow‐run handling to:
  - Schedule `workflow_run` events to run 10 seconds later
  - In `handleWorkflowRunEvent(...)`, we download the `workflow-context` artifact (if available) to extract the triggered workflow info (branch, SHA, etc.).
  - We call `workflowSyncService.processRunWithContext(...)` to store the extra fields (triggeredWorkflowRunId, headBranch, headSha), locate matching open PRs by branch/sha, and link them.
  - We finish by processing test results if the run meets the criterias
- Updated `GitHubWorkflowRunSyncService` with two methods: `processRun(...)` and `processRunWithContext(...)`, which delegate to a private `process(...)` method. This allows us to handle either the standard or “with context” scenario uniformly.


### Testing Instructions
Make sure that [your workflow saves](https://github.com/ls1intum/Artemis/blob/develop/.github/workflows/test-e2e.yml#L54-L65) the workflow-context file just like the Artemis E2E test workflow. Also triggering method of E2E test workflow must be 
```
on:
  workflow_run:
```