### PR TITLE
fix: conditionally show user related PR filter

### DIFF
--- a/client/src/app/components/pull-request-table/pull-request-table.component.ts
+++ b/client/src/app/components/pull-request-table/pull-request-table.component.ts
@@ -21,22 +21,31 @@ import { PullRequestStatusIconComponent } from '@app/components/pull-request-sta
 import { MessageService, SortMeta } from 'primeng/api';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconExternalLink, IconFilterPlus, IconGitPullRequest, IconPinned, IconPinnedOff, IconPoint, IconBrandGithub } from 'angular-tabler-icons/icons';
-import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { NgTemplateOutlet } from '@angular/common';
 
 // Define filter options for pull requests
-const PR_FILTER_OPTIONS = [
-  { name: 'Open pull requests', value: 'OPEN' },
-  { name: 'All pull requests', value: 'ALL' },
-  { name: 'Open and ready for review', value: 'OPEN_READY_FOR_REVIEW' },
-  { name: 'Draft pull requests', value: 'DRAFT' },
-  { name: 'Merged pull requests', value: 'MERGED' },
-  { name: 'Closed pull requests', value: 'CLOSED' },
-  { name: 'Your pull requests', value: 'USER_AUTHORED' },
-  { name: 'Everything assigned to you', value: 'ASSIGNED_TO_USER' },
-  { name: 'Everything that requests a review by you', value: 'REVIEW_REQUESTED' },
-];
+export function createPullRequestFilterOptions(keycloakService: KeycloakService): PaginatedFilterOption[] {
+  const isLoggedIn = keycloakService.isLoggedIn();
+
+  const baseOptions: PaginatedFilterOption[] = [
+    { name: 'Open pull requests', value: 'OPEN' },
+    { name: 'All pull requests', value: 'ALL' },
+    { name: 'Open and ready for review', value: 'OPEN_READY_FOR_REVIEW' },
+    { name: 'Draft pull requests', value: 'DRAFT' },
+    { name: 'Merged pull requests', value: 'MERGED' },
+    { name: 'Closed pull requests', value: 'CLOSED' },
+  ];
+
+  const userOptions: PaginatedFilterOption[] = [
+    { name: 'Your pull requests', value: 'USER_AUTHORED' },
+    { name: 'Everything assigned to you', value: 'ASSIGNED_TO_USER' },
+    { name: 'Everything that requests a review by you', value: 'REVIEW_REQUESTED' },
+  ];
+
+  return isLoggedIn ? [...baseOptions, ...userOptions] : baseOptions;
+}
 
 @Component({
   selector: 'app-pull-request-table',
@@ -61,7 +70,7 @@ const PR_FILTER_OPTIONS = [
   ],
   providers: [
     PaginatedTableService,
-    { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useValue: PR_FILTER_OPTIONS },
+    { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createPullRequestFilterOptions, deps: [KeycloakService] },
     provideTablerIcons({
       IconFilterPlus,
       IconPoint,

--- a/client/src/app/pages/pull-request-list/pull-request-list.spec.ts
+++ b/client/src/app/pages/pull-request-list/pull-request-list.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PullRequestListComponent } from './pull-request-list.component';
 import { importProvidersFrom } from '@angular/core';
 import { TestModule } from '@app/test.module';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption } from '@app/core/services/paginated-table.service';
 
 describe('Integration Test Pull Request List Page', () => {
   let component: PullRequestListComponent;
@@ -10,7 +12,24 @@ describe('Integration Test Pull Request List Page', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PullRequestListComponent],
-      providers: [importProvidersFrom(TestModule)],
+      providers: [
+        importProvidersFrom(TestModule),
+        // Mock KeycloakService
+        {
+          provide: KeycloakService,
+          useValue: {
+            isLoggedIn: () => false,
+          },
+        },
+        // Provide filtered options through a factory
+        {
+          provide: PAGINATED_FILTER_OPTIONS_TOKEN,
+          useFactory: (): PaginatedFilterOption[] => {
+            return [{ name: 'Open pull requests', value: 'OPEN' }];
+          },
+          deps: [KeycloakService],
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PullRequestListComponent);


### PR DESCRIPTION
### Motivation
Refer to https://github.com/ls1intum/Helios/issues/416

### Description
- If user logged in show user related filters, either show base ones
- Since we persist filter selection in the local storage, when loading the localstorage if any user related filters detected then do not set it and default to ALL prs

### Screenshots
