### PR TITLE
feat: add separate log‑level buttons for test result filtering and download options for all/filtered logs

### DIFF
--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.html
@@ -102,15 +102,15 @@
       }
 
       <p-popover #op>
-        <div class="flex flex-col gap-4">
-          <div class="flex flex-col gap-1">
-            @if (showOnlyFailed()) {
-              <p-button severity="secondary" text styleClass="w-full" (click)="toggleShowOnlyFailed()">All tests</p-button>
-              <p-button severity="secondary" styleClass="w-full">Only failed tests</p-button>
-            } @else {
-              <p-button severity="secondary" styleClass="w-full">All tests</p-button>
-              <p-button severity="secondary" text styleClass="w-full" (click)="toggleShowOnlyFailed()">Only failed tests</p-button>
-            }
+        <div class="flex flex-col gap-3">
+          <span class="text-xs uppercase tracking-wide text-muted-color">Result filter</span>
+          <div class="flex gap-2">
+            <p-button size="small" [severity]="!showOnlyFailed() ? 'primary' : 'secondary'" [outlined]="showOnlyFailed()" styleClass="w-full" (click)="setShowOnlyFailed(false)">
+              All tests
+            </p-button>
+            <p-button size="small" [severity]="showOnlyFailed() ? 'primary' : 'secondary'" [outlined]="!showOnlyFailed()" styleClass="w-full" (click)="setShowOnlyFailed(true)">
+              Only failed tests
+            </p-button>
           </div>
         </div>
       </p-popover>
@@ -304,17 +304,25 @@
 
       @if (selectedTestCase()?.systemOut || selectedTestCase()?.suiteSystemOut) {
         <!-- Log Level Filter -->
-        <div class="flex flex-col gap-1 mb-2">
+        <div class="flex flex-col gap-3 mb-3 border border-muted-color rounded-md p-3 bg-surface-100">
           <div class="flex justify-between items-center">
-            <span class="text-sm font-medium">Log Level Filter:</span>
-            <span class="text-sm font-medium" [class]="selectedLogLevel().color">
+            <div class="flex flex-col">
+              <span class="text-sm font-medium">Log Level Filter</span>
+            </div>
+            <span class="text-sm font-semibold" [class]="selectedLogLevel().color">
               {{ selectedLogLevel().label }}
             </span>
           </div>
-          <p-slider [ngModel]="getLogLevelValue()" (ngModelChange)="updateLogLevel($event)" [min]="0" [max]="7" [step]="1"> </p-slider>
-          <div class="flex justify-between text-xs text-gray-500">
-            <span>Higher Severity</span>
-            <span>Lower Severity</span>
+          <div class="flex flex-wrap gap-2">
+            @for (level of logLevels; track level.value) {
+              <p-button
+                size="small"
+                [label]="level.label"
+                [outlined]="getLogLevelValue() !== level.value"
+                [severity]="getLogLevelValue() === level.value ? 'primary' : 'secondary'"
+                (onClick)="updateLogLevel(level.value)"
+              ></p-button>
+            }
           </div>
         </div>
       }
@@ -334,16 +342,38 @@
               }
             }
           </div>
-          <div class="flex justify-end mt-2">
-            <button
-              pButton
-              class="p-button-sm p-button-secondary"
-              (click)="downloadLogs(filteredTestCaseLogs(), selectedTestCase()?.name + '_case_logs.txt')"
-              [disabled]="!filteredTestCaseLogs()"
-            >
-              <i-tabler name="download" class="mr-2"></i-tabler>
-              Download Logs
-            </button>
+          <div class="flex flex-col gap-2 mt-2">
+            <div class="flex flex-wrap items-center gap-2 text-xs text-muted-color">
+              <p-tag
+                [class]="selectedLogLevel().color"
+                severity="secondary"
+                [value]="isLogFilterActive() ? 'Filter applied: ' + selectedLogLevel().label : 'Filter disabled'"
+              ></p-tag>
+            </div>
+            <div class="flex flex-wrap justify-end gap-2">
+              <button
+                pButton
+                type="button"
+                class="p-button-sm p-button-outlined"
+                (click)="downloadLogs(selectedTestCase()?.systemOut || '', selectedTestCase()?.name + '_case_logs.txt')"
+                [disabled]="!selectedTestCase()?.systemOut"
+              >
+                <i-tabler name="download" class="mr-2"></i-tabler>
+                Download All Logs
+              </button>
+              @if (isLogFilterActive()) {
+                <button
+                  pButton
+                  type="button"
+                  class="p-button-sm p-button-secondary"
+                  (click)="downloadLogs(filteredTestCaseLogs(), selectedTestCase()?.name + '_case_logs_filtered.txt')"
+                  [disabled]="!filteredTestCaseLogs()"
+                >
+                  <i-tabler name="download" class="mr-2"></i-tabler>
+                  Download Filtered Logs
+                </button>
+              }
+            </div>
           </div>
         </div>
       }
@@ -363,16 +393,38 @@
               }
             }
           </div>
