### PR TITLE
fix(server): handle offline team reviewer sync gracefully

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/github/GitHubPullRequestSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/github/GitHubPullRequestSyncService.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHPullRequest;
@@ -152,10 +153,17 @@ public class GitHubPullRequestSyncService {
             try {
               requestedReviewers.addAll(requestedTeam.getMembers());
             } catch (IOException e) {
-              log.error(
-                  "Failed to link requested reviewers (by team) for pull request {}: {}",
-                  ghPullRequest.getId(),
-                  e.getMessage());
+              if (isOfflineError(e)) {
+                log.debug(
+                    "Skipping team reviewer expansion for pull request {} "
+                        + "because GitHub client is offline.",
+                    ghPullRequest.getId());
+              } else {
+                log.error(
+                    "Failed to link requested reviewers (by team) for pull request {}: {}",
+                    ghPullRequest.getId(),
+                    e.getMessage());
+              }
             }
           });
 
@@ -175,12 +183,24 @@ public class GitHubPullRequestSyncService {
 
       result.setRequestedReviewers(resultRequestedReviewers);
     } catch (IOException e) {
-      log.error(
-          "Failed to link requested reviewers for pull request {}: {}",
-          ghPullRequest.getId(),
-          e.getMessage());
+      if (isOfflineError(e)) {
+        log.debug(
+            "Skipping requested reviewer sync for pull request {} "
+                + "because GitHub client is offline.",
+            ghPullRequest.getId());
+      } else {
+        log.error(
+            "Failed to link requested reviewers for pull request {}: {}",
+            ghPullRequest.getId(),
+            e.getMessage());
+      }
     }
 
     pullRequestRepository.save(result);
+  }
+
+  static boolean isOfflineError(IOException e) {
+    var message = e.getMessage();
+    return message != null && message.toLowerCase(Locale.ROOT).contains("offline");
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/github/GitHubPullRequestSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/github/GitHubPullRequestSyncServiceTest.java
@@ -1,0 +1,27 @@
+package de.tum.cit.aet.helios.pullrequest.github;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubPullRequestSyncServiceTest {
+
+  @Test
+  void isOfflineErrorReturnsTrueWhenMessageMatches() {
+    IOException exception = new IOException("Offline");
+
+    assertTrue(GitHubPullRequestSyncService.isOfflineError(exception));
+  }
+
+  @Test
+  void isOfflineErrorReturnsFalseForOtherMessages() {
+    IOException exception = new IOException("Bad credentials");
+
+    assertFalse(GitHubPullRequestSyncService.isOfflineError(exception));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

  ### Motivation

  Issue #860 reports repeated server error logs when team reviewer expansion runs while the GitHub client is offline. These logs are noisy and misleading because offline mode can
  be an expected runtime state.

  ### Description

  Updated pull request sync logic to treat offline reviewer-team expansion failures as expected behavior instead of hard errors.

  Changes:

  - In GitHubPullRequestSyncService, added isOfflineError(IOException) to classify offline errors.
  - For offline reviewer expansion failures, log at DEBUG and continue sync.
  - Kept ERROR logging for non-offline failures.
  - Added unit tests for offline error classification in GitHubPullRequestSyncServiceTest.

  ### Testing Instructions

  #### Prerequisites:

  - Java 21
  - Gradle wrapper available (./gradlew)
  - Checked out branch fix/860-offline-reviewer-sync

  #### Flow:

  1. Run:
     ./gradlew :application-server:test --tests de.tum.cit.aet.helios.pullrequest.github.GitHubPullRequestSyncServiceTest
  2. Verify tests pass.
  3. Optionally run:
     ./gradlew :application-server:test --tests de.tum.cit.aet.helios.branch.github.GitHubBranchComparisonServiceTest
  4. Inspect GitHubPullRequestSyncService and confirm offline cases are handled via debug logging while other IO failures remain error-level.

  ### Screenshots

  No UI changes were made.

  ### Checklist

  #### General

  - [x] PR description explains the purpose and changes. (f.e. following the 'Conventional Commits') (https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] Changes have been tested locally.

  #### Server

  - [x] Code is performant and follows best practices
