### PR TITLE
feat: add 28-day retention for NATS JetStream streams

### DIFF
--- a/server/webhook-listener/app/main.py
+++ b/server/webhook-listener/app/main.py
@@ -8,8 +8,8 @@ from app.config import settings
 from app.nats_client import nats_client
 
 RETENTION_DAYS = 28
-NANOS_PER_SECOND = 1_000_000_000
-RETENTION_MAX_AGE_NANOS = RETENTION_DAYS * 24 * 60 * 60 * NANOS_PER_SECOND
+SECONDS_PER_DAY = 24 * 60 * 60
+RETENTION_MAX_AGE_SECONDS = RETENTION_DAYS * SECONDS_PER_DAY
 
 
 @asynccontextmanager
@@ -18,12 +18,12 @@ async def lifespan(app: FastAPI):
     await nats_client.js.add_stream(
         name="github",
         subjects=["github.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
     )
     await nats_client.js.add_stream(
         name="notification",
         subjects=["notification.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
     )
     yield
     await nats_client.close()

--- a/server/webhook-listener/app/main.py
+++ b/server/webhook-listener/app/main.py
@@ -8,8 +8,8 @@ from app.config import settings
 from app.nats_client import nats_client
 
 RETENTION_DAYS = 28
-SECONDS_PER_DAY = 24 * 60 * 60
-RETENTION_MAX_AGE_SECONDS = RETENTION_DAYS * SECONDS_PER_DAY
+NANOS_PER_SECOND = 1_000_000_000
+RETENTION_MAX_AGE_NANOS = RETENTION_DAYS * 24 * 60 * 60 * NANOS_PER_SECOND
 
 
 @asynccontextmanager
@@ -18,12 +18,12 @@ async def lifespan(app: FastAPI):
     await nats_client.js.add_stream(
         name="github",
         subjects=["github.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
     )
     await nats_client.js.add_stream(
         name="notification",
         subjects=["notification.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
     )
     yield
     await nats_client.close()

--- a/server/webhook-listener/app/main.py
+++ b/server/webhook-listener/app/main.py
@@ -4,7 +4,9 @@ from contextlib import asynccontextmanager
 from fastapi import Body, FastAPI, HTTPException, Header, Request, status
 from pydantic import BaseModel
 from nats.js.api import StreamConfig
+from nats.js.errors import BadRequestError
 from app.config import settings
+from app.logger import logger
 from app.nats_client import nats_client
 
 RETENTION_DAYS = 28
@@ -12,19 +14,27 @@ SECONDS_PER_DAY = 24 * 60 * 60
 RETENTION_MAX_AGE_SECONDS = RETENTION_DAYS * SECONDS_PER_DAY
 
 
+async def ensure_stream(name: str, subjects: list[str]) -> None:
+    stream_config = StreamConfig(
+        name=name,
+        subjects=subjects,
+        storage="file",
+        max_age=RETENTION_MAX_AGE_SECONDS,
+    )
+    try:
+        await nats_client.js.add_stream(config=stream_config)
+    except BadRequestError as error:
+        if getattr(error, "err_code", None) != 10058:
+            raise
+        await nats_client.js.update_stream(config=stream_config)
+        logger.info(f"Updated existing stream configuration for '{name}'")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await nats_client.connect()
-    await nats_client.js.add_stream(
-        name="github",
-        subjects=["github.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
-    )
-    await nats_client.js.add_stream(
-        name="notification",
-        subjects=["notification.>"],
-        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_SECONDS),
-    )
+    await ensure_stream(name="github", subjects=["github.>"])
+    await ensure_stream(name="notification", subjects=["notification.>"])
     yield
     await nats_client.close()
 

--- a/server/webhook-listener/app/main.py
+++ b/server/webhook-listener/app/main.py
@@ -7,12 +7,24 @@ from nats.js.api import StreamConfig
 from app.config import settings
 from app.nats_client import nats_client
 
+RETENTION_DAYS = 28
+NANOS_PER_SECOND = 1_000_000_000
+RETENTION_MAX_AGE_NANOS = RETENTION_DAYS * 24 * 60 * 60 * NANOS_PER_SECOND
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await nats_client.connect()
-    await nats_client.js.add_stream(name="github", subjects=["github.>"], config=StreamConfig(storage="file"))
-    await nats_client.js.add_stream(name="notification", subjects=["notification.>"], config=StreamConfig(storage="file"))
+    await nats_client.js.add_stream(
+        name="github",
+        subjects=["github.>"],
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
+    )
+    await nats_client.js.add_stream(
+        name="notification",
+        subjects=["notification.>"],
+        config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS),
+    )
     yield
     await nats_client.close()
 


### PR DESCRIPTION
### Motivation
- Limit how long JetStream retains webhook and notification events by configuring a 28-day max age so persisted NATS data does not grow unbounded.
- Centralize retention constants to make the retention policy explicit and reusable when creating streams.

### Description
- Added `RETENTION_DAYS`, `NANOS_PER_SECOND`, and `RETENTION_MAX_AGE_NANOS` constants and computed a `max_age` value in nanoseconds in `server/webhook-listener/app/main.py`.
- Updated JetStream stream creation for the `github` and `notification` streams to set `config=StreamConfig(storage="file", max_age=RETENTION_MAX_AGE_NANOS)`.
- Change is limited to `server/webhook-listener/app/main.py` and does not alter other NATS-related services or compose files.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7eff2a30832b8b0b0c7b59397f85)