### PR TITLE
fix: prevent LazyInitializationException in environment unlock scheduler

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentScheduler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentScheduler.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +29,7 @@ public class EnvironmentScheduler {
 
   // Every minute
   @Scheduled(fixedRate = 60000)
+  @Transactional
   public void unlockExpiredEnvironments() {
     if (springEnvironment.matchesProfiles("openapi")) {
       log.info("OpenAPI profile detected. Skipping Status Check Scheduler.");


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This PR prevents recurring scheduler errors when auto‑unlocking environments.
It fixes a LazyInitializationException (“Could not initialize proxy … no session”) thrown by EnvironmentScheduler when unlocking expired locks for some environments. #871

### Description
<!-- Describe your changes in detail -->
`@Transactional` annotation is added so the session stays open while you iterate and access lazy relations.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- Running Helios locally with a database including at least one Environment.
- One environment configured as `locked = true`, `lock_expiration_threshold and locked_at set so the lock is already expired`.
#### Flow:
1. Start Helios locally with your usual dev profile.
2. Confirm in the DB that there is at least one locked environment whose lock should have expired.
3. Wait for the scheduler (or manually trigger unlockExpiredEnvironments).
4. Verify in the logs that:
- No Could not initialize proxy [de.tum.cit.aet.helios.gitrepo.GitRepository…] - no session error is logged.
- The environment’s locked flag is cleared and lock history is updated as expected.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.