### PR TITLE
feat: add flakiness scores endpoint and related data structures

### DIFF
--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -35,6 +35,7 @@ import {
   getEnvironmentReviewers,
   getEnvironmentsByRepositoryId,
   getEnvironmentsByUserLocking,
+  getFlakinessScores,
   getGitRepoSettings,
   getGroupsWithWorkflows,
   getLatestDeploymentByEnvironmentId,
@@ -129,6 +130,9 @@ import type {
   GetEnvironmentReviewersData,
   GetEnvironmentsByRepositoryIdData,
   GetEnvironmentsByUserLockingData,
+  GetFlakinessScoresData,
+  GetFlakinessScoresError,
+  GetFlakinessScoresResponse,
   GetGitRepoSettingsData,
   GetGroupsWithWorkflowsData,
   GetLatestDeploymentByEnvironmentIdData,
@@ -515,6 +519,22 @@ export const updateNotificationPreferencesMutation = (
   const mutationOptions: MutationOptions<unknown, UpdateNotificationPreferencesError, Options<UpdateNotificationPreferencesData>> = {
     mutationFn: async fnOptions => {
       const { data } = await updateNotificationPreferences({
+        ...options,
+        ...fnOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const getFlakinessScoresMutation = (
+  options?: Partial<Options<GetFlakinessScoresData>>
+): MutationOptions<GetFlakinessScoresResponse, GetFlakinessScoresError, Options<GetFlakinessScoresData>> => {
+  const mutationOptions: MutationOptions<GetFlakinessScoresResponse, GetFlakinessScoresError, Options<GetFlakinessScoresData>> = {
+    mutationFn: async fnOptions => {
+      const { data } = await getFlakinessScores({
         ...options,
         ...fnOptions,
         throwOnError: true,

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -485,6 +485,60 @@ export const NotificationPreferencesWrapperSchema = {
   },
 } as const;
 
+export const TestCaseIdentifierSchema = {
+  type: 'object',
+  properties: {
+    testName: {
+      type: 'string',
+      minLength: 1,
+    },
+    className: {
+      type: 'string',
+      minLength: 1,
+    },
+  },
+  required: ['className', 'testName'],
+} as const;
+
+export const TestFlakinessScoreRequestSchema = {
+  type: 'object',
+  properties: {
+    testCases: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/TestCaseIdentifier',
+      },
+      minItems: 1,
+    },
+  },
+  required: ['testCases'],
+} as const;
+
+export const TestFlakinessScoreDtoSchema = {
+  type: 'object',
+  properties: {
+    testName: {
+      type: 'string',
+    },
+    className: {
+      type: 'string',
+    },
+    flakinessScore: {
+      type: 'number',
+      format: 'double',
+    },
+    defaultBranchFailureRate: {
+      type: 'number',
+      format: 'double',
+    },
+    combinedFailureRate: {
+      type: 'number',
+      format: 'double',
+    },
+  },
+  required: ['className', 'testName'],
+} as const;
+
 export const ReleaseCandidateCreateDtoSchema = {
   type: 'object',
   properties: {

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -96,6 +96,9 @@ import type {
   GetEnvironmentsByUserLockingData,
   GetEnvironmentsByUserLockingErrors,
   GetEnvironmentsByUserLockingResponses,
+  GetFlakinessScoresData,
+  GetFlakinessScoresErrors,
+  GetFlakinessScoresResponses,
   GetGitRepoSettingsData,
   GetGitRepoSettingsErrors,
   GetGitRepoSettingsResponses,
@@ -386,6 +389,17 @@ export const getNotificationPreferences = <ThrowOnError extends boolean = false>
 export const updateNotificationPreferences = <ThrowOnError extends boolean = false>(options: Options<UpdateNotificationPreferencesData, ThrowOnError>) => {
   return (options.client ?? client).post<UpdateNotificationPreferencesResponses, UpdateNotificationPreferencesErrors, ThrowOnError>({
     url: '/api/user/notification-preferences',
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+};
+
+export const getFlakinessScores = <ThrowOnError extends boolean = false>(options: Options<GetFlakinessScoresData, ThrowOnError>) => {
+  return (options.client ?? client).post<GetFlakinessScoresResponses, GetFlakinessScoresErrors, ThrowOnError>({
+    url: '/api/tests/flakiness-scores',
     ...options,
     headers: {
       'Content-Type': 'application/json',

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -159,6 +159,23 @@ export type NotificationPreferencesWrapper = {
   preferences?: Array<NotificationPreferenceDto>;
 };
 
+export type TestCaseIdentifier = {
+  testName: string;
+  className: string;
+};
+
+export type TestFlakinessScoreRequest = {
+  testCases: Array<TestCaseIdentifier>;
+};
+
+export type TestFlakinessScoreDto = {
+  testName: string;
+  className: string;
+  flakinessScore?: number;
+  defaultBranchFailureRate?: number;
+  combinedFailureRate?: number;
+};
+
 export type ReleaseCandidateCreateDto = {
   name: string;
   commitSha: string;
@@ -988,6 +1005,31 @@ export type UpdateNotificationPreferencesResponses = {
    */
   200: unknown;
 };
+
+export type GetFlakinessScoresData = {
+  body: TestFlakinessScoreRequest;
+  path?: never;
+  query?: never;
+  url: '/api/tests/flakiness-scores';
+};
+
+export type GetFlakinessScoresErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type GetFlakinessScoresError = GetFlakinessScoresErrors[keyof GetFlakinessScoresErrors];
+
+export type GetFlakinessScoresResponses = {
+  /**
+   * OK
+   */
+  200: Array<TestFlakinessScoreDto>;
+};
+
+export type GetFlakinessScoresResponse = GetFlakinessScoresResponses[keyof GetFlakinessScoresResponses];
 
 export type GetAllTestTypesData = {
   body?: never;

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -445,6 +445,32 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "200":
           description: OK
+  /api/tests/flakiness-scores:
+    post:
+      tags:
+      - test-result-controller
+      operationId: getFlakinessScores
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestFlakinessScoreRequest"
+        required: true
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TestFlakinessScoreDto"
   /api/test-types:
     get:
       tags:
@@ -2230,6 +2256,47 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/NotificationPreferenceDto"
+    TestCaseIdentifier:
+      type: object
+      properties:
+        testName:
+          type: string
+          minLength: 1
+        className:
+          type: string
+          minLength: 1
+      required:
+      - className
+      - testName
+    TestFlakinessScoreRequest:
+      type: object
+      properties:
+        testCases:
+          type: array
+          items:
+            $ref: "#/components/schemas/TestCaseIdentifier"
+          minItems: 1
+      required:
+      - testCases
+    TestFlakinessScoreDto:
+      type: object
+      properties:
+        testName:
+          type: string
+        className:
+          type: string
+        flakinessScore:
+          type: number
+          format: double
+        defaultBranchFailureRate:
+          type: number
+          format: double
+        combinedFailureRate:
+          type: number
+          format: double
+      required:
+      - className
+      - testName
     ReleaseCandidateCreateDto:
       type: object
       properties:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                   .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                   /* shared‑secret filter handles these requests */
                   .requestMatchers(HttpMethod.POST, "/api/environments/status/**").permitAll()
+                  .requestMatchers(HttpMethod.POST, "/api/tests/flakiness-scores").permitAll()
                   /* other public endpoints (e.g. Swagger) */
                   .requestMatchers(
                       "/auth/**",

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/filters/RepoSecretFilter.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/filters/RepoSecretFilter.java
@@ -30,7 +30,9 @@ public class RepoSecretFilter extends OncePerRequestFilter {
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     // avoid parsing unrelated paths
-    return !request.getRequestURI().startsWith("/api/environments/status");
+    String uri = request.getRequestURI();
+    return !uri.startsWith("/api/environments/status")
+        && !uri.equals("/api/tests/flakiness-scores");
   }
 
   @Override

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -1,8 +1,10 @@
 package de.tum.cit.aet.helios.tests;
 
+import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class TestCaseStatisticsService {
 
   private final TestCaseStatisticsRepository statisticsRepository;
+  private final BranchRepository branchRepository;
   private static final double DEFAULT_BRANCH_WEIGHT = 0.7;
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
@@ -115,6 +118,101 @@ public class TestCaseStatisticsService {
    */
   public List<TestCaseStatistics> getStatisticsForBranch(String branchName, Long repositoryId) {
     return statisticsRepository.findByBranchNameAndRepositoryRepositoryId(branchName, repositoryId);
+  }
+
+  /**
+   * Returns flakiness scores for the requested test cases identified by testName + className.
+   * Matches against accumulated default-branch and combined-branch statistics.
+   *
+   * @param repositoryId the repository ID
+   * @param testIdentifiers the list of test case identifiers to look up
+   * @return matching flakiness scores
+   */
+  public List<TestFlakinessScoreDto> getFlakinessScoresForTests(
+      Long repositoryId,
+      List<TestFlakinessScoreRequest.TestCaseIdentifier> testIdentifiers) {
+    // Step 1: Fetch historical statistics using the getStatisticsForBranch method.
+    // We need two sets: default-branch stats and combined-branch stats
+    var defaultBranch =
+        branchRepository
+            .findFirstByRepositoryRepositoryIdAndIsDefaultTrue(repositoryId)
+            .orElseThrow();
+    String defaultBranchName = defaultBranch.getName();
+    List<TestCaseStatistics> defaultBranchStats =
+        getStatisticsForBranch(defaultBranchName, repositoryId);
+    List<TestCaseStatistics> combinedStats =
+        getStatisticsForBranch("combined", repositoryId);
+
+    // Step 2: For each requested test identifier,
+    // compute the flakiness score using the pre-fetched stats
+    List<TestFlakinessScoreDto> flakinessScoreDtos = new ArrayList<>();
+    testIdentifiers.forEach(testIdentifier -> {
+      FlakinessInfo flakinessInfo = computeFlakinessInfo(
+          testIdentifier.testName(),
+          testIdentifier.className(),
+          defaultBranchStats,
+          combinedStats
+      );
+      TestFlakinessScoreDto testFlakinessScoreDto = new TestFlakinessScoreDto(
+          testIdentifier.testName(),
+          testIdentifier.className(),
+          flakinessInfo.flakinessScore(),
+          flakinessInfo.defaultBranchFailureRate(),
+          flakinessInfo.combinedFailureRate());
+      flakinessScoreDtos.add(testFlakinessScoreDto);
+    });
+    return flakinessScoreDtos;
+  }
+
+  /** Holds computed flakiness information for a single test case. */
+  public record FlakinessInfo(
+      double flakinessScore,
+      double defaultBranchFailureRate,
+      double combinedFailureRate
+  ) {}
+
+  /**
+   * Computes flakiness information for a single test case from pre-fetched statistics lists.
+   * This is the shared core logic.
+   *
+   * Each caller pre-fetches the two stat lists (default branch + combined),
+   * then delegates the per-test-case score computation here.
+   *
+   * @param testName the test name to look up
+   * @param className the class name to look up
+   * @param defaultBranchStats statistics for the default branch
+   * @param combinedStats statistics for the "combined" pseudo-branch
+   * @return computed flakiness info
+   */
+  public FlakinessInfo computeFlakinessInfo(
+      String testName,
+      String className,
+      List<TestCaseStatistics> defaultBranchStats,
+      List<TestCaseStatistics> combinedStats) {
+    double defaultFailureRate =
+        defaultBranchStats.stream()
+            .filter(
+                s ->
+                    s.getTestName().equals(testName) && s.getClassName().equals(className))
+            .findFirst()
+            .map(TestCaseStatistics::getFailureRate)
+            .orElse(0.0);
+
+    double combinedFailureRate =
+        combinedStats.stream()
+            .filter(
+                s ->
+                    s.getTestName().equals(testName)
+                        && s.getClassName().equals(className))
+            .findFirst()
+            .map(TestCaseStatistics::getFailureRate)
+            .orElse(0.0);
+
+    double flakinessScore = calculateFlakinessScore(defaultFailureRate, combinedFailureRate);
+    return new FlakinessInfo(
+        flakinessScore,
+        defaultFailureRate,
+        combinedFailureRate);
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -174,7 +174,6 @@ public class TestCaseStatisticsService {
   /**
    * Computes flakiness information for a single test case from pre-fetched statistics lists.
    * This is the shared core logic.
-   *
    * Each caller pre-fetches the two stat lists (default branch + combined),
    * then delegates the per-test-case score computation here.
    *

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreDto.java
@@ -1,0 +1,11 @@
+package de.tum.cit.aet.helios.tests;
+
+import org.springframework.lang.NonNull;
+
+public record TestFlakinessScoreDto(
+    @NonNull String testName,
+    @NonNull String className,
+    double flakinessScore,
+    double defaultBranchFailureRate,
+    double combinedFailureRate) {
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreRequest.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreRequest.java
@@ -1,0 +1,15 @@
+package de.tum.cit.aet.helios.tests;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+import org.springframework.lang.NonNull;
+
+public record TestFlakinessScoreRequest(
+    @NonNull @NotEmpty @Valid List<TestCaseIdentifier> testCases) {
+
+  public record TestCaseIdentifier(
+      @NonNull @NotBlank String testName,
+      @NonNull @NotBlank String className) {}
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
@@ -1,9 +1,15 @@
 package de.tum.cit.aet.helios.tests;
 
+import de.tum.cit.aet.helios.gitreposettings.GitRepoSettings;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class TestResultController {
   private final TestResultService testResultService;
+  private final TestCaseStatisticsService testCaseStatisticsService;
 
   /**
    * Get the latest test results for a pull request, grouped by workflow. This enables separate
@@ -52,4 +59,24 @@ public class TestResultController {
         testResultService.getLatestTestResultsForBranch(
             branch, new TestResultService.TestSearchCriteria(page, size, search, onlyFailed)));
   }
+
+  /**
+   * Look up historical flakiness scores for a list of test cases.
+   * Authenticated via repository shared secret.
+   * Designed for CI pipelines (e.g. GitHub Actions)
+   * that need to annotate failed tests with flakiness data.
+   *
+   * @param repo the repository settings, populated by {@code RepoSecretFilter}
+   * @param request the list of test case identifiers to look up
+   * @return matching flakiness scores
+   */
+  @PostMapping("/flakiness-scores")
+  public ResponseEntity<List<TestFlakinessScoreDto>> getFlakinessScores(
+      @RequestAttribute("repository") GitRepoSettings repo,
+      @Valid @RequestBody TestFlakinessScoreRequest request) {
+    Long repositoryId = repo.getRepository().getRepositoryId();
+    return ResponseEntity.ok(
+        testCaseStatisticsService.getFlakinessScoresForTests(repositoryId, request.testCases()));
+  }
+
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -5,9 +5,7 @@ import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.tests.TestCase.TestStatus;
-import de.tum.cit.aet.helios.tests.TestResultsDto.CombinedTestCaseStatisticsInfo;
 import de.tum.cit.aet.helios.tests.TestResultsDto.TestCaseDto;
-import de.tum.cit.aet.helios.tests.TestResultsDto.TestCaseStatisticsInfo;
 import de.tum.cit.aet.helios.tests.TestResultsDto.TestTypeResults;
 import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
@@ -17,7 +15,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -319,58 +316,27 @@ public class TestResultService {
         testCaseStatisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             suiteClassNames, "combined", RepositoryContext.getRepositoryId());
 
-    Function<TestCase, TestResultsDto.TestCaseStatisticsInfo> statisticsProvider =
-        testCase -> {
-          Optional<TestCaseStatistics> stats =
-              defaultBranchStats.stream()
-                  .filter(
-                      s ->
-                          s.getTestName().equals(testCase.getName())
-                              && s.getClassName().equals(testCase.getClassName()))
-                  .findFirst();
-
-          double failureRate = stats.map(TestCaseStatistics::getFailureRate).orElse(0.0);
-
-          boolean failsInDefaultBranch =
-              failedTestsInDefault.stream()
-                  .anyMatch(
-                      failedTest ->
-                          failedTest.getName().equals(testCase.getName())
-                              && failedTest.getClassName().equals(testCase.getClassName()));
-
-          return new TestResultsDto.TestCaseStatisticsInfo(failureRate, failsInDefaultBranch);
-        };
-
-    Function<TestCase, TestResultsDto.CombinedTestCaseStatisticsInfo> combinedStatisticsProvider =
-        testCase -> {
-          Optional<TestCaseStatistics> stats =
-              combinedStats.stream()
-                  .filter(
-                      s ->
-                          s.getTestName().equals(testCase.getName())
-                              && s.getClassName().equals(testCase.getClassName()))
-                  .findFirst();
-
-          double combinedFailureRate = stats.map(TestCaseStatistics::getFailureRate).orElse(0.0);
-
-          return new TestResultsDto.CombinedTestCaseStatisticsInfo(combinedFailureRate);
-        };
-
     var prevStateCandidates =
         testCaseRepository.findByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
             prevWorkflowRunId, suiteClassNames, type.getId());
 
     for (TestSuite suite : suites) {
       for (TestCase testCase : suite.getTestCases()) {
-        TestCaseStatisticsInfo statistics = statisticsProvider.apply(testCase);
-        CombinedTestCaseStatisticsInfo combinedStatistics =
-            combinedStatisticsProvider.apply(testCase);
-        testCase.setFlakinessScore(
-            testCaseStatisticsService.calculateFlakinessScore(
-                statistics.failureRate(), combinedStatistics.combinedFailureRate()));
-        testCase.setFailsInDefaultBranch(statistics.failsInDefaultBranch());
-        testCase.setFailureRate(statistics.failureRate());
-        testCase.setCombinedFailureRate(combinedStatistics.combinedFailureRate());
+        var flakinessInfo =
+            testCaseStatisticsService.computeFlakinessInfo(
+                testCase.getName(), testCase.getClassName(), defaultBranchStats, combinedStats);
+        testCase.setFlakinessScore(flakinessInfo.flakinessScore());
+        testCase.setFailureRate(flakinessInfo.defaultBranchFailureRate());
+        testCase.setCombinedFailureRate(flakinessInfo.combinedFailureRate());
+
+        boolean failsInDefaultBranch =
+            failedTestsInDefault.stream()
+                .anyMatch(
+                    failedTest ->
+                        failedTest.getName().equals(testCase.getName())
+                            && failedTest.getClassName().equals(testCase.getClassName()));
+        testCase.setFailsInDefaultBranch(failsInDefaultBranch);
+
         testCase.setPreviousStatus(
             prevStateCandidates.stream()
                 .filter(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultsDto.java
@@ -94,9 +94,4 @@ public record TestResultsDto(@NonNull List<TestTypeResults> testResults, boolean
           testCase.isFailsInDefaultBranch());
     }
   }
-
-  /** Record for storing test case statistics information. */
-  record TestCaseStatisticsInfo(double failureRate, boolean failsInDefaultBranch) {}
-
-  record CombinedTestCaseStatisticsInfo(double combinedFailureRate) {}
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
@@ -1,0 +1,175 @@
+package de.tum.cit.aet.helios.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.gitreposettings.GitRepoSettings;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = TestResultController.class)
+@WebMvcTest(TestResultController.class)
+class TestResultControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private TestResultService testResultService;
+
+  @MockitoBean private TestCaseStatisticsService testCaseStatisticsService;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  private GitRepoSettings repoSettings;
+  private GitRepository gitRepository;
+
+  @BeforeEach
+  void setUp() {
+    gitRepository = new GitRepository();
+    gitRepository.setRepositoryId(1L);
+
+    repoSettings = new GitRepoSettings();
+    repoSettings.setRepository(gitRepository);
+  }
+
+  @Test
+  void getFlakinessScores_withValidRequest_returnsScores() throws Exception {
+    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1");
+    var request = new TestFlakinessScoreRequest(List.of(identifier));
+
+    var expectedDto = new TestFlakinessScoreDto("test1", "Class1", 63.0, 0.05, 0.0);
+
+    when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
+        .thenReturn(List.of(expectedDto));
+
+    String response =
+        mockMvc
+            .perform(
+                post("/api/tests/flakiness-scores")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+                    .requestAttr("repository", repoSettings))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    var expectedJson = objectMapper.writeValueAsString(List.of(expectedDto));
+    assertEquals(expectedJson, response);
+  }
+
+  @Test
+  void getFlakinessScores_withMultipleTests_returnsAllScores() throws Exception {
+    var identifiers =
+        List.of(
+            new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1"),
+            new TestFlakinessScoreRequest.TestCaseIdentifier("test2", "Class2"));
+    var request = new TestFlakinessScoreRequest(identifiers);
+
+    var dto1 = new TestFlakinessScoreDto("test1", "Class1", 63.0, 0.05, 0.0);
+    var dto2 = new TestFlakinessScoreDto("test2", "Class2", 0.0, 0.0, 0.0);
+
+    when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
+        .thenReturn(List.of(dto1, dto2));
+
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.length()").value(2))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].testName").value("test1"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].flakinessScore").value(63.0))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].testName").value("test2"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[1].flakinessScore").value(0.0));
+  }
+
+  @Test
+  void getFlakinessScores_withEmptyTestCases_returnsBadRequest() throws Exception {
+    var request = new TestFlakinessScoreRequest(Collections.emptyList());
+
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  }
+
+  @Test
+  void getFlakinessScores_withBlankTestName_returnsBadRequest() throws Exception {
+    String json = "{\"testCases\":[{\"testName\":\"\",\"className\":\"Class1\"}]}";
+
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  }
+
+  @Test
+  void getFlakinessScores_withBlankClassName_returnsBadRequest() throws Exception {
+    String json = "{\"testCases\":[{\"testName\":\"test1\",\"className\":\"\"}]}";
+
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json)
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  }
+
+  @Test
+  void getFlakinessScores_withMissingBody_returnsBadRequest() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isBadRequest());
+  }
+
+  @Test
+  void getFlakinessScores_withNoMatchingTests_returnsZeroScores() throws Exception {
+    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("unknownTest", "Unknown");
+    var request = new TestFlakinessScoreRequest(List.of(identifier));
+
+    var zeroDto = new TestFlakinessScoreDto("unknownTest", "Unknown", 0.0, 0.0, 0.0);
+
+    when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
+        .thenReturn(List.of(zeroDto));
+
+    mockMvc
+        .perform(
+            post("/api/tests/flakiness-scores")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .requestAttr("repository", repoSettings))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].testName").value("unknownTest"))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].flakinessScore").value(0.0))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].defaultBranchFailureRate").value(0.0))
+        .andExpect(MockMvcResultMatchers.jsonPath("$[0].combinedFailureRate").value(0.0));
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -155,14 +154,17 @@ class TestResultServiceTest {
             anyList(), anyString(), anyLong()))
         .thenReturn(Collections.emptyList());
     lenient()
-        .when(testCaseStatisticsService.calculateFlakinessScore(anyDouble(), anyDouble()))
-        .thenReturn(0.0);
+        .when(testCaseStatisticsService.computeFlakinessInfo(
+            anyString(), anyString(), anyList(), anyList()
+        ))
+        .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
     TestResultsDto result =
         testResultService.getLatestTestResultsForBranch("featureBranch", criteria);
 
     // Verify the problematic call
-    verify(testCaseStatisticsService).calculateFlakinessScore(0.0, 0.0);
+    verify(testCaseStatisticsService).computeFlakinessInfo(
+        anyString(), anyString(), anyList(), anyList());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());
@@ -210,13 +212,15 @@ class TestResultServiceTest {
             anyList(), anyString(), anyLong()))
         .thenReturn(Collections.emptyList());
     lenient()
-        .when(testCaseStatisticsService.calculateFlakinessScore(anyDouble(), anyDouble()))
-        .thenReturn(0.0);
+        .when(testCaseStatisticsService.computeFlakinessInfo(
+            anyString(), anyString(), anyList(), anyList()))
+        .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
     TestResultsDto result = testResultService.getLatestTestResultsForPr(1L, criteria);
 
     // Verify the problematic call
-    verify(testCaseStatisticsService).calculateFlakinessScore(0.0, 0.0);
+    verify(testCaseStatisticsService).computeFlakinessInfo(
+        anyString(), anyString(), anyList(), anyList());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Atlas team is currently working on the End-to-End tests for Artemis, specifically the GitHub actions pipeline. They are planning also incorporate a flakiness score, which is already calculated inside Helios, to the E2E report comments. For that, we are expected to expose an API endpoint to pull it from Helios to the GitHub actions pipeline and post the flakiness score next to each failed test.  #898

### Description
<!-- Describe your changes in detail -->
New flakiness-scores REST endpoint (POST /api/tests/flakiness-scores):
- Added TestFlakinessScoreRequest (validated request DTO) and TestFlakinessScoreDto (response DTO).
- Added getFlakinessScores endpoint in TestResultController, authenticated via the existing repository shared-secret filter (RepoSecretFilter).
- Added getFlakinessScoresForTests method in TestCaseStatisticsService that fetches default-branch and combined-branch statistics and computes per-test flakiness scores.
- Registered the new route in SecurityConfig (permitAll, since the shared-secret filter handles auth) and in RepoSecretFilter.
- Updated openapi.yaml with the new endpoint and schemas.

Refactored flakiness computation into shared method
- Extracted computeFlakinessInfo and the FlakinessInfo record into TestCaseStatisticsService so both TestResultService (used for branch/PR test results) and the new endpoint share the same computation logic.
- Simplified TestResultService by removing the duplicated inline flakiness calculation and delegating to computeFlakinessInfo.
- Removed unused flakinessScore, failureRate, and combinedFailureRate fields from TestResultsDto.TestCaseDto (these are now set on the entity and read via fromTestCase).

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- A repository with existing test case statistics (flakiness data)
- Access to the shared secret configured for the repository

#### Flow:
1. Run all server tests: `./gradlew :application-server:clean :application-server:test` — all 162 tests should pass.
2. Start the application server locally.
3. Send a POST request to `/api/tests/flakiness-scores` with the repository shared secret and a JSON body:
```
{
   "testCases": [
      { "testName": "shouldCreateUser", "className": "UserServiceTest" }
   ]
}
```
4. Verify the response returns flakiness scores for the requested tests.
5. Navigate to a PR or branch test results page and verify flakiness scores still display correctly (refactored computation path).

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