-          <div class="flex justify-end mt-2">
-            <button
-              pButton
-              class="p-button-sm p-button-secondary"
-              (click)="downloadLogs(filteredTestSuiteLogs(), selectedTestCase()?.name + '_suite_logs.txt')"
-              [disabled]="!filteredTestSuiteLogs()"
-            >
-              <i-tabler name="download" class="mr-2"></i-tabler>
-              Download Logs
-            </button>
+          <div class="flex flex-col gap-2 mt-2">
+            <div class="flex flex-wrap items-center gap-2 text-xs text-muted-color">
+              <p-tag
+                [class]="selectedLogLevel().color"
+                severity="secondary"
+                [value]="isLogFilterActive() ? 'Filter applied: ' + selectedLogLevel().label : 'Filter disabled'"
+              ></p-tag>
+            </div>
+            <div class="flex flex-wrap justify-end gap-2">
+              <button
+                pButton
+                type="button"
+                class="p-button-sm p-button-outlined"
+                (click)="downloadLogs(selectedTestCase()?.suiteSystemOut || '', selectedTestCase()?.name + '_suite_logs.txt')"
+                [disabled]="!selectedTestCase()?.suiteSystemOut"
+              >
+                <i-tabler name="download" class="mr-2"></i-tabler>
+                Download All Logs
+              </button>
+              @if (isLogFilterActive()) {
+                <button
+                  pButton
+                  type="button"
+                  class="p-button-sm p-button-secondary"
+                  (click)="downloadLogs(filteredTestSuiteLogs(), selectedTestCase()?.name + '_suite_logs_filtered.txt')"
+                  [disabled]="!filteredTestSuiteLogs()"
+                >
+                  <i-tabler name="download" class="mr-2"></i-tabler>
+                  Download Filtered Logs
+                </button>
+              }
+            </div>
           </div>
         </div>
       }

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -106,6 +106,8 @@ const LOG_LEVELS: LogLevel[] = [
 export class PipelineTestResultsComponent {
   selector = input<PipelineSelector | null>();
 
+  readonly logLevels = LOG_LEVELS;
+
   testSuiteRows = signal(10);
   testSuiteFirst = signal(0);
   activeTestTypeTab = signal(0);
@@ -131,6 +133,8 @@ export class PipelineTestResultsComponent {
     const level = this.selectedLogLevel();
     return level.includes;
   });
+
+  isLogFilterActive = computed(() => this.selectedLogLevelValue() !== LOG_LEVELS.length - 1);
 
   // Function to filter logs by level
   filterLogsByLevel(text: string | undefined): string {
@@ -309,8 +313,11 @@ export class PipelineTestResultsComponent {
     this.op().toggle(event);
   }
 
-  toggleShowOnlyFailed() {
-    this.showOnlyFailed.set(!this.showOnlyFailed());
+  setShowOnlyFailed(value: boolean) {
+    if (this.showOnlyFailed() === value) {
+      return;
+    }
+    this.showOnlyFailed.set(value);
     this.testSuiteFirst.set(0);
   }
 


### PR DESCRIPTION
Feature: add separate log‑level buttons for test result filtering and download options for all/filtered logs

<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This task is implemented to enhance user experience in Test Results Filtering / Downloading modal view. This task refers to the open issue #705 . 

### Description
<!-- Describe your changes in detail -->
There are three changes:
1. Test Results filter dropdown's style has been improved.
2. Test Details modal view had the log level slider before. The slider has been replaced with separate buttons to improve UI/UX.
3. A text filter has been added to indicate whether the filter is applied or not. Additional download button has been added. Now there are two download options for both all logs and filtered logs. 

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- A branch or pull request with at least one pipeline and test results.

#### Flow:
1. Log in to Helios as a Developer
2. Navigate to a repository
3. Go to the Branches tab
4. Click on a branch name to view branch details
5. Expand Test Results and click on the filter dropdown to see the new style.
6. Open Test Details modal by clicking on the Details button.
7. Click on the log level buttons to filter the logs.
8. See the two download buttons below.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1461" height="622" alt="Screenshot 2025-11-28 at 10 53 15" src="https://github.com/user-attachments/assets/5eeeca96-cb2c-41ac-95f2-3c34e301fd0e" />
<figcaption><i>Fig. 1: New style of Test Results filter dropdown</i></figcaption>

<img width="1254" height="812" alt="Screenshot 2025-11-28 at 10 51 53" src="https://github.com/user-attachments/assets/b6c3284d-4a25-4922-abcf-3465042f0f44" />
<figcaption><i>Fig. 2: Example screenshot of Test Details modal when a filter is applied</i></figcaption>

<img width="786" height="734" alt="Screenshot 2025-11-28 at 10 52 36" src="https://github.com/user-attachments/assets/85176603-e098-453e-bbbf-ac2f238e475f" />
<figcaption><i>Fig. 3: Example screenshot of Test Details modal when a filter is not applied</i></figcaption>

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.