### PR TITLE
fix: set keycloak log levels to info

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -165,9 +165,6 @@ services:
     image: ghcr.io/ls1intum/helios/keycloak:${KEYCLOAK_IMAGE_TAG}
     container_name: keycloak
     environment:
-      KC_LOG_LEVEL: "INFO,org.keycloak:DEBUG,org.keycloak.services:TRACE,org.keycloak.protocol.oidc:DEBUG,org.keycloak.events:DEBUG"
-      KC_FEATURES: "log-mdc"
-      KC_LOG_MDC_ENABLED: "true"
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD}
       KC_DB: postgres

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,9 +36,6 @@ services:
       context: keycloakify
     container_name: keycloak
     environment:
-      KC_LOG_LEVEL: "INFO,org.keycloak:DEBUG,org.keycloak.services:TRACE,org.keycloak.protocol.oidc:DEBUG,org.keycloak.events:DEBUG"
-      KC_FEATURES: "log-mdc"
-      KC_LOG_MDC_ENABLED: "true"
       KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
       KC_DB: postgres


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->
fix: set keycloak log levels to info

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Keycloak log level is set back to INFO. We don't need DEBUG any more.