### PR TITLE
fix(github): retry workflow run pull request sync after token refresh

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.helios.workflow.github;
 
 import static de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment.mapWorkflowRunStatus;
 
+import de.tum.cit.aet.helios.github.GitHubClientManager;
+import de.tum.cit.aet.helios.github.GitHubFacade;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
@@ -26,6 +28,8 @@ import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHWorkflowRun;
 import org.springframework.stereotype.Service;
 
@@ -42,6 +46,8 @@ public class GitHubWorkflowRunSyncService {
   private final HeliosDeploymentRepository heliosDeploymentRepository;
   private final DeploymentFailureNotificationDecider deploymentFailureNotificationDecider;
   private final NatsNotificationPublisherService notificationPublisherService;
+  private final GitHubFacade github;
+  private final GitHubClientManager clientManager;
 
   @Transactional
   public WorkflowRun processRun(GHWorkflowRun ghWorkflowRun) {
@@ -112,8 +118,7 @@ public class GitHubWorkflowRunSyncService {
     try {
       Set<PullRequest> pullRequests = new HashSet<>();
 
-      ghWorkflowRun
-          .getPullRequests()
+      loadPullRequests(ghWorkflowRun)
           .forEach(
               pullRequest -> {
                 var pr = pullRequestRepository.findById(pullRequest.getId());
@@ -166,6 +171,34 @@ public class GitHubWorkflowRunSyncService {
     workflowRunRepository.save(result);
 
     return result;
+  }
+
+  private List<GHPullRequest> loadPullRequests(GHWorkflowRun ghWorkflowRun) throws IOException {
+    try {
+      return ghWorkflowRun.getPullRequests();
+    } catch (IOException e) {
+      if (!isBadCredentials(e)) {
+        throw e;
+      }
+
+      log.warn(
+          "Bad credentials while loading pull requests for workflow run {}. "
+              + "Refreshing client and retrying once.",
+          ghWorkflowRun.getId());
+
+      clientManager.forceRefreshClient();
+
+      GHRepository freshRepository =
+          github.getRepository(ghWorkflowRun.getRepository().getFullName());
+      GHWorkflowRun freshRun = freshRepository.getWorkflowRun(ghWorkflowRun.getId());
+      return freshRun.getPullRequests();
+    }
+  }
+
+  private boolean isBadCredentials(IOException e) {
+    String message = e.getMessage();
+    return message != null
+        && (message.contains("Bad credentials") || message.contains("\"status\": \"401\""));
   }
 
   private void processRunForHeliosDeployment(GHWorkflowRun workflowRun) throws IOException {


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Issue #864 reports intermittent 401 Bad credentials errors while syncing workflow runs and loading their pull requests from GitHub.

### Description
<!-- Describe your changes in detail -->
  This change makes workflow run pull request syncing recover from stale GitHub credentials by refreshing the GitHub client and retrying the pull request lookup once when GitHub responds with 401 Bad credentials.

  On the server side, the workflow run sync service now:

  - Detects credential-related failures while calling GHWorkflowRun#getPullRequests()
  - Forces a GitHub client refresh
  - Reloads the workflow run from a fresh repository client
  - Retries the pull request fetch once

  This keeps the fix localized to the failing code path instead of spreading repository re-fetching across the full sync flow.
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
  ### Testing Instructions

  #### Prerequisites:

  - A staging or test environment with Helios connected to a GitHub App installation
  - Access to a repository that is already synced by Helios
  - Permission to trigger a GitHub Actions workflow run for an open pull request
  - Access to Helios application logs for the test environment

  #### Flow:

  1. Open a pull request in a repository that is monitored by Helios.
  2. Trigger a GitHub Actions workflow run for that pull request and verify that the workflow run appears in Helios as expected.
  3. Wait long enough for the currently used GitHub App installation token to become stale in the running Helios instance.
  4. Trigger another workflow run for the same pull request without restarting Helios.
  5. Verify in Helios that the new workflow run is still synced correctly and remains linked to the pull request.
  6. Check the application logs during that second sync:
      - Helios may log a single warning about bad credentials while loading pull requests for the workflow run.
      - Helios should then refresh the GitHub client and complete the sync successfully.
      - There should be no persistent Failed to process pull requests for workflow run ... Bad credentials error loop.
  7. Repeat the workflow trigger once more to confirm the system continues syncing normally after the refresh.

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices

