### PR TITLE
fix(server): resolve annotated GitHub release tags to commits

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/status/EnvironmentStatusConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/status/EnvironmentStatusConfig.java
@@ -51,8 +51,7 @@ public class EnvironmentStatusConfig {
   public Duration getCheckInterval() {
     if (checkRecentInterval.compareTo(checkStableInterval) > 0) {
       throw new IllegalArgumentException(
-        "Recent interval must be lower or equal to stable interval"
-      );
+          "Recent interval must be lower or equal to stable interval");
     }
     return checkRecentInterval;
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubMessageHandler.java
@@ -31,7 +31,7 @@ public abstract class GitHubMessageHandler<T extends GHEventPayload> extends Nat
   }
 
   /**
-   * Processes a GitHub webhook event for a repository that is installed
+   * Processes a GitHub webhook event for a repository that is installed.
    *
    * @param payload The GitHub event payload for a installed repository. The payload type varies
    *     depending on the event type (Push, Pull Request, etc.).

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncService.java
@@ -14,6 +14,7 @@ import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHRef;
 import org.kohsuke.github.GHRelease;
 import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTagObject;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,19 +64,23 @@ public class GitHubReleaseSyncService {
         .orElseGet(
             () -> {
               try {
-                GHRepository currentRepository = gitHubService
-                    .getRepository(ghRepository.getFullName());
-                final GHRef ref = currentRepository.getRef("tags/" + ghRelease.getTagName());
+                GHRepository currentRepository =
+                    gitHubService.getRepository(ghRepository.getFullName());
+                final String commitSha =
+                    resolveCommitShaForTag(currentRepository, ghRelease.getTagName());
+
+                if (commitSha == null) {
+                  return null;
+                }
+
                 final Commit commit =
                     commitRepository
-                        .findByShaAndRepositoryRepositoryId(
-                            ref.getObject().getSha(), repository.getRepositoryId())
+                        .findByShaAndRepositoryRepositoryId(commitSha, repository.getRepositoryId())
                         .orElseGet(
                             () -> {
                               try {
                                 return commitSyncService.processCommit(
-                                  currentRepository
-                                      .getCommit(ref.getObject().getSha()), ghRepository);
+                                    currentRepository.getCommit(commitSha), ghRepository);
                               } catch (IOException e) {
                                 log.error(
                                     "Failed to get commit for release candidate {}: {}",
@@ -84,6 +89,13 @@ public class GitHubReleaseSyncService {
                                 return null;
                               }
                             });
+
+                if (commit == null) {
+                  log.error(
+                      "Skipping release candidate {} because no commit could be resolved",
+                      ghRelease.getTagName());
+                  return null;
+                }
 
                 ReleaseCandidate releaseCandidate = new ReleaseCandidate();
                 releaseCandidate.setRepository(repository);
@@ -101,5 +113,31 @@ public class GitHubReleaseSyncService {
                 return null;
               }
             });
+  }
+
+  private String resolveCommitShaForTag(GHRepository repository, String tagName)
+      throws IOException {
+    GHRef.GHObject object = repository.getRef("tags/" + tagName).getObject();
+
+    // Release tags can be lightweight (points directly to commit) or annotated (points to tag
+    // object). Follow tag objects until we reach the underlying commit.
+    for (int depth = 0; depth < 5; depth++) {
+      if ("commit".equals(object.getType())) {
+        return object.getSha();
+      }
+      if (!"tag".equals(object.getType())) {
+        log.error(
+            "Unsupported tag object type '{}' for release candidate {}",
+            object.getType(),
+            tagName);
+        return null;
+      }
+      GHTagObject tagObject = repository.getTagObject(object.getSha());
+      object = tagObject.getObject();
+    }
+
+    log.error(
+        "Failed to resolve commit for release candidate {} due to excessive tag depth", tagName);
+    return null;
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
@@ -1,0 +1,147 @@
+package de.tum.cit.aet.helios.releaseinfo.release.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.commit.Commit;
+import de.tum.cit.aet.helios.commit.CommitRepository;
+import de.tum.cit.aet.helios.commit.github.GitHubCommitSyncService;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.releaseinfo.release.Release;
+import de.tum.cit.aet.helios.releaseinfo.release.ReleaseRepository;
+import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidate;
+import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidateRepository;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHRef;
+import org.kohsuke.github.GHRelease;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.GHTagObject;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubReleaseSyncServiceTest {
+
+  @Mock private ReleaseRepository releaseRepository;
+  @Mock private GitHubReleaseConverter releaseConverter;
+  @Mock private GitHubCommitSyncService commitSyncService;
+  @Mock private GitRepoRepository gitRepoRepository;
+  @Mock private ReleaseCandidateRepository releaseCandidateRepository;
+  @Mock private CommitRepository commitRepository;
+  @Mock private GitHubService gitHubService;
+
+  @Mock private GHRelease ghRelease;
+  @Mock private GHRepository ghRepository;
+  @Mock private GHRepository currentRepository;
+  @Mock private GHRef ref;
+  @Mock private GHRef.GHObject refObject;
+
+  @InjectMocks private GitHubReleaseSyncService service;
+
+  private GitRepository repository;
+  private Release release;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    repository = new GitRepository();
+    repository.setRepositoryId(42L);
+    repository.setNameWithOwner("owner/repo");
+
+    release = new Release();
+    release.setId(1L);
+
+    when(ghRelease.getId()).thenReturn(1L);
+    when(ghRelease.getTagName()).thenReturn("v1.0.0");
+    when(ghRepository.getFullName()).thenReturn("owner/repo");
+
+    when(gitRepoRepository.findByNameWithOwner("owner/repo")).thenReturn(repository);
+    when(releaseRepository.findById(1L)).thenReturn(Optional.of(release));
+    when(releaseRepository.saveAndFlush(release)).thenReturn(release);
+    when(releaseCandidateRepository.findByRepositoryRepositoryIdAndName(42L, "v1.0.0"))
+        .thenReturn(Optional.empty());
+
+    when(gitHubService.getRepository("owner/repo")).thenReturn(currentRepository);
+    when(currentRepository.getRef("tags/v1.0.0")).thenReturn(ref);
+    when(ref.getObject()).thenReturn(refObject);
+  }
+
+  @Test
+  void processRelease_annotatedTag_resolvesCommitAndSavesReleaseCandidate() throws IOException {
+    Commit commit = new Commit();
+    commit.setSha("commit-sha");
+
+    when(refObject.getType()).thenReturn("tag");
+    when(refObject.getSha()).thenReturn("tag-sha");
+    GHTagObject tagObject = mock(GHTagObject.class);
+    when(currentRepository.getTagObject("tag-sha")).thenReturn(tagObject);
+    GHRef.GHObject tagTargetObject = mock(GHRef.GHObject.class);
+    when(tagObject.getObject()).thenReturn(tagTargetObject);
+    when(tagTargetObject.getType()).thenReturn("commit");
+    when(tagTargetObject.getSha()).thenReturn("commit-sha");
+    when(commitRepository.findByShaAndRepositoryRepositoryId("commit-sha", 42L))
+        .thenReturn(Optional.of(commit));
+    when(releaseCandidateRepository.saveAndFlush(any(ReleaseCandidate.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.processRelease(ghRelease, ghRepository);
+
+    ArgumentCaptor<ReleaseCandidate> captor = ArgumentCaptor.forClass(ReleaseCandidate.class);
+    verify(releaseCandidateRepository).saveAndFlush(captor.capture());
+    ReleaseCandidate savedReleaseCandidate = captor.getValue();
+    assertEquals("v1.0.0", savedReleaseCandidate.getName());
+    assertSame(repository, savedReleaseCandidate.getRepository());
+    assertSame(commit, savedReleaseCandidate.getCommit());
+    verify(currentRepository, never()).getCommit(anyString());
+  }
+
+  @Test
+  void processRelease_commitLookupFails_doesNotSaveReleaseCandidate() throws IOException {
+    when(refObject.getType()).thenReturn("commit");
+    when(refObject.getSha()).thenReturn("missing-commit-sha");
+    when(commitRepository.findByShaAndRepositoryRepositoryId("missing-commit-sha", 42L))
+        .thenReturn(Optional.empty());
+    when(currentRepository.getCommit("missing-commit-sha"))
+        .thenThrow(new IOException("No commit found"));
+
+    service.processRelease(ghRelease, ghRepository);
+
+    verify(releaseCandidateRepository, never()).saveAndFlush(any(ReleaseCandidate.class));
+  }
+
+  @Test
+  void processRelease_lightweightTag_syncsCommitWhenMissingLocally() throws IOException {
+    Commit commit = new Commit();
+    commit.setSha("commit-sha");
+
+    when(refObject.getType()).thenReturn("commit");
+    when(refObject.getSha()).thenReturn("commit-sha");
+    when(commitRepository.findByShaAndRepositoryRepositoryId("commit-sha", 42L))
+        .thenReturn(Optional.empty());
+    GHCommit ghCommit = mock(GHCommit.class);
+    when(currentRepository.getCommit("commit-sha")).thenReturn(ghCommit);
+    when(commitSyncService.processCommit(ghCommit, ghRepository)).thenReturn(commit);
+    when(releaseCandidateRepository.saveAndFlush(any(ReleaseCandidate.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.processRelease(ghRelease, ghRepository);
+
+    verify(commitSyncService).processCommit(ghCommit, ghRepository);
+    verify(currentRepository, never()).getTagObject(anyString());
+    verify(releaseCandidateRepository).saveAndFlush(any(ReleaseCandidate.class));
+  }
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
GitHub release synchronization currently assumes that a release tag points directly to a commit SHA. That breaks for annotated tags, where the tag reference points to a tag object first. As a result, release candidates can fail to resolve their backing commit and are not linked correctly. Fixes #865 

### Description
<!-- Describe your changes in detail -->
This change updates the server-side GitHub release sync flow to resolve the commit SHA behind both lightweight and annotated tags before looking up or syncing the commit.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
  - Java 21 configured for the server project
  - A local Helios checkout with Gradle available
  - A GitHub release/tag scenario to inspect if you want to test manually
#### Flow:
  1. Run the release sync service tests for GitHubReleaseSyncServiceTest.
  2. Verify that a lightweight tag still resolves directly to its commit and creates a release candidate.
  3. Verify that an annotated tag resolves through the tag object to the underlying commit and creates a release candidate.
  4. Verify that if the commit cannot be resolved or fetched, no release candidate is persisted.
  5. Optionally test against a repository containing annotated release tags and confirm the synced release candidate links to the expected commit.


### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
