### PR TITLE
fix: how to add repository popup fix

### DIFF
--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -141,7 +141,7 @@
         <!-- Add this section for the action button -->
         @if (step.actionButton) {
           <div class="flex justify-center mt-5">
-            <p-button [label]="step.actionButton.label" styleClass="p-button-raised" (onClick)="openExternalLink(step.actionButton.url)">
+            <p-button [label]="step.actionButton.label" styleClass="p-button-raised" [tabindex]="-1" (onClick)="openExternalLink(step.actionButton.url)">
               @if (step.actionButton.icon) {
                 <i-tabler [name]="step.actionButton.icon" class="!size-4" />
               }

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -160,7 +160,7 @@
     }
   </div>
   <div class="flex justify-center">
-    <p-button label="Open full documentation" [link]="true" (onClick)="openExternalLink('https://ls1intum.github.io/Helios/development/production/ls1intum/')" />
+    <p-button label="Open full documentation" [link]="true" (onClick)="openExternalLink('https://ls1intum.github.io/Helios/user_guide/ls1intum/')" />
   </div>
   <ng-template pTemplate="footer">
     <div class="flex justify-between w-full">


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When opening the "How to Add Repository" dialog, the carousel stepper was incorrectly starting at step 3 (the step containing an action button) instead of step 0. This occurred because the action button was receiving autofocus even when its parent carousel item was hidden (aria-hidden="true"), causing the carousel to navigate to that step automatically. This PR fixes the following issue: https://github.com/ls1intum/Helios/issues/840 

Additionally, the full documentation link was not the correct link.

### Description
<!-- Describe your changes in detail -->
- Fixed the carousel starting at the wrong step by setting `tabindex="-1"` on action buttons when they are not in the current active step. This prevents hidden buttons from receiving autofocus and causing the carousel to jump to incorrect steps.
- Updated the documentation link.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Flow:
1. Open Helios
2. Navigate to the repository overview page (main page showing connected repositories)
3. Click the "How to Add Repository" button in the top right
4. Verify that the steps can be displayed in the the following order:
   - Step 1: Define Your GitHub Environments
   - Step 2: Configure Deployment Workflow
   - Step 3: Install the Helios GitHub App
   - Step 4: Configure Repository Settings in Helios
   - Step 5: Configure Environments in Helios
5. Click on the "Open full documentation" button and verify that the official documentation is opened in a new tab.
6. Verify that both Next and Previous buttons works. 
7. Click on different step indicator dots and verify the carousel navigates to the correct step
8. Open browser developer console and verify no autofocus or aria-hidden warnings appear in the console

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1107" height="802" alt="Screenshot 2026-01-26 at 20 16 01" src="https://github.com/user-attachments/assets/bd1fa0c4-694d-4720-879f-2528f59d5ac2" />
<img width="757" height="732" alt="Screenshot 2026-01-26 at 20 16 31" src="https://github.com/user-attachments/assets/34b8d7ca-b4bf-4785-b1e5-d59bb3370dbb" />
<img width="644" height="758" alt="Screenshot 2026-01-26 at 20 16 55" src="https://github.com/user-attachments/assets/f4c95fca-d2ed-4516-923a-00aa3e7683ce" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.