### PR TITLE
docs: update production nginx/certificate section & update admin troubleshooting

### DIFF
--- a/docs/contributor/setup.rst
+++ b/docs/contributor/setup.rst
@@ -3,7 +3,7 @@ Setup Guide
 ====================
 
 This guide focuses on setting up the Helios application on your local machine. The following sections will walk you through the necessary steps to install the required dependencies and run the application.
-The production setup is covered in the `Production Setup Guide <production_setup.html>`_.
+The production setup is covered in the `Production Setup Guide <../admin/setup.html>`_.
 
 
 Prerequisites

--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -1,0 +1,121 @@
+# Main configuration directives
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+# Events block
+events {
+    worker_connections 1024;
+}
+
+# HTTP block
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Docker's internal DNS resolver
+    # When the compose is restarted, the IP addresses of the services might change
+    # This is required for resolving the service names to their IP addresses
+    resolver 127.0.0.11 ipv6=off;
+
+    # SSL Settings
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    # First server block for HTTPS
+    server {
+        listen 443 ssl;
+        server_name helios.aet.cit.tum.de;
+
+        ssl_certificate /var/lib/rbg-cert/live/host:f:asevm84.cit.tum.de.fullchain.pem;
+        ssl_certificate_key /var/lib/rbg-cert/live/host:f:asevm84.cit.tum.de.privkey.pem;
+
+
+        location / {
+            # Forward to webapp on port 80
+            proxy_pass http://client:80;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Proxy API requests
+        location /api {
+            proxy_pass http://application-server:8080;  # Forward to application server
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Proxy Keycloak requests
+        location ~* ^/(realms|resources|robots\.txt) {
+            proxy_pass http://keycloak:8081;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # Keycloak admin console
+        location /admin {
+            proxy_pass http://keycloak:8081/admin;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Port 443;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        location /github {
+            # Only allow POST requests
+            limit_except POST {
+                deny all;
+            }
+
+            # Validate required GitHub headers
+            set $valid_headers 1;
+
+            if ($http_x_github_event = "") {
+                set $valid_headers 0;
+            }
+            if ($http_x_github_delivery = "") {
+                set $valid_headers 0;
+            }
+            if ($http_x_hub_signature_256 = "") {
+                set $valid_headers 0;
+            }
+
+            # Deny access if headers are invalid
+            if ($valid_headers = 0) {
+                return 403;
+            }
+
+            # Forward to the webhook listener service
+            proxy_pass http://webhook-listener:4200;  # Forward to webhook listener on port 4200
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+        }
+    }
+
+    # Second server block for HTTP to HTTPS redirection
+    server {
+        listen 80;
+        server_name helios.aet.cit.tum.de;
+
+        return 301 https://$host$request_uri;
+    }
+}

--- a/nginx.staging.conf
+++ b/nginx.staging.conf
@@ -27,10 +27,10 @@ http {
     # First server block for HTTPS
     server {
         listen 443 ssl;
-        server_name helios.aet.cit.tum.de;
+        server_name helios-staging.aet.cit.tum.de;
 
-        ssl_certificate $SSL_CERT_PATH;
-        ssl_certificate_key $SSL_KEY_PATH;
+        ssl_certificate /var/lib/rbg-cert/live/host:f:asevm90.cit.tum.de.fullchain.pem;
+        ssl_certificate_key /var/lib/rbg-cert/live/host:f:asevm90.cit.tum.de.privkey.pem;
 
 
         location / {
@@ -114,7 +114,7 @@ http {
     # Second server block for HTTP to HTTPS redirection
     server {
         listen 80;
-        server_name helios.aet.cit.tum.de;
+        server_name helios-staging.aet.cit.tum.de;
 
         return 301 https://$host$request_uri;
     }


### PR DESCRIPTION
- Update nginx related sections with the new certificates managed by ITG
- Add `redeploy of helios from github` section to the admin troubleshooting guide