### PR TITLE
fix: ignore deleted push events in GitHubPushMessageHandler

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubPushMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/commit/github/GitHubPushMessageHandler.java
@@ -35,6 +35,14 @@ public class GitHubPushMessageHandler extends GitHubMessageHandler<GHEventPayloa
 
   @Override
   protected void handleInstalledRepositoryEvent(GHEventPayload.Push eventPayload) {
+    if (eventPayload.isDeleted()) {
+      log.debug(
+          "Ignoring push event for repository: {}, ref: {} (handled by delete event)",
+          eventPayload.getRepository().getFullName(),
+          eventPayload.getRef());
+      return;
+    }
+
     String sha = eventPayload.getHeadCommit().getSha();
     String ref = eventPayload.getRef();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
GitHub sends a push webhook when a branch or tag is deleted; for those events `head_commit` is null. The push handler assumed `getHeadCommit()` was always non-null and called `getSha()` on it, causing a `NullPointerException`. Branch/tag deletion is already handled by `GitHubDeleteMessageHandler`, so the push handler should skip processing when there is no head commit. #868 

### Description
<!-- Describe your changes in detail -->
In `GitHubPushMessageHandler.handleInstalledRepositoryEvent`, added a guard at the start: if `eventPayload.isDeleted()`, log at debug level and return without processing. This avoids the `NullPointerException` and correctly ignores push events that represent branch/tag deletion (handled by `GitHubDeleteMessageHandler`).

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- Helios connected to a GitHub App
- NATS and GitHub webhooks delivering push/delete events to Helios

#### Flow:
1. In a connected GitHub repository, delete a branch.
2. Confirm that Helios receives both the `delete` and the `push` webhook.
3. Verify that no `NullPointerException` is thrown for the push event and that the branch is removed from the database by the existing delete handler.
4. Check the debug log for skipping message in the console.
5. Verify that normal push events (new commits) still sync commits and branches as before.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.