### PR TITLE
feat: skip repo-confirmation step for TEST environments

### DIFF
--- a/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.html
+++ b/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.html
@@ -75,8 +75,8 @@
         <br />
       }
 
-      <!-- Repository confirmation -->
-      @if (environment().repository?.nameWithOwner) {
+      <!-- ONLY show 'Repository confirmation' block if type !== 'TEST' -->
+      @if (environment().type !== 'TEST' && environment().repository?.nameWithOwner) {
         <div class="mt-4 text-sm space-y-1">
           <p>
             To confirm, type <code class="font-semibold">{{ environment().repository?.nameWithOwner }}</code> below
@@ -103,7 +103,7 @@
         type="button"
         label="Deploy"
         class="ml-2"
-        [disabled]="query.isPending() || (environment().repository?.nameWithOwner && repoConfirm !== environment().repository?.nameWithOwner)"
+        [disabled]="query.isPending() || (environment().type !== 'TEST' && environment().repository?.nameWithOwner && repoConfirm !== environment().repository?.nameWithOwner)"
         (click)="onDeploy()"
       ></button>
     </div>


### PR DESCRIPTION
### Motivation
Currently, every deployment requires the user to type the repository’s full “nameWithOwner” before the “Deploy” button becomes enabled. For `TEST` environments, we want to streamline the flow by removing this extra confirmation step and allowing an immediate deploy.

![image](https://github.com/user-attachments/assets/88845189-c945-401b-9578-0bc5bfbc4359)
![image](https://github.com/user-attachments/assets/85bc3db0-40f9-4fe8-8a6a-aff827b9e16c)


