### PR TITLE
fix(auth): use parsed token claims and guard offline GitHub client

### DIFF
--- a/client/src/app/core/services/keycloak/keycloak.service.spec.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { KeycloakService } from './keycloak.service';
+
+describe('KeycloakService', () => {
+  let service: KeycloakService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+    service = TestBed.inject(KeycloakService);
+  });
+
+  it('should read claims from tokenParsed', () => {
+    const keycloakStub = {
+      token: 'header.payload.signature',
+      tokenParsed: {
+        github_id: 123456,
+        preferred_username: 'octocat',
+      },
+    };
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+
+    expect(service.getUserGithubId()).toBe(123456);
+    expect(service.getPreferredUsername()).toBe('octocat');
+  });
+
+  it('should return undefined when tokenParsed is missing', () => {
+    const keycloakStub = {
+      token: 'header.a-b_.signature',
+      tokenParsed: undefined,
+    };
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+
+    expect(() => service.getUserGithubId()).not.toThrow();
+    expect(service.getUserGithubId()).toBeUndefined();
+  });
+});

--- a/client/src/app/core/services/keycloak/keycloak.service.spec.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.spec.ts
@@ -1,18 +1,8 @@
-import { TestBed } from '@angular/core/testing';
-import { provideZonelessChangeDetection } from '@angular/core';
 import { KeycloakService } from './keycloak.service';
 
 describe('KeycloakService', () => {
-  let service: KeycloakService;
-
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [provideZonelessChangeDetection()],
-    });
-    service = TestBed.inject(KeycloakService);
-  });
-
-  it('should read claims from tokenParsed', () => {
+  it('should read tokenParsed claims and handle missing tokenParsed', () => {
+    const service = new KeycloakService();
     const keycloakStub = {
       token: 'header.payload.signature',
       tokenParsed: {
@@ -24,14 +14,11 @@ describe('KeycloakService', () => {
 
     expect(service.getUserGithubId()).toBe(123456);
     expect(service.getPreferredUsername()).toBe('octocat');
-  });
-
-  it('should return undefined when tokenParsed is missing', () => {
-    const keycloakStub = {
+    const keycloakWithoutParsedStub = {
       token: 'header.a-b_.signature',
       tokenParsed: undefined,
     };
-    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakWithoutParsedStub;
 
     expect(() => service.getUserGithubId()).not.toThrow();
     expect(service.getUserGithubId()).toBeUndefined();

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -1,11 +1,24 @@
-import { computed, Injectable } from '@angular/core';
-import Keycloak from 'keycloak-js';
+import { Injectable } from '@angular/core';
+import Keycloak, { KeycloakTokenParsed } from 'keycloak-js';
 import { UserProfile } from './user-profile';
 import { environment } from 'environments/environment';
 @Injectable({
   providedIn: 'root',
 })
 export class KeycloakService {
+  private get tokenClaims(): KeycloakTokenParsed | null {
+    return this.keycloak.tokenParsed ?? null;
+  }
+
+  private getTokenClaim(claim: string): unknown {
+    return this.tokenClaims?.[claim];
+  }
+
+  private getStringTokenClaim(claim: string): string | undefined {
+    const value = this.getTokenClaim(claim);
+    return typeof value === 'string' ? value : undefined;
+  }
+
   private _keycloak: Keycloak | undefined;
 
   get keycloak() {
@@ -21,17 +34,8 @@ export class KeycloakService {
     return this._profile;
   }
 
-  decodedToken = computed(() => {
-    const token = this.keycloak.token;
-    if (!token) {
-      return null;
-    }
-    const [, payload] = token.split('.');
-    return JSON.parse(atob(payload));
-  });
-
   isCurrentUser(login?: string) {
-    return this.decodedToken()?.preferred_username.toLowerCase() === login?.toLowerCase();
+    return this.getPreferredUsername()?.toLowerCase() === login?.toLowerCase();
   }
 
   async init() {
@@ -58,15 +62,16 @@ export class KeycloakService {
   }
 
   getUserId() {
-    return this.decodedToken()?.sub;
+    return this.getStringTokenClaim('sub');
   }
 
   getPreferredUsername(): string | undefined {
-    return this.decodedToken()?.preferred_username;
+    return this.getStringTokenClaim('preferred_username');
   }
 
-  getUserGithubId() {
-    return this.decodedToken()?.github_id;
+  getUserGithubId(): string | number | undefined {
+    const githubId = this.getTokenClaim('github_id');
+    return typeof githubId === 'string' || typeof githubId === 'number' ? githubId : undefined;
   }
 
   getUserGithubProfilePictureUrl(): string {

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -1,24 +1,11 @@
 import { Injectable } from '@angular/core';
-import Keycloak, { KeycloakTokenParsed } from 'keycloak-js';
+import Keycloak from 'keycloak-js';
 import { UserProfile } from './user-profile';
 import { environment } from 'environments/environment';
 @Injectable({
   providedIn: 'root',
 })
 export class KeycloakService {
-  private get tokenClaims(): KeycloakTokenParsed | null {
-    return this.keycloak.tokenParsed ?? null;
-  }
-
-  private getTokenClaim(claim: string): unknown {
-    return this.tokenClaims?.[claim];
-  }
-
-  private getStringTokenClaim(claim: string): string | undefined {
-    const value = this.getTokenClaim(claim);
-    return typeof value === 'string' ? value : undefined;
-  }
-
   private _keycloak: Keycloak | undefined;
 
   get keycloak() {
@@ -62,15 +49,17 @@ export class KeycloakService {
   }
 
   getUserId() {
-    return this.getStringTokenClaim('sub');
+    const sub = this.keycloak.tokenParsed?.sub;
+    return typeof sub === 'string' ? sub : undefined;
   }
 
   getPreferredUsername(): string | undefined {
-    return this.getStringTokenClaim('preferred_username');
+    const preferredUsername = this.keycloak.tokenParsed?.['preferred_username'];
+    return typeof preferredUsername === 'string' ? preferredUsername : undefined;
   }
 
   getUserGithubId(): string | number | undefined {
-    const githubId = this.getTokenClaim('github_id');
+    const githubId = this.keycloak.tokenParsed?.['github_id'];
     return typeof githubId === 'string' || typeof githubId === 'number' ? githubId : undefined;
   }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubClientManager.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubClientManager.java
@@ -156,11 +156,7 @@ public class GitHubClientManager {
     try {
       log.info("Forcing GitHub client refresh...");
       gitHubClient = createGitHubClientWithCache();
-      if (authType == AuthType.APP && gitHubClient != null && !gitHubClient.isOffline()) {
-        fetchGitHubAppNodeId();
-      } else if (authType == AuthType.APP) {
-        log.warn("GitHub client is offline. Skipping GitHub App node ID fetch.");
-      }
+      fetchGitHubAppNodeIdIfAvailable();
       log.info("Forced GitHub client refresh successful");
     } finally {
       lock.unlock();
@@ -174,16 +170,23 @@ public class GitHubClientManager {
       if (gitHubClient == null || Instant.now().isAfter(tokenExpirationTime)) {
         log.info("Refreshing GitHub client...");
         gitHubClient = createGitHubClientWithCache();
-        if (authType == AuthType.APP && gitHubClient != null && !gitHubClient.isOffline()) {
-          fetchGitHubAppNodeId();
-        } else if (authType == AuthType.APP) {
-          log.warn("GitHub client is offline. Skipping GitHub App node ID fetch.");
-        }
+        fetchGitHubAppNodeIdIfAvailable();
         log.info("GitHub client refreshed successfully");
       }
     } finally {
       lock.unlock();
     }
+  }
+
+  private void fetchGitHubAppNodeIdIfAvailable() {
+    if (authType != AuthType.APP) {
+      return;
+    }
+    if (gitHubClient == null || gitHubClient.isOffline()) {
+      log.warn("GitHub client is offline. Skipping GitHub App node ID fetch.");
+      return;
+    }
+    fetchGitHubAppNodeId();
   }
 
   /** Fetches the GitHub App node ID using the app name. */

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubClientManager.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubClientManager.java
@@ -156,8 +156,10 @@ public class GitHubClientManager {
     try {
       log.info("Forcing GitHub client refresh...");
       gitHubClient = createGitHubClientWithCache();
-      if (authType == AuthType.APP) {
+      if (authType == AuthType.APP && gitHubClient != null && !gitHubClient.isOffline()) {
         fetchGitHubAppNodeId();
+      } else if (authType == AuthType.APP) {
+        log.warn("GitHub client is offline. Skipping GitHub App node ID fetch.");
       }
       log.info("Forced GitHub client refresh successful");
     } finally {
@@ -172,8 +174,10 @@ public class GitHubClientManager {
       if (gitHubClient == null || Instant.now().isAfter(tokenExpirationTime)) {
         log.info("Refreshing GitHub client...");
         gitHubClient = createGitHubClientWithCache();
-        if (authType == AuthType.APP) {
+        if (authType == AuthType.APP && gitHubClient != null && !gitHubClient.isOffline()) {
           fetchGitHubAppNodeId();
+        } else if (authType == AuthType.APP) {
+          log.warn("GitHub client is offline. Skipping GitHub App node ID fetch.");
         }
         log.info("GitHub client refreshed successfully");
       }


### PR DESCRIPTION
 ### Motivation
  The auth flow relied on manual JWT payload decoding in `KeycloakService`, which is fragile and can fail on malformed/base64url token payload handling.
  Additionally, `GitHubClientManager` attempted to fetch the GitHub App node ID even when the client was offline, which can cause unnecessary failures during refresh.

  ### Description
  This PR improves auth/token handling and hardens GitHub client refresh logic:

  - Client (`KeycloakService`)
    - Replaced manual token decoding (`atob` + JSON parse) with `keycloak.tokenParsed`.
    - Added typed claim helpers:
      - `getTokenClaim(...)`
      - `getStringTokenClaim(...)`
    - Updated user accessors (`getUserId`, `getPreferredUsername`, `getUserGithubId`) to read from parsed claims safely.
    - Updated `isCurrentUser(...)` to use `getPreferredUsername()`.

  - Client tests
    - Added `keycloak.service.spec.ts` to verify:
      - claims are read from `tokenParsed`
      - missing `tokenParsed` is handled safely without throwing.

  - Server (`GitHubClientManager`)
    - Added guard before `fetchGitHubAppNodeId()`:
      - only fetch when auth type is `APP` and client is not offline.
    - Added warning log when skipped due to offline client.

  ### Testing Instructions
  #### Prerequisites:
  - Local Helios setup running (client + application-server)
  - Access to logs for `application-server`
  - GitHub account without elevated permissions (Developer-level is enough)

  #### Flow:
  1. **Run client tests**
     - Execute client unit tests and confirm `keycloak.service.spec.ts` passes.
     - Verify both scenarios:
       - claims are read from `tokenParsed`
       - missing `tokenParsed` does not throw and returns `undefined` for GitHub ID.

  2. **Manual auth sanity check (local)**
     - Log in to Helios normally.
     - Navigate through views that rely on user identity (where username/profile data is shown).
     - Confirm no runtime errors related to token parsing in browser console.

  3. **Server-side offline guard check (local)**
     - Trigger a GitHub client refresh path (or restart the server and observe initialization/refresh logs).
     - Confirm that when GitHub client is offline, the app does **not** fail on node ID fetch.
     - Verify warning log appears:
       - `GitHub client is offline. Skipping GitHub App node ID fetch.`

  4. **Staging environment verification**
     - Deploy this branch to **staging**.
     - Validate login works end-to-end in staging.
     - Verify no regressions in GitHub integration behavior (especially around refresh/startup).
     - Check staging `application-server` logs for absence of new auth/token parsing errors and confirm expected offline-skip warning behavior if applicable.
   
  ### Checklist
  #### General
  - [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] Changes have been tested locally.
  - [ ] Screenshots have been attached.

  #### Server
  - [x] Code is performant and follows best practices
  - [ ] I documented the Java code using JavaDoc style.

  #### Client
  - [ ] I documented the TypeScript code using JSDoc style.
  - [ ] I added multiple screenshots/screencasts of my UI changes.
  - [ ] I translated all newly inserted strings into English and German.