### PR TITLE
fix: correct reassign logic for workflow_run in data sync

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -12,14 +12,20 @@ import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.permissions.GitHubPermissionsResponse;
 import de.tum.cit.aet.helios.github.permissions.GitHubRepositoryRoleDto;
 import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
+import de.tum.cit.aet.helios.workflow.GitHubWorkflowContext;
 import jakarta.transaction.Transactional;
+import java.io.BufferedReader;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import okhttp3.MediaType;
@@ -597,4 +603,132 @@ public class GitHubService {
       return getRepository(repoNameWithOwner).getReleaseByTagName(tagName);
     }
   }
+
+  /**
+   * Extracts workflow context from the workflow-context artifact.
+   *
+   * @param repositoryId The ID of the repository
+   * @param runId The ID of the workflow run
+   * @return The extracted GitHubWorkflowContext or null if not found or error occurred
+   */
+  public GitHubWorkflowContext extractWorkflowContext(long repositoryId, long runId) {
+    GHArtifact ghArtifact = null;
+
+    // Fetch artifacts to get the triggering workflow run ID
+    try {
+      PagedIterable<GHArtifact> artifacts =
+          getWorkflowRunArtifacts(repositoryId, runId);
+
+      // First artifact with the configured name
+      for (GHArtifact artifact : artifacts) {
+        if (artifact.getName().equals("workflow-context")) {
+          ghArtifact = artifact;
+          break;
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Failed to fetch artifacts for workflow run: {}", e.getMessage());
+      return null;
+    }
+
+    if (ghArtifact == null) {
+      log.warn("No workflow-context artifact found for E2E Tests workflow_run: {}", runId);
+      return null;
+    }
+
+    log.debug("Found artifact {}", ghArtifact.getName());
+
+    try {
+      // Parse the artifact to extract the triggering workflow information
+      return parseWorkflowContextArtifact(ghArtifact);
+    } catch (Exception e) {
+      log.error("Failed to parse workflow context artifact: {}", e.getMessage());
+      return null;
+    }
+  }
+
+  /**
+   * Parses the workflow context artifact to extract the triggering workflow information.
+   */
+  private GitHubWorkflowContext parseWorkflowContextArtifact(GHArtifact artifact)
+      throws IOException {
+    // Download & Parse the artifact
+    return artifact.download(
+        artifactContent -> {
+          if (artifactContent.available() == 0) {
+            throw new RuntimeException("Empty artifact stream!");
+          }
+
+          Long workflowRunId = null;
+          String headBranch = null;
+          String headSha = null;
+
+          try (ZipInputStream zipInput = new ZipInputStream(artifactContent)) {
+            ZipEntry entry;
+
+            while ((entry = zipInput.getNextEntry()) != null) {
+              if (!entry.isDirectory()
+                  && "workflow-context.txt".equalsIgnoreCase(entry.getName())) {
+
+                var nonClosingStream =
+                    new FilterInputStream(zipInput) {
+                      @Override
+                      public void close() throws IOException {
+                        // Do nothing, so the underlying stream stays open.
+                      }
+                    };
+
+                // Read file content
+                try (BufferedReader reader =
+                         new BufferedReader(new InputStreamReader(nonClosingStream))) {
+                  String line;
+                  while ((line = reader.readLine()) != null) {
+                    // Skip empty lines
+                    if (line.trim().isEmpty()) {
+                      continue;
+                    }
+
+                    // Split each line by equals sign
+                    String[] parts = line.split("=", 2);
+                    if (parts.length == 2) {
+                      String key = parts[0].trim();
+                      String value = parts[1].trim();
+
+                      // Extract values
+                      switch (key) {
+                        case "TRIGGERING_WORKFLOW_RUN_ID" -> workflowRunId = Long.parseLong(value);
+                        case "TRIGGERING_WORKFLOW_HEAD_BRANCH" -> headBranch = value;
+                        case "TRIGGERING_WORKFLOW_HEAD_SHA" -> headSha = value;
+                        default -> log.warn("Unknown key in workflow-context.txt: {}", key);
+                      }
+                    }
+                  }
+                }
+              }
+              zipInput.closeEntry();
+            }
+          }
+
+          // Validate that we found all required values
+          if (workflowRunId == null) {
+            throw new RuntimeException("Could not find TRIGGERING_WORKFLOW_RUN_ID in artifact");
+          }
+          if (headBranch == null) {
+            throw new RuntimeException(
+                "Could not find TRIGGERING_WORKFLOW_HEAD_BRANCH in artifact");
+          }
+          if (headSha == null) {
+            throw new RuntimeException("Could not find TRIGGERING_WORKFLOW_HEAD_SHA in artifact");
+          }
+
+          log.info(
+              "Context extracted: workflowRunId: {}, headBranch: {}, headSha: {}",
+              workflowRunId,
+              headBranch,
+              headSha);
+
+          return new GitHubWorkflowContext(workflowRunId, headBranch, headSha);
+        });
+  }
+
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/GitHubDataSyncOrchestrator.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/GitHubDataSyncOrchestrator.java
@@ -24,6 +24,7 @@ import de.tum.cit.aet.helios.releaseinfo.release.github.GitHubReleaseSyncService
 import de.tum.cit.aet.helios.user.User;
 import de.tum.cit.aet.helios.user.UserRepository;
 import de.tum.cit.aet.helios.user.github.GitHubUserSyncService;
+import de.tum.cit.aet.helios.workflow.GitHubWorkflowContext;
 import de.tum.cit.aet.helios.workflow.github.GitHubWorkflowRunSyncService;
 import de.tum.cit.aet.helios.workflow.github.GitHubWorkflowSyncService;
 import java.io.IOException;
@@ -39,6 +40,7 @@ import lombok.extern.log4j.Log4j2;
 import org.jetbrains.annotations.NotNull;
 import org.kohsuke.github.GHCommit;
 import org.kohsuke.github.GHDirection;
+import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHPullRequestQueryBuilder;
 import org.kohsuke.github.GHRelease;
@@ -415,10 +417,46 @@ public class GitHubDataSyncOrchestrator {
       }
     }
 
-    workflowRuns.forEach(workflowRunSyncService::processRun);
+    workflowRuns.forEach(run -> {
+      try {
+
+        if (run.getEvent().equals(GHEvent.WORKFLOW_RUN)) {
+          log.info("Received workflow_run event, delaying processing");
+          GitHubWorkflowContext context = null;
+          try {
+            context =
+                gitHubService.extractWorkflowContext(repository.getId(), run.getId());
+          } catch (Exception e) {
+            log.error("Error while extracting workflow context: {}", e.getMessage());
+            return;
+          }
+
+          if (context == null) {
+            log.warn("No workflow context found for workflow run: {}", run.getId());
+            return;
+          }
+
+          log.info(
+              "Context found with triggering workflow run id: {}, head branch: {}, head sha: {}",
+              context.runId(), context.headBranch(), context.headSha());
+
+          workflowRunSyncService.processRunWithContext(run, context);
+        } else {
+          workflowRunSyncService.processRun(run);
+        }
+
+      } catch (Exception e) {
+        log.error(
+            "Failed to process workflow run {}: {}",
+            run.getId(),
+            e.getMessage());
+      }
+    });
   }
 
