### PR TITLE
fix: enable admin-fine-grained-authz v1 feature in keycloak to use to…

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -179,7 +179,7 @@ services:
       - postgres
     volumes:
       - ./helios-realm.json:/opt/keycloak/data/import/prod-realm-export.json
-    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true --features="token-exchange,admin-fine-grained-authz"
+    command: start-dev --import-realm --http-port=8081 --proxy-headers xforwarded --hostname-strict=true --features="token-exchange,admin-fine-grained-authz:v1"
     networks:
       - helios-network
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,7 +50,7 @@ services:
     # If you have an existing realm JSON, mount it here; otherwise skip the volume and import flags
     volumes:
       - ./helios-example-realm.json:/opt/keycloak/data/import/dev-realm-export.json
-    command: start-dev --import-realm --http-port=8081 --features="token-exchange,admin-fine-grained-authz"
+    command: start-dev --import-realm --http-port=8081 --features="token-exchange,admin-fine-grained-authz:v1"
     networks:
       - helios-network
 


### PR DESCRIPTION
[fix/keycloak-token-exchange](fix: enable admin-fine-grained-authz v1 feature in keycloak to use token exchange)

<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Token-exchange feature is not working in the production. We cannot configure this feature via dashboard because admin-fine-grained-authz v1 is not enabled.

### Description
<!-- Describe your changes in detail -->
Token-exchange feature is not working in the production. We cannot configure this feature via dashboard because admin-fine-grained-authz v1 is not enabled. This feature is required for auto-approval of deployments.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Flow:
1. Open Keycloak.
2. Login with admin user.
3. Go to the Users menu.
4. In this menu, verify if you can see Permissions tab.
5. Enable Permissions and configure impersonation as explain in the document.
6. Send token-exchange request via postman and verify if you can receive a token.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
