### PR TITLE
fix: implement environment cleanup in GitHubEnvironmentSyncService

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -56,8 +56,7 @@ public class EnvironmentService {
   private final HeliosDeploymentRepository heliosDeploymentRepository;
   private final ReleaseCandidateRepository releaseCandidateRepository;
   private final DeploymentRepository deploymentRepository;
-  @Lazy
-  private final GitRepoSettingsService gitRepoSettingsService;
+  @Lazy private final GitRepoSettingsService gitRepoSettingsService;
   private final EnvironmentScheduler environmentScheduler;
   private final WorkflowRepository workflowRepository;
   private final ProtectionRuleRepository protectionRuleRepository;
@@ -706,12 +705,14 @@ public class EnvironmentService {
       throw new EntityNotFoundException("GitHub repository not found for repository ID: " + repoId);
     }
     try {
-      List<GitHubEnvironmentDto> gitHubEnvironmentDtoS =
+      List<GitHubEnvironmentDto> gitHubEnvironmentDtos =
           gitHubService.getEnvironments(ghRepository);
 
-      for (GitHubEnvironmentDto gitHubEnvironmentDto : gitHubEnvironmentDtoS) {
+      for (GitHubEnvironmentDto gitHubEnvironmentDto : gitHubEnvironmentDtos) {
         environmentSyncService.processEnvironment(gitHubEnvironmentDto, ghRepository);
       }
+
+      environmentSyncService.removeDeletedEnvironments(gitHubEnvironmentDtos, repoId);
 
     } catch (IOException e) {
       log.error(

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncServiceTest.java
@@ -1,0 +1,110 @@
+package de.tum.cit.aet.helios.environment.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.environment.EnvironmentRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubEnvironmentSyncServiceTest {
+
+  @Mock private EnvironmentRepository environmentRepository;
+
+  @InjectMocks private GitHubEnvironmentSyncService syncService;
+
+  @Test
+  void shouldDeleteEnvironmentNotInGitHub() {
+    GitHubEnvironmentDto env1 = createDto(1L);
+    GitHubEnvironmentDto env2 = createDto(2L);
+    Environment localEnv3 = createEnvironment(3L, "env3");
+
+    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
+        .thenReturn(
+            List.of(createEnvironment(1L, "env1"), createEnvironment(2L, "env2"), localEnv3));
+
+    syncService.removeDeletedEnvironments(List.of(env1, env2), 100L);
+
+    ArgumentCaptor<Environment> captor = ArgumentCaptor.forClass(Environment.class);
+    verify(environmentRepository, times(1)).delete(captor.capture());
+    assertEquals(3L, captor.getValue().getId());
+  }
+
+  @Test
+  void shouldNotDeleteWhenAllExistInGitHub() {
+    GitHubEnvironmentDto env1 = createDto(1L);
+    GitHubEnvironmentDto env2 = createDto(2L);
+
+    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
+        .thenReturn(List.of(createEnvironment(1L, "env1"), createEnvironment(2L, "env2")));
+
+    syncService.removeDeletedEnvironments(List.of(env1, env2), 100L);
+
+    verify(environmentRepository, never()).delete(any());
+  }
+
+  @Test
+  void shouldDeleteMultipleMissingEnvironments() {
+    GitHubEnvironmentDto env1 = createDto(1L);
+
+    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
+        .thenReturn(
+            List.of(
+                createEnvironment(1L, "env1"),
+                createEnvironment(2L, "env2"),
+                createEnvironment(3L, "env3")));
+
+    syncService.removeDeletedEnvironments(List.of(env1), 100L);
+
+    ArgumentCaptor<Environment> captor = ArgumentCaptor.forClass(Environment.class);
+    verify(environmentRepository, times(2)).delete(captor.capture());
+    assertEquals(List.of(2L, 3L), captor.getAllValues().stream().map(Environment::getId).toList());
+  }
+
+  @Test
+  void shouldDeleteAllWhenGitHubListIsEmpty() {
+    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
+        .thenReturn(List.of(createEnvironment(1L, "env1"), createEnvironment(2L, "env2")));
+
+    syncService.removeDeletedEnvironments(List.of(), 100L);
+
+    verify(environmentRepository, times(2)).delete(any());
+  }
+
+  @Test
+  void shouldNotDeleteWhenLocalListIsEmpty() {
+    GitHubEnvironmentDto env1 = createDto(1L);
+
+    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
+        .thenReturn(List.of());
+
+    syncService.removeDeletedEnvironments(List.of(env1), 100L);
+
+    verify(environmentRepository, never()).delete(any());
+  }
+
+  private GitHubEnvironmentDto createDto(Long id) {
+    GitHubEnvironmentDto dto = new GitHubEnvironmentDto();
+    ReflectionTestUtils.setField(dto, "id", id);
+    return dto;
+  }
+
+  private Environment createEnvironment(Long id, String name) {
+    Environment env = new Environment();
+    env.setId(id);
+    env.setName(name);
+    return env;
+  }
+}


### PR DESCRIPTION
Added a method to remove environments from the local database that no longer exist in GitHub. Updated the EnvironmentService to call this new method and adjusted variable names for clarity. Added unit tests to ensure correct functionality of the environment deletion process.

### Motivation

<!-- Why is this change required? What problem does it solve? -->

When environments are deleted from GitHub, they remain in the Helios local database. This causes inconsistencies between the GitHub repository state and the Helios database, leading to stale environment data that can confuse users and cause issues with environment synchronization.

This change ensures that when environments are synchronized from GitHub, any environments that have been deleted from GitHub are also removed from the local database, maintaining data consistency.

<!-- If it fixes an open issue, please link to the issue here. -->



### Description

<!-- Describe your changes in detail -->

Added environment cleanup functionality to the GitHub environment synchronization process:

- **New method `removeDeletedEnvironments`** in `GitHubEnvironmentSyncService`:
  - Compares environments currently in GitHub with those stored locally for a given repository
  - Identifies and deletes local environments that no longer exist in GitHub
  - Includes comprehensive logging for deleted environments
  - Uses transactional operations to ensure data consistency

- **Updated `EnvironmentService.syncRepositoryEnvironments()`**:
  - Calls the new cleanup method after processing all GitHub environments
  - Ensures deleted environments are removed during each synchronization cycle

- **Code improvements**:
  - Fixed variable naming for clarity (`gitHubEnvironmentDtoS` → `gitHubEnvironmentDtos`)
  - Improved code formatting consistency

- **Comprehensive unit tests**:
  - Tests deletion of single missing environment
  - Tests deletion of multiple missing environments
  - Tests that existing environments are not deleted
  - Tests edge cases (empty GitHub list, empty local list)



### Testing Instructions

<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->

#### Prerequisites:

- GitHub Account with admin/owner access to a repository
- Access to a repository with GitHub environments configured
- Ability to create and delete GitHub environments

#### Flow:

1. Log in to Helios as a Developer or Admin

2. Navigate to Settings for a repository that has GitHub environments configured

3. **Test environment synchronization with existing environments:**
   - Ensure the repository has at least one environment in GitHub
   - Trigger environment synchronization (via the sync button or automatic sync)
   - Verify that all existing environments are synchronized correctly
   - Verify that no environments are deleted if they still exist in GitHub

4. **Test deletion of removed environments:**
   - Note the current environments in Helios for a repository
   - Go to GitHub and delete one or more environments from the repository settings
   - Return to Helios and trigger environment synchronization
   - Verify that:
     - The deleted environments are removed from the Helios database
     - The remaining environments are still present and correctly synchronized
     - Check application logs for deletion messages

5. **Test deletion of all environments:**
   - Delete all environments from a GitHub repository
   - Trigger environment synchronization in Helios
   - Verify that all environments are removed from the Helios database

6. **Test with empty repository:**
   - Use a repository that has never had environments configured
   - Trigger environment synchronization
   - Verify that no errors occur and the sync completes successfully

7. **Verify logging:**
   - Check application logs after synchronization
   - Verify that deletion operations are logged with appropriate information (environment name, ID, repository ID)
   - Verify that summary logs show the number of environments removed

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
