### PR TITLE
fix(github): handle Copilot actor without user profile fetch

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/branch/github/GitHubBranchSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/branch/github/GitHubBranchSyncService.java
@@ -94,7 +94,9 @@ public class GitHubBranchSyncService {
                 .findById(updatedBy.getId())
                 .orElseGet(() -> userRepository.save(userConverter.convert(updatedBy)));
         result.setUpdatedBy(resultUpdatedBy);
-        result.setUpdatedAt(DateUtil.convertToOffsetDateTime(updatedBy.getUpdatedAt()));
+        result.setUpdatedAt(
+            DateUtil.convertToOffsetDateTime(
+                ghRepository.getCommit(ghBranch.getSHA1()).getCommitShortInfo().getCommitDate()));
       }
     } catch (IOException e) {
       log.error(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
@@ -58,61 +58,19 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
     user.setAvatarUrl(source.getAvatarUrl());
     user.setDescription(source.getBio());
     user.setHtmlUrl(source.getHtmlUrl().toString());
-    try {
-      user.setName(source.getName() != null ? source.getName() : source.getLogin());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user name field for source {}: {}", source.getId(), e.getMessage());
-      user.setName(source.getLogin());
-    }
-    try {
-      user.setCompany(source.getCompany());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user company field for source {}: {}", source.getId(), e.getMessage());
-    }
-    try {
-      user.setBlog(source.getBlog());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user blog field for source {}: {}", source.getId(), e.getMessage());
-    }
-    try {
-      user.setLocation(source.getLocation());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user location field for source {}: {}",
-          source.getId(),
-          e.getMessage());
-    }
-    try {
-      user.setEmail(source.getEmail());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user email field for source {}: {}", source.getId(), e.getMessage());
-    }
-    try {
-      user.setType(convertUserType(source.getType()));
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user type field for source {}: {}", source.getId(), e.getMessage());
-    }
-    try {
-      user.setFollowers(source.getFollowersCount());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user followers field for source {}: {}",
-          source.getId(),
-          e.getMessage());
-    }
-    try {
-      user.setFollowing(source.getFollowingCount());
-    } catch (IOException e) {
-      log.error(
-          "Failed to convert user following field for source {}: {}",
-          source.getId(),
-          e.getMessage());
-    }
+    user.setName(
+        readUserField(
+            source,
+            "name",
+            () -> source.getName() != null ? source.getName() : source.getLogin(),
+            source.getLogin()));
+    user.setCompany(readUserField(source, "company", source::getCompany, null));
+    user.setBlog(readUserField(source, "blog", source::getBlog, null));
+    user.setLocation(readUserField(source, "location", source::getLocation, null));
+    user.setEmail(readUserField(source, "email", source::getEmail, null));
+    user.setType(readUserField(source, "type", () -> convertUserType(source.getType()), Type.USER));
+    user.setFollowers(readUserField(source, "followers", source::getFollowersCount, 0));
+    user.setFollowing(readUserField(source, "following", source::getFollowingCount, 0));
     return user;
   }
 
@@ -147,6 +105,25 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
     }
 
     return "copilot".equals(login.toLowerCase(Locale.ROOT));
+  }
+
+  private <T> T readUserField(
+      @NonNull GHUser source, String fieldName, IoFieldReader<T> reader, T fallback) {
+    try {
+      return reader.read();
+    } catch (IOException e) {
+      log.error(
+          "Failed to convert user {} field for source {}: {}",
+          fieldName,
+          source.getId(),
+          e.getMessage());
+      return fallback;
+    }
+  }
+
+  @FunctionalInterface
+  private interface IoFieldReader<T> {
+    T read() throws IOException;
   }
 
   private User.Type convertUserType(String type) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
@@ -5,6 +5,7 @@ import de.tum.cit.aet.helios.user.User;
 import de.tum.cit.aet.helios.user.User.Type;
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.Locale;
 import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHUser;
 import org.springframework.lang.NonNull;
@@ -48,6 +49,10 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
 
   @Override
   public User update(@NonNull GHUser source, @NonNull User user) {
+    if (isCopilotActorLogin(source.getLogin())) {
+      return updateFromCopilotActor(source, user);
+    }
+
     convertBaseFields(source, user);
     user.setLogin(source.getLogin());
     user.setAvatarUrl(source.getAvatarUrl());
@@ -109,6 +114,39 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
           e.getMessage());
     }
     return user;
