### PR TITLE
fix: truncate long titles and names in GitHub issue and workflow run converters

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/issue/github/GitHubIssueConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/issue/github/GitHubIssueConverter.java
@@ -50,7 +50,7 @@ public class GitHubIssueConverter extends BaseGitServiceEntityConverter<GHIssue,
       return value;
     }
     String truncatedValue = value.substring(0, maxLength);
-    log.warn(
+    log.info(
         "Truncated issue field '{}' from {} to {} characters for source {}: '{}'",
         fieldName,
         value.length(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/issue/github/GitHubIssueConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/issue/github/GitHubIssueConverter.java
@@ -3,13 +3,17 @@ package de.tum.cit.aet.helios.issue.github;
 import de.tum.cit.aet.helios.github.BaseGitServiceEntityConverter;
 import de.tum.cit.aet.helios.issue.Issue;
 import de.tum.cit.aet.helios.util.DateUtil;
+import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
+@Log4j2
 @Component
 public class GitHubIssueConverter extends BaseGitServiceEntityConverter<GHIssue, Issue> {
+
+  private static final int MAX_TITLE_LENGTH = 255;
 
   @Override
   public Issue convert(@NonNull GHIssue source) {
@@ -21,7 +25,7 @@ public class GitHubIssueConverter extends BaseGitServiceEntityConverter<GHIssue,
     convertBaseFields(source, issue);
     issue.setNumber(source.getNumber());
     issue.setState(convertState(source.getState()));
-    issue.setTitle(source.getTitle());
+    issue.setTitle(truncate(source.getTitle(), MAX_TITLE_LENGTH, "title", source.getId()));
     issue.setBody(source.getBody());
     issue.setHtmlUrl(source.getHtmlUrl().toString());
     issue.setLocked(source.isLocked());
@@ -39,5 +43,20 @@ public class GitHubIssueConverter extends BaseGitServiceEntityConverter<GHIssue,
       default:
         return Issue.State.CLOSED;
     }
+  }
+
+  private static String truncate(String value, int maxLength, String fieldName, long sourceId) {
+    if (value == null || value.length() <= maxLength) {
+      return value;
+    }
+    String truncatedValue = value.substring(0, maxLength);
+    log.warn(
+        "Truncated issue field '{}' from {} to {} characters for source {}: '{}'",
+        fieldName,
+        value.length(),
+        maxLength,
+        sourceId,
+        truncatedValue);
+    return truncatedValue;
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunConverter.java
@@ -71,7 +71,7 @@ public class GitHubWorkflowRunConverter
       return value;
     }
     String truncatedValue = value.substring(0, maxLength);
-    log.warn(
+    log.info(
         "Truncated workflow run field '{}' from {} to {} characters for source {}: '{}'",
         fieldName,
         value.length(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunConverter.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Component;
 public class GitHubWorkflowRunConverter
     extends BaseGitServiceEntityConverter<GHWorkflowRun, WorkflowRun> {
 
+  private static final int MAX_NAME_AND_TITLE_LENGTH = 255;
+
   @Override
   public WorkflowRun convert(@NonNull GHWorkflowRun source) {
     return update(source, new WorkflowRun());
@@ -23,8 +25,11 @@ public class GitHubWorkflowRunConverter
   @Override
   public WorkflowRun update(@NonNull GHWorkflowRun source, @NonNull WorkflowRun workflowRun) {
     convertBaseFields(source, workflowRun);
-    workflowRun.setName(source.getName());
-    workflowRun.setDisplayTitle(source.getDisplayTitle());
+    workflowRun.setName(
+        truncate(source.getName(), MAX_NAME_AND_TITLE_LENGTH, "name", source.getId()));
+    workflowRun.setDisplayTitle(
+        truncate(workflowRun.getDisplayTitle(), MAX_NAME_AND_TITLE_LENGTH, "displayTitle",
+            source.getId()));
     workflowRun.setRunNumber(source.getRunNumber());
     workflowRun.setRunAttempt(source.getRunAttempt());
     try {
@@ -59,6 +64,21 @@ public class GitHubWorkflowRunConverter
         Optional.ofNullable(source.getConclusion()).map(this::convertConclusion));
 
     return workflowRun;
+  }
+
+  private static String truncate(String value, int maxLength, String fieldName, long sourceId) {
+    if (value == null || value.length() <= maxLength) {
+      return value;
+    }
+    String truncatedValue = value.substring(0, maxLength);
+    log.warn(
+        "Truncated workflow run field '{}' from {} to {} characters for source {}: '{}'",
+        fieldName,
+        value.length(),
+        maxLength,
+        sourceId,
+        truncatedValue);
+    return truncatedValue;
   }
 
   private WorkflowRun.Status convertStatus(GHWorkflowRun.Status status) {


### PR DESCRIPTION
fix: truncate long titles and names in GitHub issue and workflow run converters

<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Some PRs or workflow runs can have titles and names longer than 255 characters. When syncing these via the GitHub API, Helios tries to save them into the database. However, PostgreSQL raises: `ERROR: value too long for type character varying(255)`

This PR fixes issue #866 .  

### Description
<!-- Describe your changes in detail -->
This issue causes sync failures for affected workflow runs (and similarly for issues/PRs with long titles). This change truncates long titles and names to 255 characters in the converters with a warning log. Since long titles/names are actually unusual, I don't prefer changing database schema and increasing the character limit, which can lead to the poor data modeling.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->

#### Flow:
1. First, in your local environment, create a PR with a name longer than 255 character and see the error logs containing `[ERROR: value too long for type character varying(255)]`
2. Then, checkout to this branch and create another PR.
3. In the logs, you should see a warning log containing `Truncated ... field '...' from .. to 255 characters for source ...: ...`
4. Verify than the PR is successfully added to your database.
5. Do the same steps for a workflow.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
