### PR TITLE
fix: add admin pull request state reconciliation endpoint

### DIFF
--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -61,6 +61,7 @@ import {
   lockEnvironment,
   type Options,
   publishReleaseDraft,
+  reconcilePullRequestState,
   rotateSecret,
   setBranchPinnedByRepositoryIdAndNameAndUserId,
   setPrPinnedByNumber,
@@ -168,6 +169,9 @@ import type {
   LockEnvironmentResponse,
   PublishReleaseDraftData,
   PublishReleaseDraftError,
+  ReconcilePullRequestStateData,
+  ReconcilePullRequestStateError,
+  ReconcilePullRequestStateResponse,
   RotateSecretData,
   RotateSecretError,
   RotateSecretResponse,
@@ -725,6 +729,22 @@ export const setPrPinnedByNumberMutation = (
   const mutationOptions: MutationOptions<unknown, SetPrPinnedByNumberError, Options<SetPrPinnedByNumberData>> = {
     mutationFn: async fnOptions => {
       const { data } = await setPrPinnedByNumber({
+        ...options,
+        ...fnOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const reconcilePullRequestStateMutation = (
+  options?: Partial<Options<ReconcilePullRequestStateData>>
+): MutationOptions<ReconcilePullRequestStateResponse, ReconcilePullRequestStateError, Options<ReconcilePullRequestStateData>> => {
+  const mutationOptions: MutationOptions<ReconcilePullRequestStateResponse, ReconcilePullRequestStateError, Options<ReconcilePullRequestStateData>> = {
+    mutationFn: async fnOptions => {
+      const { data } = await reconcilePullRequestState({
         ...options,
         ...fnOptions,
         throwOnError: true,

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -799,10 +799,6 @@ export const PullRequestStateReconciliationResultDtoSchema = {
       type: 'integer',
       format: 'int32',
     },
-    missingCount: {
-      type: 'integer',
-      format: 'int32',
-    },
     errorCount: {
       type: 'integer',
       format: 'int32',

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -760,6 +760,62 @@ export const ReleaseInfoDetailsDtoSchema = {
   required: ['commit', 'createdAt', 'deployments', 'evaluations', 'name'],
 } as const;
 
+export const PullRequestStateReconciliationResultDtoSchema = {
+  type: 'object',
+  properties: {
+    dryRun: {
+      type: 'boolean',
+    },
+    repositoryId: {
+      type: 'integer',
+      format: 'int64',
+    },
+    repositoryNameWithOwner: {
+      type: 'string',
+    },
+    scannedCount: {
+      type: 'integer',
+      format: 'int32',
+    },
+    updatedCount: {
+      type: 'integer',
+      format: 'int32',
+    },
+    updatedPullRequestIds: {
+      type: 'array',
+      items: {
+        type: 'integer',
+        format: 'int64',
+      },
+    },
+    updatedPullRequestNumbers: {
+      type: 'array',
+      items: {
+        type: 'integer',
+        format: 'int32',
+      },
+    },
+    unchangedCount: {
+      type: 'integer',
+      format: 'int32',
+    },
+    missingCount: {
+      type: 'integer',
+      format: 'int32',
+    },
+    errorCount: {
+      type: 'integer',
+      format: 'int32',
+    },
+    errors: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
+  },
+} as const;
+
 export const PushStatusPayloadSchema = {
   type: 'object',
   properties: {

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -171,6 +171,9 @@ import type {
   PublishReleaseDraftData,
   PublishReleaseDraftErrors,
   PublishReleaseDraftResponses,
+  ReconcilePullRequestStateData,
+  ReconcilePullRequestStateErrors,
+  ReconcilePullRequestStateResponses,
   RotateSecretData,
   RotateSecretErrors,
   RotateSecretResponses,
@@ -520,6 +523,13 @@ export const getReleaseInfoByName = <ThrowOnError extends boolean = false>(optio
 export const setPrPinnedByNumber = <ThrowOnError extends boolean = false>(options: Options<SetPrPinnedByNumberData, ThrowOnError>) => {
   return (options.client ?? client).post<SetPrPinnedByNumberResponses, SetPrPinnedByNumberErrors, ThrowOnError>({
     url: '/api/pullrequests/{pr}/pin',
+    ...options,
+  });
+};
+
+export const reconcilePullRequestState = <ThrowOnError extends boolean = false>(options: Options<ReconcilePullRequestStateData, ThrowOnError>) => {
+  return (options.client ?? client).post<ReconcilePullRequestStateResponses, ReconcilePullRequestStateErrors, ThrowOnError>({
+    url: '/api/pullrequests/repository/{repositoryId}/reconcile-state',
     ...options,
   });
 };

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -252,6 +252,20 @@ export type ReleaseInfoDetailsDto = {
   body?: string;
 };
 
+export type PullRequestStateReconciliationResultDto = {
+  dryRun?: boolean;
+  repositoryId?: number;
+  repositoryNameWithOwner?: string;
+  scannedCount?: number;
+  updatedCount?: number;
+  updatedPullRequestIds?: Array<number>;
+  updatedPullRequestNumbers?: Array<number>;
+  unchangedCount?: number;
+  missingCount?: number;
+  errorCount?: number;
+  errors?: Array<string>;
+};
+
 export type PushStatusPayload = {
   environment: string;
   state: 'STARTING_UP' | 'DB_MIGRATION_STARTED' | 'DB_MIGRATION_FAILED' | 'DB_MIGRATION_FINISHED' | 'RUNNING' | 'DEGRADED' | 'SHUTTING_DOWN' | 'STOPPED' | 'FAILED';
@@ -1333,6 +1347,35 @@ export type SetPrPinnedByNumberResponses = {
    */
   200: unknown;
 };
+
+export type ReconcilePullRequestStateData = {
+  body?: never;
+  path: {
+    repositoryId: number;
+  };
+  query?: {
+    dryRun?: boolean;
+  };
+  url: '/api/pullrequests/repository/{repositoryId}/reconcile-state';
+};
+
+export type ReconcilePullRequestStateErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type ReconcilePullRequestStateError = ReconcilePullRequestStateErrors[keyof ReconcilePullRequestStateErrors];
+
+export type ReconcilePullRequestStateResponses = {
+  /**
+   * OK
+   */
+  200: PullRequestStateReconciliationResultDto;
+};
+
+export type ReconcilePullRequestStateResponse = ReconcilePullRequestStateResponses[keyof ReconcilePullRequestStateResponses];
 
 export type SyncEnvironmentsData = {
   body?: never;

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -261,7 +261,6 @@ export type PullRequestStateReconciliationResultDto = {
   updatedPullRequestIds?: Array<number>;
   updatedPullRequestNumbers?: Array<number>;
   unchangedCount?: number;
-  missingCount?: number;
   errorCount?: number;
   errors?: Array<string>;
 };

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -2521,9 +2521,6 @@ components:
         unchangedCount:
           type: integer
           format: int32
-        missingCount:
-          type: integer
-          format: int32
         errorCount:
           type: integer
           format: int32

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -750,6 +750,37 @@ paths:
                 $ref: "#/components/schemas/ApiError"
         "200":
           description: OK
+  /api/pullrequests/repository/{repositoryId}/reconcile-state:
+    post:
+      tags:
+      - pull-request-controller
+      operationId: reconcilePullRequestState
+      parameters:
+      - name: repositoryId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: dryRun
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PullRequestStateReconciliationResultDto"
   /api/environments/sync:
     post:
       tags:
@@ -2461,6 +2492,45 @@ components:
       - deployments
       - evaluations
       - name
+    PullRequestStateReconciliationResultDto:
+      type: object
+      properties:
+        dryRun:
+          type: boolean
+        repositoryId:
+          type: integer
+          format: int64
+        repositoryNameWithOwner:
+          type: string
+        scannedCount:
+          type: integer
+          format: int32
+        updatedCount:
+          type: integer
+          format: int32
+        updatedPullRequestIds:
+          type: array
+          items:
+            type: integer
+            format: int64
+        updatedPullRequestNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+        unchangedCount:
+          type: integer
+          format: int32
+        missingCount:
+          type: integer
+          format: int32
+        errorCount:
+          type: integer
+          format: int32
+        errors:
+          type: array
+          items:
+            type: string
     PushStatusPayload:
       type: object
       properties:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/error/GlobalExceptionHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/error/GlobalExceptionHandler.java
@@ -13,6 +13,8 @@ import java.util.stream.Collectors;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -99,7 +101,12 @@ public class GlobalExceptionHandler {
   }
 
   // -- 403 FORBIDDEN ------------------------------------
-  @ExceptionHandler({SecurityException.class, EnvironmentException.class})
+  @ExceptionHandler({
+      SecurityException.class,
+      EnvironmentException.class,
+      AccessDeniedException.class,
+      AuthorizationDeniedException.class
+  })
   public ResponseEntity<ApiError> handleSecurityExceptions(
       RuntimeException ex, HttpServletRequest request) {
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/permissions/RepositoryAuthorizationService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/permissions/RepositoryAuthorizationService.java
@@ -1,0 +1,46 @@
+package de.tum.cit.aet.helios.permissions;
+
+import de.tum.cit.aet.helios.auth.AuthService;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
+import java.io.IOException;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class RepositoryAuthorizationService {
+
+  private final AuthService authService;
+  private final GitHubService gitHubService;
+
+  @Value("${helios.developers:}")
+  private Set<String> heliosDevelopers;
+
+  public boolean hasAdminAccess(Long repositoryId) {
+    if (repositoryId == null) {
+      return false;
+    }
+
+    try {
+      String username = authService.getPreferredUsername();
+
+      if (heliosDevelopers.contains(username)) {
+        return true;
+      }
+
+      return gitHubService.getRepositoryRole(repositoryId.toString(), username).getPermission()
+          == RepoPermissionType.ADMIN;
+    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+      log.warn(
+          "Failed to evaluate admin access for repository {}: {}",
+          repositoryId,
+          e.getMessage());
+      return false;
+    }
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestController.java
@@ -1,8 +1,10 @@
 package de.tum.cit.aet.helios.pullrequest;
 
+import de.tum.cit.aet.helios.config.security.annotations.EnforceAdmin;
 import de.tum.cit.aet.helios.pullrequest.pagination.PaginatedPullRequestsResponse;
 import de.tum.cit.aet.helios.pullrequest.pagination.PullRequestFilterType;
 import de.tum.cit.aet.helios.pullrequest.pagination.PullRequestPageRequest;
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PullRequestController {
 
   private final PullRequestService pullRequestService;
+  private final PullRequestStateReconciliationService pullRequestStateReconciliationService;
 
   @GetMapping
   public ResponseEntity<PaginatedPullRequestsResponse> getPullRequests(
@@ -71,5 +74,14 @@ public class PullRequestController {
       @PathVariable Long pr, @RequestParam(name = "isPinned") Boolean isPinned) {
     pullRequestService.setPrPinnedByNumberAndUserId(pr, isPinned);
     return ResponseEntity.ok().build();
+  }
+
+  @EnforceAdmin
+  @PostMapping("/repository/{repositoryId}/reconcile-state")
+  public ResponseEntity<PullRequestStateReconciliationResultDto> reconcilePullRequestState(
+      @PathVariable Long repositoryId,
+      @RequestParam(name = "dryRun", defaultValue = "false") boolean dryRun) throws IOException {
+    return ResponseEntity.ok(
+        pullRequestStateReconciliationService.reconcilePullRequestState(repositoryId, dryRun));
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestController.java
@@ -1,6 +1,6 @@
 package de.tum.cit.aet.helios.pullrequest;
 
-import de.tum.cit.aet.helios.config.security.annotations.EnforceAdmin;
+import de.tum.cit.aet.helios.permissions.RepositoryAuthorizationService;
 import de.tum.cit.aet.helios.pullrequest.pagination.PaginatedPullRequestsResponse;
 import de.tum.cit.aet.helios.pullrequest.pagination.PullRequestFilterType;
 import de.tum.cit.aet.helios.pullrequest.pagination.PullRequestPageRequest;
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,6 +23,7 @@ public class PullRequestController {
 
   private final PullRequestService pullRequestService;
   private final PullRequestStateReconciliationService pullRequestStateReconciliationService;
+  private final RepositoryAuthorizationService repositoryAuthorizationService;
 
   @GetMapping
   public ResponseEntity<PaginatedPullRequestsResponse> getPullRequests(
@@ -76,11 +78,15 @@ public class PullRequestController {
     return ResponseEntity.ok().build();
   }
 
-  @EnforceAdmin
   @PostMapping("/repository/{repositoryId}/reconcile-state")
   public ResponseEntity<PullRequestStateReconciliationResultDto> reconcilePullRequestState(
       @PathVariable Long repositoryId,
       @RequestParam(name = "dryRun", defaultValue = "false") boolean dryRun) throws IOException {
+    if (!repositoryAuthorizationService.hasAdminAccess(repositoryId)) {
+      throw new AccessDeniedException(
+          "You do not have admin access for repository ID: " + repositoryId);
+    }
+
     return ResponseEntity.ok(
         pullRequestStateReconciliationService.reconcilePullRequestState(repositoryId, dryRun));
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestRepository.java
@@ -33,6 +33,9 @@ public interface PullRequestRepository extends JpaRepository<PullRequest, Long>,
 
   List<PullRequest> findAllByState(Issue.State state);
 
+  List<PullRequest> findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+      Long repositoryId, Issue.State state);
+
   List<PullRequest> findAllByOrderByUpdatedAtDesc();
 
   List<PullRequest> findByRepositoryRepositoryIdOrderByUpdatedAtDesc(Long repositoryId);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationResultDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationResultDto.java
@@ -1,0 +1,16 @@
+package de.tum.cit.aet.helios.pullrequest;
+
+import java.util.List;
+
+public record PullRequestStateReconciliationResultDto(
+    boolean dryRun,
+    Long repositoryId,
+    String repositoryNameWithOwner,
+    int scannedCount,
+    int updatedCount,
+    List<Long> updatedPullRequestIds,
+    List<Integer> updatedPullRequestNumbers,
+    int unchangedCount,
+    int missingCount,
+    int errorCount,
+    List<String> errors) {}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationResultDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationResultDto.java
@@ -11,6 +11,5 @@ public record PullRequestStateReconciliationResultDto(
     List<Long> updatedPullRequestIds,
     List<Integer> updatedPullRequestNumbers,
     int unchangedCount,
-    int missingCount,
     int errorCount,
     List<String> errors) {}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationService.java
@@ -1,0 +1,127 @@
+package de.tum.cit.aet.helios.pullrequest;
+
+import de.tum.cit.aet.helios.github.GitHubFacade;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.issue.Issue;
+import de.tum.cit.aet.helios.pullrequest.github.GitHubPullRequestSyncService;
+import jakarta.persistence.EntityNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.kohsuke.github.GHIssueState;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+public class PullRequestStateReconciliationService {
+
+  private static final Pattern NOT_FOUND_PATTERN =
+      Pattern.compile("not found|\"status\"\\s*:\\s*\"404\"", Pattern.CASE_INSENSITIVE);
+
+  private final PullRequestRepository pullRequestRepository;
+  private final GitRepoRepository gitRepoRepository;
+  private final GitHubPullRequestSyncService pullRequestSyncService;
+  private final GitHubFacade github;
+
+  @Transactional
+  public PullRequestStateReconciliationResultDto reconcilePullRequestState(
+      Long repositoryId, boolean dryRun)
+      throws IOException {
+    GitRepository repository =
+        gitRepoRepository
+            .findByRepositoryId(repositoryId)
+            .orElseThrow(
+                () -> new EntityNotFoundException("Repository not found with ID: " + repositoryId));
+
+    org.kohsuke.github.GHRepository ghRepository;
+    try {
+      ghRepository = github.getRepository(repository.getNameWithOwner());
+    } catch (IOException e) {
+      if (isNotFound(e)) {
+        throw new EntityNotFoundException(
+            "GitHub repository not found for repository ID: " + repositoryId);
+      }
+      throw e;
+    }
+
+    List<PullRequest> pullRequests =
+        pullRequestRepository.findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+            repositoryId, Issue.State.OPEN);
+    List<Long> updatedPullRequestIds = new ArrayList<>();
+    List<Integer> updatedPullRequestNumbers = new ArrayList<>();
+    List<String> errors = new ArrayList<>();
+    int unchangedCount = 0;
+    int missingCount = 0;
+
+    for (PullRequest pullRequest : pullRequests) {
+      try {
+        var gitHubPullRequest = ghRepository.getPullRequest(pullRequest.getNumber());
+        if (gitHubPullRequest.getState() == GHIssueState.CLOSED) {
+          updatedPullRequestIds.add(pullRequest.getId());
+          updatedPullRequestNumbers.add(pullRequest.getNumber());
+          if (dryRun) {
+            log.info(
+                "DRY-RUN: Would reconcile local pull request {} (#{}) "
+                    + "to closed state for repository {}.",
+                pullRequest.getId(),
+                pullRequest.getNumber(),
+                repository.getNameWithOwner());
+          } else {
+            pullRequestSyncService.processPullRequest(gitHubPullRequest);
+            log.info(
+                "Reconciled local pull request {} (#{}) to closed state for repository {}.",
+                pullRequest.getId(),
+                pullRequest.getNumber(),
+                repository.getNameWithOwner());
+          }
+        } else {
+          unchangedCount++;
+        }
+      } catch (IOException e) {
+        if (isNotFound(e)) {
+          missingCount++;
+          log.warn(
+              "Pull request {} (#{}) was not found on GitHub "
+                  + "during reconciliation for repository {}.",
+              pullRequest.getId(),
+              pullRequest.getNumber(),
+              repository.getNameWithOwner());
+        } else {
+          log.warn(
+              "Failed to reconcile pull request {} (#{}) in repository {}: {}",
+              pullRequest.getId(),
+              pullRequest.getNumber(),
+              repository.getNameWithOwner(),
+              e.getMessage());
+          errors.add(
+              "Failed to reconcile PR #%d (id=%d): %s"
+                  .formatted(pullRequest.getNumber(), pullRequest.getId(), e.getMessage()));
+        }
+      }
+    }
+
+    return new PullRequestStateReconciliationResultDto(
+        dryRun,
+        repository.getRepositoryId(),
+        repository.getNameWithOwner(),
+        pullRequests.size(),
+        updatedPullRequestIds.size(),
+        List.copyOf(updatedPullRequestIds),
+        List.copyOf(updatedPullRequestNumbers),
+        unchangedCount,
+        missingCount,
+        errors.size(),
+        List.copyOf(errors));
+  }
+
+  static boolean isNotFound(IOException exception) {
+    return exception.getMessage() != null
+        && NOT_FOUND_PATTERN.matcher(exception.getMessage()).find();
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationService.java
@@ -13,8 +13,8 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Log4j2
@@ -29,7 +29,6 @@ public class PullRequestStateReconciliationService {
   private final GitHubPullRequestSyncService pullRequestSyncService;
   private final GitHubFacade github;
 
-  @Transactional
   public PullRequestStateReconciliationResultDto reconcilePullRequestState(
       Long repositoryId, boolean dryRun)
       throws IOException {
@@ -57,52 +56,22 @@ public class PullRequestStateReconciliationService {
     List<Integer> updatedPullRequestNumbers = new ArrayList<>();
     List<String> errors = new ArrayList<>();
     int unchangedCount = 0;
-    int missingCount = 0;
 
     for (PullRequest pullRequest : pullRequests) {
-      try {
-        var gitHubPullRequest = ghRepository.getPullRequest(pullRequest.getNumber());
-        if (gitHubPullRequest.getState() == GHIssueState.CLOSED) {
+      ReconciliationOutcome outcome =
+          reconcilePullRequest(pullRequest, ghRepository, repository.getNameWithOwner(), dryRun);
+      switch (outcome.status()) {
+        case UPDATED -> {
           updatedPullRequestIds.add(pullRequest.getId());
           updatedPullRequestNumbers.add(pullRequest.getNumber());
-          if (dryRun) {
-            log.info(
-                "DRY-RUN: Would reconcile local pull request {} (#{}) "
-                    + "to closed state for repository {}.",
-                pullRequest.getId(),
-                pullRequest.getNumber(),
-                repository.getNameWithOwner());
-          } else {
-            pullRequestSyncService.processPullRequest(gitHubPullRequest);
-            log.info(
-                "Reconciled local pull request {} (#{}) to closed state for repository {}.",
-                pullRequest.getId(),
-                pullRequest.getNumber(),
-                repository.getNameWithOwner());
-          }
-        } else {
+        }
+        case UNCHANGED -> {
           unchangedCount++;
         }
-      } catch (IOException e) {
-        if (isNotFound(e)) {
-          missingCount++;
-          log.warn(
-              "Pull request {} (#{}) was not found on GitHub "
-                  + "during reconciliation for repository {}.",
-              pullRequest.getId(),
-              pullRequest.getNumber(),
-              repository.getNameWithOwner());
-        } else {
-          log.warn(
-              "Failed to reconcile pull request {} (#{}) in repository {}: {}",
-              pullRequest.getId(),
-              pullRequest.getNumber(),
-              repository.getNameWithOwner(),
-              e.getMessage());
-          errors.add(
-              "Failed to reconcile PR #%d (id=%d): %s"
-                  .formatted(pullRequest.getNumber(), pullRequest.getId(), e.getMessage()));
-        }
+        case ERROR -> errors.add(outcome.errorMessage());
+        default ->
+            throw new IllegalStateException(
+                "Unexpected reconciliation status: " + outcome.status());
       }
     }
 
@@ -115,7 +84,6 @@ public class PullRequestStateReconciliationService {
         List.copyOf(updatedPullRequestIds),
         List.copyOf(updatedPullRequestNumbers),
         unchangedCount,
-        missingCount,
         errors.size(),
         List.copyOf(errors));
   }
@@ -123,5 +91,67 @@ public class PullRequestStateReconciliationService {
   static boolean isNotFound(IOException exception) {
     return exception.getMessage() != null
         && NOT_FOUND_PATTERN.matcher(exception.getMessage()).find();
+  }
+
+  private ReconciliationOutcome reconcilePullRequest(
+      PullRequest pullRequest,
+      org.kohsuke.github.GHRepository ghRepository,
+      String repositoryNameWithOwner,
+      boolean dryRun) {
+    try {
+      GHPullRequest gitHubPullRequest = ghRepository.getPullRequest(pullRequest.getNumber());
+      if (gitHubPullRequest.getState() != GHIssueState.CLOSED) {
+        return ReconciliationOutcome.unchanged();
+      }
+
+      if (dryRun) {
+        log.info(
+            "DRY-RUN: Would reconcile local pull request {} (#{}) "
+                + "to closed state for repository {}.",
+            pullRequest.getId(),
+            pullRequest.getNumber(),
+            repositoryNameWithOwner);
+      } else {
+        pullRequestSyncService.processPullRequest(gitHubPullRequest);
+        log.info(
+            "Reconciled local pull request {} (#{}) to closed state for repository {}.",
+            pullRequest.getId(),
+            pullRequest.getNumber(),
+            repositoryNameWithOwner);
+      }
+      return ReconciliationOutcome.updated();
+    } catch (Exception e) {
+      log.warn(
+          "Failed to reconcile pull request {} (#{}) in repository {}: {}",
+          pullRequest.getId(),
+          pullRequest.getNumber(),
+          repositoryNameWithOwner,
+          e.getMessage(),
+          e);
+      return ReconciliationOutcome.error(
+          "Failed to reconcile PR #%d (id=%d): %s"
+              .formatted(pullRequest.getNumber(), pullRequest.getId(), e.getMessage()));
+    }
+  }
+
+  private record ReconciliationOutcome(ReconciliationStatus status, String errorMessage) {
+
+    private static ReconciliationOutcome updated() {
+      return new ReconciliationOutcome(ReconciliationStatus.UPDATED, null);
+    }
+
+    private static ReconciliationOutcome unchanged() {
+      return new ReconciliationOutcome(ReconciliationStatus.UNCHANGED, null);
+    }
+
+    private static ReconciliationOutcome error(String errorMessage) {
+      return new ReconciliationOutcome(ReconciliationStatus.ERROR, errorMessage);
+    }
+  }
+
+  private enum ReconciliationStatus {
+    UPDATED,
+    UNCHANGED,
+    ERROR
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/GitHubDataSyncOrchestratorTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/GitHubDataSyncOrchestratorTest.java
@@ -1,0 +1,72 @@
+package de.tum.cit.aet.helios.github.sync;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.pullrequest.github.GitHubPullRequestSyncService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHDirection;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHPullRequestQueryBuilder;
+import org.kohsuke.github.GHRepository;
+import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.PagedIterator;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubDataSyncOrchestratorTest {
+
+  @Mock private GitHubPullRequestSyncService pullRequestSyncService;
+
+  @Test
+  void syncPullRequestsOfRepositoryBuildsOpenPullRequestQuery() {
+    final GitHubDataSyncOrchestrator orchestrator =
+        new GitHubDataSyncOrchestrator(
+            null,
+            pullRequestSyncService,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null);
+    GHRepository repository = mock(GHRepository.class);
+    GHPullRequestQueryBuilder builder = mock(GHPullRequestQueryBuilder.class);
+    @SuppressWarnings("unchecked")
+    PagedIterable<GHPullRequest> iterable = mock(PagedIterable.class);
+    @SuppressWarnings("unchecked")
+    PagedIterator<GHPullRequest> iterator = mock(PagedIterator.class);
+
+    when(repository.queryPullRequests()).thenReturn(builder);
+    when(builder.state(any())).thenReturn(builder);
+    when(builder.sort(any())).thenReturn(builder);
+    when(builder.direction(any())).thenReturn(builder);
+    when(builder.list()).thenReturn(iterable);
+    when(iterable.withPageSize(100)).thenReturn(iterable);
+    when(iterable.iterator()).thenReturn(iterator);
+    lenient().when(iterator.hasNext()).thenReturn(false);
+
+    orchestrator.syncPullRequestsOfRepository(repository);
+
+    verify(builder).state(GHIssueState.OPEN);
+    verify(builder).sort(GHPullRequestQueryBuilder.Sort.UPDATED);
+    verify(builder).direction(GHDirection.DESC);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/permissions/RepositoryAuthorizationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/permissions/RepositoryAuthorizationServiceTest.java
@@ -1,0 +1,79 @@
+package de.tum.cit.aet.helios.permissions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.auth.AuthService;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.github.permissions.GitHubRepositoryRoleDto;
+import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
+import java.io.IOException;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RepositoryAuthorizationServiceTest {
+
+  @Mock private AuthService authService;
+
+  @Mock private GitHubService gitHubService;
+
+  @InjectMocks private RepositoryAuthorizationService repositoryAuthorizationService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(
+        repositoryAuthorizationService, "heliosDevelopers", Set.of("helios-developer"));
+  }
+
+  @Test
+  void hasAdminAccessReturnsTrueForHeliosDeveloper() {
+    when(authService.getPreferredUsername()).thenReturn("helios-developer");
+
+    boolean hasAdminAccess = repositoryAuthorizationService.hasAdminAccess(1L);
+
+    assertTrue(hasAdminAccess);
+    verifyNoInteractions(gitHubService);
+  }
+
+  @Test
+  void hasAdminAccessReturnsTrueForRepositoryAdmin() throws Exception {
+    when(authService.getPreferredUsername()).thenReturn("repo-admin");
+    when(gitHubService.getRepositoryRole("1", "repo-admin"))
+        .thenReturn(new GitHubRepositoryRoleDto(RepoPermissionType.ADMIN, "admin"));
+
+    boolean hasAdminAccess = repositoryAuthorizationService.hasAdminAccess(1L);
+
+    assertTrue(hasAdminAccess);
+  }
+
+  @Test
+  void hasAdminAccessReturnsFalseForNonAdminPermission() throws Exception {
+    when(authService.getPreferredUsername()).thenReturn("writer");
+    when(gitHubService.getRepositoryRole("1", "writer"))
+        .thenReturn(new GitHubRepositoryRoleDto(RepoPermissionType.WRITE, "write"));
+
+    boolean hasAdminAccess = repositoryAuthorizationService.hasAdminAccess(1L);
+
+    assertFalse(hasAdminAccess);
+  }
+
+  @Test
+  void hasAdminAccessReturnsFalseWhenPermissionLookupFails() throws Exception {
+    when(authService.getPreferredUsername()).thenReturn("repo-admin");
+    when(gitHubService.getRepositoryRole("1", "repo-admin"))
+        .thenThrow(new IOException("GitHub unavailable"));
+
+    boolean hasAdminAccess = repositoryAuthorizationService.hasAdminAccess(1L);
+
+    assertFalse(hasAdminAccess);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestControllerTest.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.helios.config.SecurityConfig;
 import de.tum.cit.aet.helios.error.GlobalExceptionHandler;
 import de.tum.cit.aet.helios.filters.RepoSecretFilter;
 import de.tum.cit.aet.helios.filters.RepositoryInterceptor;
+import de.tum.cit.aet.helios.permissions.RepositoryAuthorizationService;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.FilterChain;
 import java.util.List;
@@ -44,6 +45,8 @@ class PullRequestControllerTest {
 
   @MockitoBean private RepositoryInterceptor repositoryInterceptor;
 
+  @MockitoBean private RepositoryAuthorizationService repositoryAuthorizationService;
+
   @BeforeEach
   void setUp() throws Exception {
     doAnswer(
@@ -58,6 +61,7 @@ class PullRequestControllerTest {
 
   @Test
   void reconcileStateReturnsResultForAdminUser() throws Exception {
+    when(repositoryAuthorizationService.hasAdminAccess(1L)).thenReturn(true);
     when(pullRequestStateReconciliationService.reconcilePullRequestState(1L, true))
         .thenReturn(
             new PullRequestStateReconciliationResultDto(
@@ -70,7 +74,6 @@ class PullRequestControllerTest {
                 List.of(42),
                 1,
                 0,
-                0,
                 List.of()));
 
     mockMvc
@@ -78,7 +81,7 @@ class PullRequestControllerTest {
             post("/api/pullrequests/repository/{repositoryId}/reconcile-state", 1L)
                 .param("dryRun", "true")
                 .with(SecurityMockMvcRequestPostProcessors.csrf())
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+                .with(SecurityMockMvcRequestPostProcessors.user("admin")))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.dryRun").value(true))
         .andExpect(jsonPath("$.updatedCount").value(1));
@@ -86,6 +89,7 @@ class PullRequestControllerTest {
 
   @Test
   void reconcileStateReturnsNotFoundWhenRepositoryDoesNotExist() throws Exception {
+    when(repositoryAuthorizationService.hasAdminAccess(99L)).thenReturn(true);
     when(pullRequestStateReconciliationService.reconcilePullRequestState(99L, false))
         .thenThrow(new EntityNotFoundException("Repository not found with ID: 99"));
 
@@ -93,7 +97,19 @@ class PullRequestControllerTest {
         .perform(
             post("/api/pullrequests/repository/{repositoryId}/reconcile-state", 99L)
                 .with(SecurityMockMvcRequestPostProcessors.csrf())
-                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+                .with(SecurityMockMvcRequestPostProcessors.user("admin")))
         .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void reconcileStateReturnsForbiddenWhenUserHasNoRepositoryAdminAccess() throws Exception {
+    when(repositoryAuthorizationService.hasAdminAccess(1L)).thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/pullrequests/repository/{repositoryId}/reconcile-state", 1L)
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("user")))
+        .andExpect(status().isForbidden());
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestControllerTest.java
@@ -1,0 +1,99 @@
+package de.tum.cit.aet.helios.pullrequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.tum.cit.aet.helios.config.GitHubJwtAuthenticationConverter;
+import de.tum.cit.aet.helios.config.SecurityConfig;
+import de.tum.cit.aet.helios.error.GlobalExceptionHandler;
+import de.tum.cit.aet.helios.filters.RepoSecretFilter;
+import de.tum.cit.aet.helios.filters.RepositoryInterceptor;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.FilterChain;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+@Import({GlobalExceptionHandler.class, SecurityConfig.class})
+@ContextConfiguration(classes = PullRequestController.class)
+@WebMvcTest(PullRequestController.class)
+class PullRequestControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PullRequestService pullRequestService;
+
+  @MockitoBean private PullRequestStateReconciliationService pullRequestStateReconciliationService;
+
+  @MockitoBean private GitHubJwtAuthenticationConverter gitHubJwtAuthenticationConverter;
+
+  @MockitoBean private RepoSecretFilter repoSecretFilter;
+
+  @MockitoBean private RepositoryInterceptor repositoryInterceptor;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    doAnswer(
+            invocation -> {
+              FilterChain chain = invocation.getArgument(2);
+              chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+              return null;
+            })
+        .when(repoSecretFilter)
+        .doFilter(any(), any(), any());
+  }
+
+  @Test
+  void reconcileStateReturnsResultForAdminUser() throws Exception {
+    when(pullRequestStateReconciliationService.reconcilePullRequestState(1L, true))
+        .thenReturn(
+            new PullRequestStateReconciliationResultDto(
+                true,
+                1L,
+                "ls1intum/Helios",
+                2,
+                1,
+                List.of(1001L),
+                List.of(42),
+                1,
+                0,
+                0,
+                List.of()));
+
+    mockMvc
+        .perform(
+            post("/api/pullrequests/repository/{repositoryId}/reconcile-state", 1L)
+                .param("dryRun", "true")
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.dryRun").value(true))
+        .andExpect(jsonPath("$.updatedCount").value(1));
+  }
+
+  @Test
+  void reconcileStateReturnsNotFoundWhenRepositoryDoesNotExist() throws Exception {
+    when(pullRequestStateReconciliationService.reconcilePullRequestState(99L, false))
+        .thenThrow(new EntityNotFoundException("Repository not found with ID: 99"));
+
+    mockMvc
+        .perform(
+            post("/api/pullrequests/repository/{repositoryId}/reconcile-state", 99L)
+                .with(SecurityMockMvcRequestPostProcessors.csrf())
+                .with(SecurityMockMvcRequestPostProcessors.user("admin").roles("ADMIN")))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationServiceTest.java
@@ -1,0 +1,126 @@
+package de.tum.cit.aet.helios.pullrequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.github.GitHubFacade;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.issue.Issue;
+import de.tum.cit.aet.helios.pullrequest.github.GitHubPullRequestSyncService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.github.GHIssueState;
+import org.kohsuke.github.GHPullRequest;
+import org.kohsuke.github.GHRepository;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PullRequestStateReconciliationServiceTest {
+
+  @Mock private PullRequestRepository pullRequestRepository;
+
+  @Mock private GitRepoRepository gitRepoRepository;
+
+  @Mock private GitHubFacade gitHubFacade;
+
+  @Mock private GitHubPullRequestSyncService pullRequestSyncService;
+
+  @Mock private GHRepository ghRepository;
+
+  @InjectMocks
+  private PullRequestStateReconciliationService pullRequestStateReconciliationService;
+
+  @Test
+  void reconcilePullRequestStateUpdatesClosedPullRequest() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("ls1intum/Helios");
+
+    PullRequest pullRequest = new PullRequest();
+    pullRequest.setId(1001L);
+    pullRequest.setNumber(42);
+    pullRequest.setRepository(repository);
+
+    GHPullRequest gitHubPullRequest = org.mockito.Mockito.mock(GHPullRequest.class);
+
+    when(gitRepoRepository.findByRepositoryId(1L)).thenReturn(Optional.of(repository));
+    when(gitHubFacade.getRepository("ls1intum/Helios")).thenReturn(ghRepository);
+    when(pullRequestRepository.findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+            1L, Issue.State.OPEN))
+        .thenReturn(List.of(pullRequest));
+    when(ghRepository.getPullRequest(42)).thenReturn(gitHubPullRequest);
+    when(gitHubPullRequest.getState()).thenReturn(GHIssueState.CLOSED);
+
+    PullRequestStateReconciliationResultDto result =
+        pullRequestStateReconciliationService.reconcilePullRequestState(1L, false);
+
+    assertEquals(1, result.updatedCount());
+    assertEquals(List.of(1001L), result.updatedPullRequestIds());
+    assertEquals(List.of(42), result.updatedPullRequestNumbers());
+    verify(pullRequestSyncService).processPullRequest(gitHubPullRequest);
+  }
+
+  @Test
+  void reconcilePullRequestStateDryRunKeepsSyncSideEffectsDisabled() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("ls1intum/Helios");
+
+    PullRequest pullRequest = new PullRequest();
+    pullRequest.setId(1001L);
+    pullRequest.setNumber(42);
+    pullRequest.setRepository(repository);
+
+    GHPullRequest gitHubPullRequest = org.mockito.Mockito.mock(GHPullRequest.class);
+
+    when(gitRepoRepository.findByRepositoryId(1L)).thenReturn(Optional.of(repository));
+    when(gitHubFacade.getRepository("ls1intum/Helios")).thenReturn(ghRepository);
+    when(pullRequestRepository.findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+            1L, Issue.State.OPEN))
+        .thenReturn(List.of(pullRequest));
+    when(ghRepository.getPullRequest(42)).thenReturn(gitHubPullRequest);
+    when(gitHubPullRequest.getState()).thenReturn(GHIssueState.CLOSED);
+
+    PullRequestStateReconciliationResultDto result =
+        pullRequestStateReconciliationService.reconcilePullRequestState(1L, true);
+
+    assertTrue(result.dryRun());
+    assertEquals(1, result.updatedCount());
+    verify(pullRequestSyncService, never()).processPullRequest(gitHubPullRequest);
+  }
+
+  @Test
+  void reconcilePullRequestStateMarksMissingPullRequestWhenGitHubReturnsNotFound()
+      throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("ls1intum/Helios");
+
+    PullRequest pullRequest = new PullRequest();
+    pullRequest.setId(1001L);
+    pullRequest.setNumber(42);
+    pullRequest.setRepository(repository);
+
+    when(gitRepoRepository.findByRepositoryId(1L)).thenReturn(Optional.of(repository));
+    when(gitHubFacade.getRepository("ls1intum/Helios")).thenReturn(ghRepository);
+    when(pullRequestRepository.findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+            1L, Issue.State.OPEN))
+        .thenReturn(List.of(pullRequest));
+    when(ghRepository.getPullRequest(42)).thenThrow(new IOException("Not Found"));
+
+    PullRequestStateReconciliationResultDto result =
+        pullRequestStateReconciliationService.reconcilePullRequestState(1L, false);
+
+    assertEquals(1, result.missingCount());
+    assertEquals(0, result.errorCount());
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/pullrequest/PullRequestStateReconciliationServiceTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.helios.pullrequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -99,8 +100,7 @@ class PullRequestStateReconciliationServiceTest {
   }
 
   @Test
-  void reconcilePullRequestStateMarksMissingPullRequestWhenGitHubReturnsNotFound()
-      throws Exception {
+  void reconcilePullRequestStateReportsErrorWhenGitHubReturnsNotFound() throws Exception {
     GitRepository repository = new GitRepository();
     repository.setRepositoryId(1L);
     repository.setNameWithOwner("ls1intum/Helios");
@@ -120,7 +120,51 @@ class PullRequestStateReconciliationServiceTest {
     PullRequestStateReconciliationResultDto result =
         pullRequestStateReconciliationService.reconcilePullRequestState(1L, false);
 
-    assertEquals(1, result.missingCount());
-    assertEquals(0, result.errorCount());
+    assertEquals(1, result.errorCount());
+    assertTrue(result.errors().getFirst().contains("Not Found"));
+  }
+
+  @Test
+  void reconcilePullRequestStateContinuesAfterUncheckedSyncFailure() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("ls1intum/Helios");
+
+    PullRequest failingPullRequest = new PullRequest();
+    failingPullRequest.setId(1001L);
+    failingPullRequest.setNumber(42);
+    failingPullRequest.setRepository(repository);
+
+    PullRequest succeedingPullRequest = new PullRequest();
+    succeedingPullRequest.setId(1002L);
+    succeedingPullRequest.setNumber(43);
+    succeedingPullRequest.setRepository(repository);
+
+    GHPullRequest failingGitHubPullRequest = org.mockito.Mockito.mock(GHPullRequest.class);
+    GHPullRequest succeedingGitHubPullRequest = org.mockito.Mockito.mock(GHPullRequest.class);
+
+    when(gitRepoRepository.findByRepositoryId(1L)).thenReturn(Optional.of(repository));
+    when(gitHubFacade.getRepository("ls1intum/Helios")).thenReturn(ghRepository);
+    when(pullRequestRepository.findByRepositoryRepositoryIdAndStateOrderByUpdatedAtDesc(
+            1L, Issue.State.OPEN))
+        .thenReturn(List.of(failingPullRequest, succeedingPullRequest));
+    when(ghRepository.getPullRequest(42)).thenReturn(failingGitHubPullRequest);
+    when(ghRepository.getPullRequest(43)).thenReturn(succeedingGitHubPullRequest);
+    when(failingGitHubPullRequest.getState()).thenReturn(GHIssueState.CLOSED);
+    when(succeedingGitHubPullRequest.getState()).thenReturn(GHIssueState.CLOSED);
+    doThrow(new IllegalStateException("sync failed"))
+        .when(pullRequestSyncService)
+        .processPullRequest(failingGitHubPullRequest);
+
+    PullRequestStateReconciliationResultDto result =
+        pullRequestStateReconciliationService.reconcilePullRequestState(1L, false);
+
+    assertEquals(1, result.updatedCount());
+    assertEquals(List.of(1002L), result.updatedPullRequestIds());
+    assertEquals(List.of(43), result.updatedPullRequestNumbers());
+    assertEquals(1, result.errorCount());
+    assertTrue(result.errors().getFirst().contains("sync failed"));
+    verify(pullRequestSyncService).processPullRequest(failingGitHubPullRequest);
+    verify(pullRequestSyncService).processPullRequest(succeedingGitHubPullRequest);
   }
 }


### PR DESCRIPTION
### Motivation

  Open pull requests can remain stale in Helios when GitHub state changes are missed or delayed. This makes the local PR state unreliable for reviewers and administrators and makes it harder to recover from synchronization gaps.

  ### Description

  - add an admin-only pull request state reconciliation endpoint for a repository, including optional dryRun support
  - add a reconciliation service and result DTO that:
      - loads locally open pull requests for a repository
      - checks their current state on GitHub
      - reprocesses pull requests that are already closed on GitHub
      - reports updated, unchanged, missing, and failed reconciliations
  - extend error handling so authorization failures on the new endpoint are returned as 403 Forbidden
  - add focused tests for:
      - the reconciliation service behavior
      - controller authorization and dryRun handling
      - pull request sync cutoff behavior in the GitHub data sync orchestrator
  - include minor supporting cleanup in related server files

  ### Testing Instructions

  #### Prerequisites:

  - local server environment for Helios
  - a repository connected to Helios
  - one admin user and one non-admin user
  - a repository ID with pull requests available in Helios

  #### Flow:

  1. Run the targeted server tests for the new reconciliation flow and controller coverage.
  2. Start the application server locally.
  3. As a non-admin user, call POST `/api/pullrequests/repository/{repositoryId}/reconcile-state` and verify the request is rejected with 403 Forbidden.
  4. As an admin user, call POST `/api/pullrequests/repository/{repositoryId}/reconcile-state?dryRun=true` and verify the response contains reconciliation statistics without modifying data.
  5. Call POST `/api/pullrequests/repository/{repositoryId}/reconcile-state` as an admin user and verify that pull requests which are locally open but already closed on GitHub are reconciled correctly.
  6. Verify that missing GitHub pull requests are counted as missing and unexpected GitHub/API failures are reported as errors in the response.

  ### Checklist

  #### General

  - [x] PR description explains the purpose and changes. (f.e. following the 'Conventional Commits') (https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] Changes have been tested locally.

  #### Server

  - [x] Code is performant and follows best practices
  - [x] I documented the Java code using JavaDoc style.