+  }
+
+  private User updateFromCopilotActor(@NonNull GHUser source, @NonNull User user) {
+    var now = OffsetDateTime.now();
+
+    user.setId(source.getId());
+    user.setCreatedAt(user.getCreatedAt() != null ? user.getCreatedAt() : now);
+    user.setUpdatedAt(now);
+    user.setLogin(source.getLogin());
+    user.setAvatarUrl(source.getAvatarUrl());
+    user.setDescription("Copilot bot actor from GitHub metadata.");
+    user.setName("GitHub Copilot");
+    user.setCompany(null);
+    user.setBlog(null);
+    user.setLocation(null);
+    user.setEmail(null);
+    user.setHtmlUrl("https://github.com/apps/copilot");
+    user.setType(Type.BOT);
+    user.setFollowers(0);
+    user.setFollowing(0);
+
+    log.warn(
+        "Resolved Copilot actor '{}' without fetching /users endpoint.",
+        source.getLogin());
+    return user;
+  }
+
+  public boolean isCopilotActorLogin(String login) {
+    if (login == null) {
+      return false;
+    }
+
+    return "copilot".equals(login.toLowerCase(Locale.ROOT));
   }
 
   private User.Type convertUserType(String type) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserConverter.java
@@ -79,7 +79,7 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
 
     user.setId(source.getId());
     user.setCreatedAt(user.getCreatedAt() != null ? user.getCreatedAt() : now);
-    user.setUpdatedAt(now);
+    user.setUpdatedAt(null);
     user.setLogin(source.getLogin());
     user.setAvatarUrl(source.getAvatarUrl());
     user.setDescription("Copilot bot actor from GitHub metadata.");
@@ -88,7 +88,7 @@ public class GitHubUserConverter extends BaseGitServiceEntityConverter<GHUser, U
     user.setBlog(null);
     user.setLocation(null);
     user.setEmail(null);
-    user.setHtmlUrl("https://github.com/apps/copilot");
+    user.setHtmlUrl(source.getHtmlUrl().toString());
     user.setType(Type.BOT);
     user.setFollowers(0);
     user.setFollowing(0);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncService.java
