### PR TITLE
feat: Filter logs by log level

### DIFF
--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -246,7 +246,7 @@
 }
 
 <p-dialog [(visible)]="showTestDetails" [style]="{ width: '50vw' }" [modal]="true">
-  <ng-template #header>
+  <ng-template pTemplate="header">
     <div class="font-bold text-xl">Test Details</div>
   </ng-template>
 
@@ -261,11 +261,32 @@
         </div>
       }
 
+      @if (selectedTestCase()?.systemOut || selectedTestCase()?.suiteSystemOut) {
+        <!-- Log Level Filter -->
+        <div class="flex flex-col gap-1 mb-2">
+          <div class="flex justify-between items-center">
+            <span class="text-sm font-medium">Log Level Filter:</span>
+            <span class="text-sm font-medium" [class]="selectedLogLevel().color">
+              {{ selectedLogLevel().label }}
+            </span>
+          </div>
+          <p-slider [ngModel]="getLogLevelValue()" (ngModelChange)="updateLogLevel($event)" [min]="0" [max]="7" [step]="1"> </p-slider>
+          <div class="flex justify-between text-xs text-gray-500">
+            <span>Higher Severity</span>
+            <span>Lower Severity</span>
+          </div>
+        </div>
+      }
+
       @if (selectedTestCase()?.systemOut) {
         <div>
           <h4 class="font-medium mb-2">Test Case Logs</h4>
           <div class="bg-gray-50 p-4 rounded overflow-auto max-h-[400px]">
-            <pre class="font-mono text-sm">{{ selectedTestCase()?.systemOut }}</pre>
+            @if (filteredTestCaseLogs()) {
+              @for (line of filteredTestCaseLogs().split('\n'); track $index) {
+                <pre class="font-mono text-sm" [class]="getLogLevelClass(line)">{{ line }}</pre>
+              }
+            }
           </div>
         </div>
       }
@@ -274,7 +295,11 @@
         <div>
           <h4 class="font-medium mb-2">Test Suite Logs</h4>
           <div class="bg-gray-50 p-4 rounded overflow-auto max-h-[400px]">
-            <pre class="font-mono text-sm">{{ selectedTestCase()?.suiteSystemOut }}</pre>
+            @if (filteredTestSuiteLogs()) {
+              @for (line of filteredTestSuiteLogs().split('\n'); track $index) {
+                <pre class="font-mono text-sm" [class]="getLogLevelClass(line)">{{ line }}</pre>
+              }
+            }
           </div>
         </div>
       }

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -75,7 +75,6 @@ export class PipelineTestResultsComponent {
   showTestDetails = false;
   selectedTestCase = signal<(TestCaseDto & { suiteSystemOut: string | undefined }) | null>(null);
 
-
   // Log level filtering
   selectedLogLevelValue = signal<number>(7); // Default to ALL
 


### PR DESCRIPTION
- Implemented a filter with slider component to filter logs by level including the higher severity logs.
Log levels: OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE, ALL
if you choose ERROR then FATAL and OFF will be included
if you choose DEBUG then INFO, WARN, ERROR, FATAL, OFF will be included

- I also added log level coloring to the lines
- Lines that doesn't contain any log level is kept in the text all the time
- Matching logic: It looks for lines that contains following pattern -> | <uppercase_log_level> |

Screen recording:

https://github.com/user-attachments/assets/4dcdb979-cbeb-4ebc-af97-f26de8cdfa1f