-  /** Sync all existing users in the local repository with their GitHub data. */
+  /**
+   * Sync all existing users in the local repository with their GitHub data.
+   */
   public void syncAllExistingUsers() {
     userRepository.findAll().stream().map(User::getLogin).forEach(this::syncUser);
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunMessageHandler.java
@@ -3,25 +3,14 @@ package de.tum.cit.aet.helios.workflow.github;
 import de.tum.cit.aet.helios.github.GitHubMessageHandler;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.github.GitHubRepositorySyncService;
-import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.tests.TestResultProcessor;
 import de.tum.cit.aet.helios.workflow.GitHubWorkflowContext;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
-import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
-import de.tum.cit.aet.helios.workflow.WorkflowRunService;
-import java.io.BufferedReader;
-import java.io.FilterInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.time.Instant;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.kohsuke.github.GHArtifact;
 import org.kohsuke.github.GHEvent;
 import org.kohsuke.github.GHEventPayload;
-import org.kohsuke.github.PagedIterable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
@@ -35,9 +24,6 @@ public class GitHubWorkflowRunMessageHandler
   private final GitHubWorkflowRunSyncService workflowSyncService;
   private final TestResultProcessor testResultProcessor;
   private final GitHubService gitHubService;
-  private final WorkflowRunService workflowRunService;
-  private final WorkflowRunRepository workflowRunRepository;
-  private final PullRequestRepository pullRequestRepository;
   @Qualifier("workflowRunTaskScheduler")
   private final TaskScheduler taskScheduler;
 
@@ -110,7 +96,7 @@ public class GitHubWorkflowRunMessageHandler
 
     try {
       context =
-          extractWorkflowContext(repository.getId(), githubRun.getId());
+          gitHubService.extractWorkflowContext(repository.getId(), githubRun.getId());
     } catch (Exception e) {
       log.error("Error while extracting workflow context: {}", e.getMessage());
       return;
@@ -138,132 +124,5 @@ public class GitHubWorkflowRunMessageHandler
     if (run != null && testResultProcessor.shouldProcess(run)) {
       testResultProcessor.processRun(run);
     }
-  }
-
-  /**
-   * Extracts workflow context from the workflow-context artifact.
-   *
-   * @param repositoryId The ID of the repository
-   * @param runId The ID of the workflow run
-   * @return The extracted GitHubWorkflowContext or null if not found or error occurred
-   */
-  private GitHubWorkflowContext extractWorkflowContext(long repositoryId, long runId) {
-    GHArtifact ghArtifact = null;
-
-    // Fetch artifacts to get the triggering workflow run ID
-    try {
-      PagedIterable<GHArtifact> artifacts =
-          this.gitHubService.getWorkflowRunArtifacts(repositoryId, runId);
-
-      // First artifact with the configured name
-      for (GHArtifact artifact : artifacts) {
-        if (artifact.getName().equals("workflow-context")) {
-          ghArtifact = artifact;
-          break;
-        }
-      }
-    } catch (Exception e) {
-      log.warn("Failed to fetch artifacts for workflow run: {}", e.getMessage());
-      return null;
-    }
-
-    if (ghArtifact == null) {
-      log.warn("No workflow-context artifact found for E2E Tests workflow_run: {}", runId);
-      return null;
-    }
-
-    log.debug("Found artifact {}", ghArtifact.getName());
-
-    try {
-      // Parse the artifact to extract the triggering workflow information
-      return parseWorkflowContextArtifact(ghArtifact);
-    } catch (Exception e) {
-      log.error("Failed to parse workflow context artifact: {}", e.getMessage());
-      return null;
-    }
-  }
-
-  /**
-   * Parses the workflow context artifact to extract the triggering workflow information.
-   */
-  private GitHubWorkflowContext parseWorkflowContextArtifact(GHArtifact artifact)
-      throws IOException {
-    // Download & Parse the artifact
-    return artifact.download(
-        artifactContent -> {
-          if (artifactContent.available() == 0) {
-            throw new RuntimeException("Empty artifact stream!");
-          }
-
-          Long workflowRunId = null;
-          String headBranch = null;
-          String headSha = null;
-
-          try (ZipInputStream zipInput = new ZipInputStream(artifactContent)) {
-            ZipEntry entry;
-
-            while ((entry = zipInput.getNextEntry()) != null) {
-              if (!entry.isDirectory()
-                  && "workflow-context.txt".equalsIgnoreCase(entry.getName())) {
-
-                var nonClosingStream =
-                    new FilterInputStream(zipInput) {
-                      @Override
-                      public void close() throws IOException {
-                        // Do nothing, so the underlying stream stays open.
-                      }
-                    };
-
-                // Read file content
-                try (BufferedReader reader =
-                         new BufferedReader(new InputStreamReader(nonClosingStream))) {
-                  String line;
-                  while ((line = reader.readLine()) != null) {
-                    // Skip empty lines
-                    if (line.trim().isEmpty()) {
-                      continue;
-                    }
-
-                    // Split each line by equals sign
-                    String[] parts = line.split("=", 2);
-                    if (parts.length == 2) {
-                      String key = parts[0].trim();
-                      String value = parts[1].trim();
-
-                      // Extract values
-                      switch (key) {
-                        case "TRIGGERING_WORKFLOW_RUN_ID" -> workflowRunId = Long.parseLong(value);
-                        case "TRIGGERING_WORKFLOW_HEAD_BRANCH" -> headBranch = value;
-                        case "TRIGGERING_WORKFLOW_HEAD_SHA" -> headSha = value;
-                        default -> log.warn("Unknown key in workflow-context.txt: {}", key);
-                      }
-                    }
-                  }
-                }
-              }
-              zipInput.closeEntry();
-            }
-          }
-
-          // Validate that we found all required values
-          if (workflowRunId == null) {
-            throw new RuntimeException("Could not find TRIGGERING_WORKFLOW_RUN_ID in artifact");
-          }
-          if (headBranch == null) {
-            throw new RuntimeException(
-                "Could not find TRIGGERING_WORKFLOW_HEAD_BRANCH in artifact");
-          }
-          if (headSha == null) {
-            throw new RuntimeException("Could not find TRIGGERING_WORKFLOW_HEAD_SHA in artifact");
-          }
-
-          log.info(
-              "Context extracted: workflowRunId: {}, headBranch: {}, headSha: {}",
-              workflowRunId,
-              headBranch,
-              headSha);
-
-          return new GitHubWorkflowContext(workflowRunId, headBranch, headSha);
-        });
   }
 }


### PR DESCRIPTION
### Motivation
The webhook-listener correctly handles workflow_run-typed workflow runs when they arrive via GitHub webhooks. However, during periodic data syncs (e.g., fallback polling or manual sync), the same logic failed to properly reassign workflow runs to their triggering workflows.