@@ -63,27 +63,7 @@ public class GitHubUserSyncService {
     var result =
         userRepository
             .findById(ghUser.getId())
-            .map(
-                user -> {
-                  try {
-                    if (userConverter.isCopilotActorLogin(ghUser.getLogin())
-                        || userConverter.isCopilotActorLogin(user.getLogin())) {
-                      return userConverter.update(ghUser, user);
-                    }
-
-                    if (user.getUpdatedAt() == null
-                        || (ghUser.getUpdatedAt() != null
-                        && user.getUpdatedAt()
-                        .isBefore(
-                            DateUtil.convertToOffsetDateTime(ghUser.getUpdatedAt())))) {
-                      return userConverter.update(ghUser, user);
-                    }
-                    return user;
-                  } catch (IOException e) {
-                    log.error("Failed to update repository {}: {}", ghUser.getId(), e.getMessage());
-                    return null;
-                  }
-                })
+            .map(user -> updateExistingUser(ghUser, user))
             .orElseGet(() -> userConverter.convert(ghUser));
 
     if (result == null) {
@@ -91,5 +71,36 @@ public class GitHubUserSyncService {
     }
 
     return userRepository.save(result);
+  }
+
+  private User updateExistingUser(GHUser ghUser, User user) {
+    try {
+      if (shouldForceCopilotUpdate(ghUser, user)) {
+        return userConverter.update(ghUser, user);
+      }
+
+      if (shouldUpdateByTimestamp(ghUser, user)) {
+        return userConverter.update(ghUser, user);
+      }
+      return user;
+    } catch (IOException e) {
+      log.error("Failed to update repository {}: {}", ghUser.getId(), e.getMessage());
+      return null;
+    }
+  }
+
+  private boolean shouldForceCopilotUpdate(GHUser ghUser, User user) {
+    return userConverter.isCopilotActorLogin(ghUser.getLogin())
+        || userConverter.isCopilotActorLogin(user.getLogin());
+  }
+
+  private boolean shouldUpdateByTimestamp(GHUser ghUser, User user) throws IOException {
+    if (user.getUpdatedAt() == null) {
+      return true;
+    }
+
+    var githubUpdatedAt = ghUser.getUpdatedAt();
+    return githubUpdatedAt != null
+        && user.getUpdatedAt().isBefore(DateUtil.convertToOffsetDateTime(githubUpdatedAt));
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncService.java
@@ -66,6 +66,11 @@ public class GitHubUserSyncService {
             .map(
                 user -> {
                   try {
+                    if (userConverter.isCopilotActorLogin(ghUser.getLogin())
+                        || userConverter.isCopilotActorLogin(user.getLogin())) {
+                      return userConverter.update(ghUser, user);
+                    }
+
                     if (user.getUpdatedAt() == null
                         || (ghUser.getUpdatedAt() != null
                         && user.getUpdatedAt()

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
@@ -1,0 +1,26 @@
+package de.tum.cit.aet.helios.user.github;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class GitHubUserConverterTest {
+
+  private final GitHubUserConverter converter = new GitHubUserConverter();
+
+  @Test
+  void shouldIdentifyCopilotLoginCaseInsensitively() {
+    assertTrue(converter.isCopilotActorLogin("Copilot"));
+    assertTrue(converter.isCopilotActorLogin("copilot"));
+    assertTrue(converter.isCopilotActorLogin("COPILOT"));
+  }
+
+  @Test
+  void shouldNotIdentifyOtherLoginsAsCopilotActor() {
+    assertFalse(converter.isCopilotActorLogin(null));
+    assertFalse(converter.isCopilotActorLogin(""));
+    assertFalse(converter.isCopilotActorLogin("github-copilot"));
+    assertFalse(converter.isCopilotActorLogin("octocat"));
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
@@ -1,8 +1,11 @@
 package de.tum.cit.aet.helios.user.github;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import de.tum.cit.aet.helios.user.User;
 import org.junit.jupiter.api.Test;
 
 class GitHubUserConverterTest {
@@ -22,5 +25,35 @@ class GitHubUserConverterTest {
     assertFalse(converter.isCopilotActorLogin(""));
     assertFalse(converter.isCopilotActorLogin("github-copilot"));
     assertFalse(converter.isCopilotActorLogin("octocat"));
+  }
+
+  @Test
+  void shouldCreateAnonymousUserWithExpectedDefaults() {
+    User user = converter.convertToAnonymous();
+
+    assertEquals(-1L, user.getId());
+    assertEquals("Anonymous", user.getName());
+    assertEquals("anonymous", user.getLogin());
+    assertEquals(User.Type.USER, user.getType());
+    assertEquals(
+        "https://github.githubassets.com/images/gravatars/gravatar-user-420.png?size=40",
+        user.getAvatarUrl());
+    assertEquals("https://helios.aet.cit.tum.de/not-found", user.getHtmlUrl());
+    assertNotNull(user.getCreatedAt());
+    assertNotNull(user.getUpdatedAt());
+  }
+
+  @Test
+  void shouldCreateExpirationPickerUserWithExpectedDefaults() {
+    User user = converter.convertToExpirationPicker();
+
+    assertEquals(-2L, user.getId());
+    assertEquals("Auto Release Lock", user.getName());
+    assertEquals("ls1intum/Helios", user.getLogin());
+    assertEquals(User.Type.USER, user.getType());
+    assertEquals("https://helios.aet.cit.tum.de/favicon.png", user.getAvatarUrl());
+    assertEquals("https://helios.aet.cit.tum.de/not-found", user.getHtmlUrl());
+    assertNotNull(user.getCreatedAt());
+    assertNotNull(user.getUpdatedAt());
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserConverterTest.java
@@ -1,16 +1,25 @@
 package de.tum.cit.aet.helios.user.github;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.tum.cit.aet.helios.user.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHUser;
+import org.springframework.test.util.ReflectionTestUtils;
 
 class GitHubUserConverterTest {
 
-  private final GitHubUserConverter converter = new GitHubUserConverter();
+  private GitHubUserConverter converter;
+
+  @BeforeEach
+  void setUp() {
+    converter = new GitHubUserConverter();
+  }
 
   @Test
   void shouldIdentifyCopilotLoginCaseInsensitively() {
@@ -55,5 +64,23 @@ class GitHubUserConverterTest {
     assertEquals("https://helios.aet.cit.tum.de/not-found", user.getHtmlUrl());
     assertNotNull(user.getCreatedAt());
     assertNotNull(user.getUpdatedAt());
+  }
+
+  @Test
+  void shouldLeaveUpdatedAtUnsetForCopilotActor() {
+    GHUser ghUser = new GHUser();
+    ReflectionTestUtils.setField(ghUser, "id", 198982749L);
+    ReflectionTestUtils.setField(ghUser, "login", "Copilot");
+    ReflectionTestUtils.setField(
+        ghUser, "avatar_url", "https://avatars.githubusercontent.com/u/198982749?v=4");
+    ReflectionTestUtils.setField(ghUser, "html_url", "https://github.com/Copilot");
+
+    User user = converter.update(ghUser, new User());
+
+    assertEquals(198982749L, user.getId());
+    assertEquals("Copilot", user.getLogin());
+    assertEquals(User.Type.BOT, user.getType());
+    assertNull(user.getUpdatedAt());
+    assertNotNull(user.getCreatedAt());
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
@@ -1,0 +1,112 @@
+package de.tum.cit.aet.helios.user.github;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.user.User;
+import de.tum.cit.aet.helios.user.User.Type;
+import de.tum.cit.aet.helios.user.UserRepository;
+import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHUser;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubUserSyncServiceTest {
+
+  @Mock private UserRepository userRepository;
+
+  private final GitHubUserConverter userConverter = new GitHubUserConverter();
+
+  @Test
+  void shouldProcessExistingCopilotUserWithoutCallingGhUserUpdatedAt() throws Exception {
+    GitHubUserSyncService service = new GitHubUserSyncService(userRepository, userConverter);
+    long ghId = 198982749L;
+    User existingUser = createExistingUser(ghId, "Copilot");
+    GHUser ghUser = createGhUserWithBrokenUpdatedAt(ghId, "Copilot",
+        "https://avatars.githubusercontent.com/u/198982749?v=4");
+
+    when(userRepository.findById(ghId)).thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    User result = service.processUser(ghUser);
+
+    assertNotNull(result);
+    assertTrue(userConverter.isCopilotActorLogin(result.getLogin()));
+    assertFalse(result.getAvatarUrl().isBlank());
+    // If updatedAt was read, GHUser would throw due invalid updatedAt payload.
+    assertNotNull(result.getUpdatedAt());
+    verify(userRepository).save(any(User.class));
+  }
+
+  @Test
+  void shouldProcessExistingCopilotUserCaseInsensitivelyWithoutCallingGhUserUpdatedAt()
+      throws Exception {
+    GitHubUserSyncService service = new GitHubUserSyncService(userRepository, userConverter);
+    long ghId = 198982750L;
+    User existingUser = createExistingUser(ghId, "copilot");
+    GHUser ghUser = createGhUserWithBrokenUpdatedAt(ghId, "COPILOT",
+        "https://avatars.githubusercontent.com/u/198982750?v=4");
+
+    when(userRepository.findById(ghId)).thenReturn(Optional.of(existingUser));
+    when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    User result = service.processUser(ghUser);
+
+    assertNotNull(result);
+    assertTrue(userConverter.isCopilotActorLogin(result.getLogin()));
+    assertFalse(result.getAvatarUrl().isBlank());
+    verify(userRepository).save(any(User.class));
+  }
+
+  private static User createExistingUser(long id, String login) {
+    User user = new User();
+    user.setId(id);
+    user.setLogin(login);
+    user.setAvatarUrl("https://avatars.githubusercontent.com/u/" + id + "?v=4");
+    user.setName(login);
+    user.setHtmlUrl("https://github.com/" + login);
+    user.setType(Type.USER);
+    user.setCreatedAt(OffsetDateTime.now().minusDays(1));
+    user.setUpdatedAt(OffsetDateTime.now().minusHours(1));
+    return user;
+  }
+
+  private static GHUser createGhUserWithBrokenUpdatedAt(long id, String login, String avatarUrl)
+      throws Exception {
+    GHUser user = new GHUser();
+
+    setField(user, "id", id);
+    setField(user, "login", login);
+    setField(user, "avatar_url", avatarUrl);
+    // Mark as populated to avoid any API fetch in GHPerson.populate().
+    setField(user, "createdAt", "2026-01-10T00:00:00Z");
+    // This value triggers parsing failure if GHUser.getUpdatedAt() is evaluated.
+    setField(user, "updatedAt", "not-a-valid-date");
+
+    return user;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Class<?> current = target.getClass();
+    while (current != null) {
+      try {
+        Field field = current.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        return;
+      } catch (NoSuchFieldException ignored) {
+        current = current.getSuperclass();
+      }
+    }
+    throw new IllegalArgumentException("Field not found: " + fieldName);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.helios.user.github;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -42,8 +43,7 @@ class GitHubUserSyncServiceTest {
     assertNotNull(result);
     assertTrue(userConverter.isCopilotActorLogin(result.getLogin()));
     assertFalse(result.getAvatarUrl().isBlank());
-    // If updatedAt was read, GHUser would throw due invalid updatedAt payload.
-    assertNotNull(result.getUpdatedAt());
+    assertNull(result.getUpdatedAt());
     verify(userRepository).save(any(User.class));
   }
 
@@ -64,6 +64,7 @@ class GitHubUserSyncServiceTest {
     assertNotNull(result);
     assertTrue(userConverter.isCopilotActorLogin(result.getLogin()));
     assertFalse(result.getAvatarUrl().isBlank());
+    assertNull(result.getUpdatedAt());
     verify(userRepository).save(any(User.class));
   }
 
@@ -87,11 +88,11 @@ class GitHubUserSyncServiceTest {
     ReflectionTestUtils.setField(user, "id", id);
     ReflectionTestUtils.setField(user, "login", login);
     ReflectionTestUtils.setField(user, "avatar_url", avatarUrl);
+    ReflectionTestUtils.setField(user, "html_url", "https://github.com/" + login);
     // Mark as populated to avoid any API fetch in GHPerson.populate().
     ReflectionTestUtils.setField(user, "createdAt", "2026-01-10T00:00:00Z");
     // This value triggers parsing failure if GHUser.getUpdatedAt() is evaluated.
     ReflectionTestUtils.setField(user, "updatedAt", "not-a-valid-date");
-
     return user;
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/user/github/GitHubUserSyncServiceTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.helios.user.User;
 import de.tum.cit.aet.helios.user.User.Type;
 import de.tum.cit.aet.helios.user.UserRepository;
-import java.lang.reflect.Field;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.kohsuke.github.GHUser;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class GitHubUserSyncServiceTest {
@@ -84,29 +84,14 @@ class GitHubUserSyncServiceTest {
       throws Exception {
     GHUser user = new GHUser();
 
-    setField(user, "id", id);
-    setField(user, "login", login);
-    setField(user, "avatar_url", avatarUrl);
+    ReflectionTestUtils.setField(user, "id", id);
+    ReflectionTestUtils.setField(user, "login", login);
+    ReflectionTestUtils.setField(user, "avatar_url", avatarUrl);
     // Mark as populated to avoid any API fetch in GHPerson.populate().
-    setField(user, "createdAt", "2026-01-10T00:00:00Z");
+    ReflectionTestUtils.setField(user, "createdAt", "2026-01-10T00:00:00Z");
     // This value triggers parsing failure if GHUser.getUpdatedAt() is evaluated.
-    setField(user, "updatedAt", "not-a-valid-date");
+    ReflectionTestUtils.setField(user, "updatedAt", "not-a-valid-date");
 
     return user;
-  }
-
-  private static void setField(Object target, String fieldName, Object value) throws Exception {
-    Class<?> current = target.getClass();
-    while (current != null) {
-      try {
-        Field field = current.getDeclaredField(fieldName);
-        field.setAccessible(true);
-        field.set(target, value);
-        return;
-      } catch (NoSuchFieldException ignored) {
-        current = current.getSuperclass();
-      }
-    }
-    throw new IllegalArgumentException("Field not found: " + fieldName);
   }
 }


### PR DESCRIPTION
### Motivation
Production logs contain repeated errors when syncing GitHub actors with login `Copilot`.

The GitHub API returns `404 Not Found` for `GET /users/Copilot`, but Helios attempted to fetch multiple profile fields and user timestamps anyway. This caused noisy error logs and unnecessary API calls during branch/user sync.

Fixes #859.

### Description
- Added a Copilot-specific fallback path in `GitHubUserConverter`:
  - Detects `Copilot` login case-insensitively via `isCopilotActorLogin(...)`.
  - Builds/stores a minimal BOT user model without triggering profile field fetches that call `/users/Copilot`.
  - Emits a single warning log for this synthetic actor mapping.
- Updated `GitHubBranchSyncService` to set branch `updatedAt` from commit metadata (`commitDate`) instead of `updatedBy.getUpdatedAt()` to avoid profile fetches for Copilot actors.
- Added unit tests for Copilot login detection in `GitHubUserConverterTest`.

### Testing Instructions
#### Prerequisites:
- Helios server environment configured locally
- Access to run Gradle tests
- Checking Grafana logs for staging.

#### Flow:
1. Check out branch `fix/copilot-actor-404`.
2. Run:
   ```bash
   cd server
   ./gradlew :application-server:test --tests de.tum.cit.aet.helios.user.github.GitHubUserConverterTest
   ```
3. Verify tests pass.
4. Optional integration verification:
   - Trigger GitHub sync on a repository with Copilot-authored branches/PRs.
   - Confirm no repeated `/users/Copilot` conversion errors are produced.

### Screenshots
No UI changes were made.

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
