### PR TITLE
Fix/UI refactoring

### DIFF
--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -6,10 +6,12 @@
       <span class="hidden md:block">{{ isAdmin() ? 'Manage Environments' : 'Go to Environments' }}</span>
     </p-button>
   } @else {
-    <p-button label="" (click)="syncEnvironments()" pTooltip="May take ~10 seconds after environment creation on GitHub" tooltipPosition="top" class="mr-2">
-      <i-tabler name="refresh" class="!size-5"></i-tabler>
-      <span class="hidden md:block">Sync Environments</span>
-    </p-button>
+    @if (isAtLeastMaintainer()) {
+      <p-button label="" (click)="syncEnvironments()" pTooltip="May take ~10 seconds after environment creation on GitHub" tooltipPosition="top" class="mr-2">
+        <i-tabler name="refresh" class="!size-5"></i-tabler>
+        <span class="hidden md:block">Sync Environments</span>
+      </p-button>
+    }
   }
 </div>
 

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -73,7 +73,7 @@ export class EnvironmentListViewComponent implements OnDestroy {
 
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
   isAdmin = computed(() => this.permissionService.isAdmin());
-  hasUnlockPermissions = computed(() => this.permissionService.isAtLeastMaintainer());
+  isAtLeastMaintainer = computed(() => this.permissionService.isAtLeastMaintainer());
   hasDeployPermissions = computed(() => this.permissionService.hasWritePermission());
   hasEditEnvironmentPermissions = computed(() => this.permissionService.isAdmin());
 

--- a/client/src/app/components/navigation-bar/navigation-bar.component.ts
+++ b/client/src/app/components/navigation-bar/navigation-bar.component.ts
@@ -11,7 +11,7 @@ import { PermissionService } from '@app/core/services/permission.service';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getRepositoryByIdOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { ButtonModule } from 'primeng/button';
-import { IconAdjustmentsAlt, IconArrowGuide, IconChevronLeft, IconChevronRight, IconRocket, IconServerCog } from 'angular-tabler-icons/icons';
+import { IconAdjustmentsAlt, IconArrowGuide, IconChevronLeft, IconChevronRight, IconRocket, IconServerCog, IconEyeOff } from 'angular-tabler-icons/icons';
 
 @Component({
   selector: 'app-navigation-bar',
@@ -24,6 +24,7 @@ import { IconAdjustmentsAlt, IconArrowGuide, IconChevronLeft, IconChevronRight, 
       IconAdjustmentsAlt,
       IconChevronLeft,
       IconChevronRight,
+      IconEyeOff,
     }),
   ],
   templateUrl: './navigation-bar.component.html',

--- a/client/src/app/components/pull-request-table/pull-request-table.component.html
+++ b/client/src/app/components/pull-request-table/pull-request-table.component.html
@@ -70,7 +70,7 @@
             </div>
 
             <div class="flex flex-col gap-2.5">
-              <div class="flex flex-nowrap items-center gap-2">
+              <div class="flex flex-wrap items-center gap-2">
                 <app-pull-request-status-icon [pullRequest]="pr" tooltipPosition="top" />
                 <span class="font-bold hover:underline cursor-pointer leading-none max-w-sm md:max-w-xl line-clamp-1" (click)="openPR(pr)">
                   <span [innerHTML]="pr.title | markdown" class="line-clamp-1"></span>

--- a/client/src/app/pages/main-layout/main-layout.component.ts
+++ b/client/src/app/pages/main-layout/main-layout.component.ts
@@ -46,6 +46,7 @@ import { version } from 'environments/version';
   templateUrl: './main-layout.component.html',
 })
 export class MainLayoutComponent implements OnInit {
+  private STORAGE_KEY = 'theme';
   private keycloakService = inject(KeycloakService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
@@ -53,7 +54,7 @@ export class MainLayoutComponent implements OnInit {
   deployed_version = version.deployed_version;
 
   repositoryId = signal<number | undefined>(undefined);
-  isDarkModeEnabled = signal(window.matchMedia('(prefers-color-scheme: dark)').matches);
+  isDarkModeEnabled = signal(this.isThemeDark());
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
 
   constructor() {
@@ -130,7 +131,30 @@ export class MainLayoutComponent implements OnInit {
     this.keycloakService.login();
   }
 
+  /**
+   * Checks if the current theme is dark.
+   *
+   * This method retrieves the saved theme from localStorage and checks if it is set to 'dark'.
+   * If not found, it falls back to the user's OS preference using `window.matchMedia`.
+   *
+   * @returns {boolean} - Returns true if the theme is dark, false otherwise.
+   */
+  private isThemeDark(): boolean {
+    // Get the saved theme from localStorage
+    const saved = localStorage.getItem('theme');
+
+    // Check if the saved theme is either 'light' or 'dark'
+    if (saved === 'light' || saved === 'dark') {
+      return saved === 'dark';
+    }
+
+    // fall back to OS preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
   toggleDarkMode() {
-    this.isDarkModeEnabled.set(!this.isDarkModeEnabled());
+    const next = !this.isDarkModeEnabled();
+    this.isDarkModeEnabled.set(next);
+    localStorage.setItem(this.STORAGE_KEY, next ? 'dark' : 'light');
   }
 }


### PR DESCRIPTION
### Motivation
General UI fixes.


### Description
- Added missing `IconEyeOff` icon in `navigation-bar.component.ts`
- updated `pull-request-table.component.html` to be `flex-wrap` since too much label were creating horizontal scrollable (check it out the staging)
https://github.com/user-attachments/assets/f7ce10c6-2be0-4d91-9bdc-893c773aec21
- Sync Environments button were showing to non-loggedin users, covered with `isAtLeastMainainer`
- After setting the dark/light theme, if you refresh the page then it reverts back to the system default. Right now we persist the theme information in localstorage following the login in our [keycloak login theming code](https://github.com/ls1intum/Helios/blob/staging/keycloakify/index.html#L12-L43). In the local development, after you change your theme in helios would not reflect to the keycloak login page since the urls are different (helios-> localhost:4200, keycloak-> localhost:8081). But in the staging and production since the domains are the same, then setting the same `theme` using the `localstorage` would reflect to both of them.


