### PR TITLE
feat(library): remove okhttp dependency and use spring boot's `RestClient`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 
 # Helios 🌞
 
+[![Helios latest](https://img.shields.io/github/v/tag/ls1intum/Helios?label=Helios%20latest&sort=semver&filter=v*)](https://github.com/ls1intum/Helios/releases/latest)
+[![helios-status-spring-starter latest](https://img.shields.io/maven-central/v/de.tum.cit.aet/helios-status-spring-starter.svg?label=helios-status-spring-starter%20latest)](https://central.sonatype.com/artifact/de.tum.cit.aet/helios-status-spring-starter)
 [![Build and Deploy to Prod](https://github.com/ls1intum/Helios/actions/workflows/prod.yml/badge.svg?branch=main)](https://github.com/ls1intum/Helios/actions/workflows/prod.yml)
 [![Deploy to Staging](https://github.com/ls1intum/Helios/actions/workflows/staging.yml/badge.svg?branch=staging)](https://github.com/ls1intum/Helios/actions/workflows/staging.yml)
 [![Tests](https://github.com/ls1intum/Helios/actions/workflows/test.yml/badge.svg?branch=staging)](https://github.com/ls1intum/Helios/actions/workflows/test.yml)
 [![Documentation](https://github.com/ls1intum/Helios/actions/workflows/docs.yml/badge.svg?branch=staging)](https://github.com/ls1intum/Helios/actions/workflows/docs.yml)
 [![Codacy Code Quality Badge](https://app.codacy.com/project/badge/Grade/c9a08eed385c43808b0e317505f5272d)](https://app.codacy.com/gh/ls1intum/Helios/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Codacy Coverage Badge](https://app.codacy.com/project/badge/Coverage/c9a08eed385c43808b0e317505f5272d)](https://app.codacy.com/gh/ls1intum/Helios/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
-[![Latest version)](https://img.shields.io/github/v/tag/ls1intum/Helios?label=%20Latest%20version&sort=semver)](https://github.com/ls1intum/Helios/releases/latest)
 [![License](https://img.shields.io/github/license/ls1intum/Helios)](https://github.com/ls1intum/Helios/blob/staging/LICENSE)
 
 

--- a/server/helios-status-spring-starter/CHANGELOG.md
+++ b/server/helios-status-spring-starter/CHANGELOG.md
@@ -6,8 +6,9 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
   For each pull-request touching the starter, update the *Unreleased* section.
   When cutting an official release:
     1. Move changes from *Unreleased* to a new, dated version heading.
-    2. Bump the version in pom.xml and commit both files together.
-    3. Tag the commit:  git tag -a helios-starter-vX.Y.Z -m "Helios starter X.Y.Z"
+    2. Use ISO 8601 date format — YYYY-MM-DD — for every released section header.
+    3. Bump the version in pom.xml and commit both files together.
+    4. After PR is merged, tag the commit:  git tag -a helios-starter-vX.Y.Z -m "Helios starter X.Y.Z"
 -->
 
 ## [Unreleased]
@@ -28,7 +29,7 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
 
 ---
 
-## [1.1.0] – 2025-07-07
+## [1.1.0] – 2025-07-08
 ### Added
 - **Dependency:** `org.springframework:spring-web` (pulled in transitively by many apps, but now
   declared explicitly so the starter compiles standalone).
@@ -53,9 +54,9 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
 
 ---
 
-## [1.0.0] – 2024-12-04
+## [1.0.0] – 2025-05-30
 ### Added
-- First public release extracted from the Helios monorepo.  
+- First public release.  
   Features:
     - Auto-configuration (`@AutoConfiguration`) + YAML support.
     - OkHttp-based async / sync status pushes.

--- a/server/helios-status-spring-starter/CHANGELOG.md
+++ b/server/helios-status-spring-starter/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog – Helios Status Spring Boot Starter
+All notable changes to this module are documented here.  
+The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Semantic Versioning 2.0.0]**.
+
+<!--
+  For each pull-request touching the starter, update the *Unreleased* section.
+  When cutting an official release:
+    1. Move changes from *Unreleased* to a new, dated version heading.
+    2. Bump the version in pom.xml and commit both files together.
+    3. Tag the commit:  git tag -a helios-starter-vX.Y.Z -m "Helios starter X.Y.Z"
+-->
+
+## [Unreleased]
+### Added
+- _(nothing yet)_
+### Changed
+- _(nothing yet)_
+### Deprecated
+- _(nothing yet)_
+### Removed
+- _(nothing yet)_
+### Fixed
+- _(nothing yet)_
+### Security
+- _(nothing yet)_
+### Migration notes
+- _(nothing yet)_
+
+---
+
+## [1.1.0] – 2025-07-07
+### Added
+- **Dependency:** `org.springframework:spring-web` (pulled in transitively by many apps, but now
+  declared explicitly so the starter compiles standalone).
+- **HTTP client:** now uses Spring Framework’s **`RestClient`** which Boot auto-configures and
+  exposes via `RestClient.Builder`.
+
+### Changed
+- **Async delivery:** OkHttp’s dispatcher was replaced with  
+  `CompletableFuture.runAsync(…, singleThreadExecutor)` + `orTimeout(10 s)`.  
+  Behaviour is identical: one daemon thread, bounded queue = 10, oldest entry dropped on overflow.
+- **Timeouts:** kept at 5 s connect / 5 s read; overall call timeout enforced at 10 s via
+  `CompletableFuture.orTimeout`.
+
+### Removed
+- **OkHttp 4.x** runtime dependency & its transitive `okio`/`okhttp-logging` jars.
+- All OkHttp-specific code paths (`Request`, `Call`, `Dispatcher`, `MediaType JSON`, etc.).
+
+### Migration notes
+1. No code changes for consumers; the public API of `HeliosClient` is unchanged.
+2. If you had custom `okhttp3` log-level overrides in `application.yml` or `logback.xml`
+   you can delete them—they no longer have any effect.
+
+---
+
+## [1.0.0] – 2024-12-04
+### Added
+- First public release extracted from the Helios monorepo.  
+  Features:
+    - Auto-configuration (`@AutoConfiguration`) + YAML support.
+    - OkHttp-based async / sync status pushes.
+    - Heart-beat every 30 s (configurable).
+    - Package README and comprehensive publishing instructions.
+
+[Unreleased]:   https://github.com/ls1intum/Helios/compare/helios-starter-v1.1.0...HEAD
+[1.1.0]:        https://github.com/ls1intum/Helios/compare/helios-starter-v1.0.0...helios-starter-v1.1.0
+[1.0.0]:        https://github.com/ls1intum/Helios/tree/helios-starter-v1.0.0
+[Keep a Changelog 1.1.0]: https://keepachangelog.com/en/1.1.0/
+[Semantic Versioning 2.0.0]: https://semver.org/spec/v2.0.0.html

--- a/server/helios-status-spring-starter/PACKAGE_README.md
+++ b/server/helios-status-spring-starter/PACKAGE_README.md
@@ -118,9 +118,6 @@ By default, Helios uses SLF4J with these log levels baked into our starter’s `
 
 <!-- INFO so that on application startup you’ll see whether Helios push-updates are enabled or disabled -->
 <logger name="de.tum.cit.aet.helios.autoconfig.HeliosStatusAutoConfiguration" level="INFO"/>
-
-<!-- Silence OkHttp TaskRunner debug spam (our HTTP client’s internal scheduler) -->
-<logger name="okhttp3.internal.concurrent.TaskRunner" level="WARN"/>
 ```
 
 If you supply your own `logback-spring.xml` (or `logback.xml`), your settings simply override these.
@@ -132,17 +129,7 @@ logging:
   level:
     de.tum.cit.aet.helios: DEBUG # overrides the ERROR default
     de.tum.cit.aet.helios.autoconfig.HeliosStatusAutoConfiguration: INFO
-    okhttp3.internal.concurrent.TaskRunner: WARN # silence OkHttp debug spam
 ```
-
-> **Why suppress TaskRunner?**
-> 
-> Our client uses OkHttp’s single-threaded **TaskRunner** to schedule background connection-pool maintenance and async status pushes. At **DEBUG** you’ll see a flood of lines like:
-> ```
-> DEBUG … okhttp3.internal.concurrent.TaskRunner : Q10000 scheduled after   0 µs: OkHttp ConnectionPool
-> DEBUG … okhttp3.internal.concurrent.TaskRunner : Q10000 starting              : OkHttp ConnectionPool
-> ```
-> Set it to **WARN** and only real warnings or errors surface.
 
 
 ### What events are sent?

--- a/server/helios-status-spring-starter/README.md
+++ b/server/helios-status-spring-starter/README.md
@@ -162,4 +162,33 @@ For signing artifacts, you need to have a GPG key pair. You can follow this guid
 > **Manual Signing & Validation**
 > Each Central release requires a validator to sign the package. We provide a GitHub Actions template, but you still must trigger deployments manually (or via the dispatch workflow) so a human can review/sign.
 
-If you run into any issues—or if you’re not yet added to the namespace—please reach out to @egekocabas (or @krusche) for assistance.
+### 🔖 Tagging policy & `CHANGELOG.md`
+
+* **Every public release is tagged** `helios-starter-v<MAJOR.MINOR.PATCH>`  
+  (e.g. `helios-starter-v1.1.0`).
+* Copy and populate the **Unreleased** block in `CHANGELOG.md` to a new dated section.
+* Tags can be pushed **only** by members of the *Helios Maintainers* team; the
+  repository has a tag-protection rule to enforce this.
+* Always tag the merge commit that bumps `pom.xml` and `CHANGELOG.md`.
+
+<details>
+<summary>✏️ How to create the tag after the PR is merged & the deploy has run</summary>
+
+```bash
+# 1 – Switch to the merge commit
+git checkout <SHA>
+git pull
+
+# 2 – Confirm you are on the correct commit
+git log -1 # should show the version-bump commit
+
+# 3 – Create an *annotated* tag with a clear message
+git tag -a helios-starter-v1.1.0 \
+         -m "Helios starter 1.1.0 – RestClient replaces OkHttp"
+
+# 4 – Push just the tag
+git push origin helios-starter-v1.1.0
+```
+</details>
+
+If you run into any issues—or if you’re not yet added to the namespace—please reach out to [@egekocabas](https://github.com/egekocabas) (or [@krusche](https://github.com/krusche)) for assistance.

--- a/server/helios-status-spring-starter/pom.xml
+++ b/server/helios-status-spring-starter/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>de.tum.cit.aet</groupId>
     <artifactId>helios-status-spring-starter</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
     <name>Helios Status Spring Starter</name>
     <description>Helios starter for Spring Boot apps – push-based lifecycle status reporting.</description>
@@ -23,7 +23,6 @@
         <spring.boot.version>3.5.0</spring.boot.version>
 
         <!-- dependencies -->
-        <okhttp.version>4.12.0</okhttp.version>
         <lombok.version>1.18.38</lombok.version>
         <slf4j-api.version>2.0.17</slf4j-api.version>
 
@@ -256,15 +255,13 @@
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
         <!-- compileOnly → provided -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/server/helios-status-spring-starter/src/main/java/de/tum/cit/aet/helios/autoconfig/HeliosStatusAutoConfiguration.java
+++ b/server/helios-status-spring-starter/src/main/java/de/tum/cit/aet/helios/autoconfig/HeliosStatusAutoConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestClient;
 
 /**
  * Autoconfiguration class that wires Helios lifecycle monitoring into Spring Boot apps.
@@ -71,8 +72,8 @@ public class HeliosStatusAutoConfiguration {
    * Initializes and provides the shared Helios HTTP client bean.
    */
   @Bean
-  HeliosClient heliosClient(HeliosStatusProperties props) {
-    return new HeliosClient(props);
+  HeliosClient heliosClient(HeliosStatusProperties props, RestClient.Builder builder) {
+    return new HeliosClient(props, builder);
   }
 
   /**

--- a/server/helios-status-spring-starter/src/main/resources/logback-spring.xml
+++ b/server/helios-status-spring-starter/src/main/resources/logback-spring.xml
@@ -10,7 +10,4 @@
     <!-- Set HeliosStatusAutoConfiguration log level as INFO -->
     <!-- Logs at application startup to indicate whether Helios status is enabled. -->
     <logger name="de.tum.cit.aet.helios.autoconfig.HeliosStatusAutoConfiguration" level="INFO"/>
-
-    <!-- Silence OkHttp’s TaskRunner debug spam -->
-    <logger name="okhttp3.internal.concurrent.TaskRunner" level="WARN"/>
 </configuration>


### PR DESCRIPTION
### Motivation
This PR removes the okhttp dependency in helios spring boot starter library. See the new `CHANGELOG.md` file