### PR TITLE
chore: configure `de.tum.cit.aet.helios` logging to `DEBUG`

### DIFF
--- a/server/application-server/build.gradle
+++ b/server/application-server/build.gradle
@@ -120,6 +120,26 @@ tasks.register("bootRunDev", BootRun) {
     mainClass.set("de.tum.cit.aet.helios.HeliosApplication")
 }
 
+tasks.register("bootRunStaging", BootRun) {
+    jvmArgs = ["-javaagent:${configurations.runtimeAgent1.asPath}", "-javaagent:${configurations.runtimeAgent2.asPath}"]
+    group = "application"
+    description = "Runs the Spring Boot application with the staging profile"
+    // Set the active profile to 'staging'
+    systemProperty "spring.profiles.active", "staging"
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass.set("de.tum.cit.aet.helios.HeliosApplication")
+}
+
+tasks.register("bootRunProd", BootRun) {
+    jvmArgs = ["-javaagent:${configurations.runtimeAgent1.asPath}", "-javaagent:${configurations.runtimeAgent2.asPath}"]
+    group = "application"
+    description = "Runs the Spring Boot application with the prod profile"
+    // Set the active profile to 'prod'
+    systemProperty "spring.profiles.active", "prod"
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass.set("de.tum.cit.aet.helios.HeliosApplication")
+}
+
 tasks.named("test") {
     group = "application"
     description = "Runs the Spring Boot application with the test profile"

--- a/server/application-server/src/main/resources/application-prod.yml
+++ b/server/application-server/src/main/resources/application-prod.yml
@@ -33,6 +33,10 @@ helios:
               secretKey: ${HELIOS_STAGING_SECRET_KEY:}
     clientBaseUrl: "https://helios.aet.cit.tum.de"
 
+logging:
+    level:
+        de.tum.cit.aet.helios: DEBUG
+
 nats:
     enabled: true
     timeframe: ${MONITORING_TIMEFRAME:7}

--- a/server/application-server/src/main/resources/application-staging.yml
+++ b/server/application-server/src/main/resources/application-staging.yml
@@ -33,6 +33,10 @@ helios:
               secretKey: ${HELIOS_STAGING_SECRET_KEY:}
     clientBaseUrl: "https://helios-staging.aet.cit.tum.de"
 
+logging:
+    level:
+        de.tum.cit.aet.helios: DEBUG
+
 nats:
     enabled: true
     timeframe: ${MONITORING_TIMEFRAME:7}


### PR DESCRIPTION
### Motivation
Since we added the `helios-status-spring-starter` library, it included its own `logback-spring.xml` that set all `de.tum.cit.aet.helios` Loggers to `ERROR`. Because our code uses the same package path, we weren’t seeing any `DEBUG` output (Connect to staging and check out the logs). By specifying:
  
```yaml
  logging:
    level:
      de.tum.cit.aet.helios: DEBUG
```

in `application.yml`, we ensure our Helios classes log at `DEBUG`.