### PR TITLE
fix: update repository overview pagination

### DIFF
--- a/client/src/app/components/table-filter/table-filter.component.html
+++ b/client/src/app/components/table-filter/table-filter.component.html
@@ -8,15 +8,7 @@
       }
     </p-button>
   }
-  <input
-    pInputText
-    [(ngModel)]="searchTableService().searchValue"
-    type="text"
-    pSize="small"
-    placeholder="Search"
-    class="w-full"
-    (input)="searchTableService().onInput(table(), $event)"
-  />
+  <input pInputText [(ngModel)]="searchTableService().searchValue" type="text" pSize="small" placeholder="Search" class="w-full" (input)="onInput($event)" />
 </div>
 
 <p-popover #op>

--- a/client/src/app/components/table-filter/table-filter.component.ts
+++ b/client/src/app/components/table-filter/table-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, viewChild } from '@angular/core';
+import { Component, computed, input, output, viewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { SearchTable } from '@app/core/services/search-table.service';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
@@ -24,9 +24,15 @@ export class TableFilterComponent {
   table = computed(() => this.input() as SearchTable);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   searchTableService = input.required<any>();
+  inputChanged = output<void>();
   op = viewChild.required<Popover>('op');
 
   toggle(event: Event) {
     this.op().toggle(event);
+  }
+
+  onInput(event: Event): void {
+    this.searchTableService().onInput(this.table(), event);
+    this.inputChanged.emit();
   }
 }

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -10,14 +10,22 @@
 </app-page-heading>
 
 @if (query.isPending() || query.isError()) {
-  <p-dataview [value]="[1, 2, 3, 4, 5]" layout="grid" [paginator]="true" [rows]="6">
+  <p-dataview
+    [value]="skeletonItems()"
+    layout="grid"
+    [paginator]="true"
+    [rows]="rows()"
+    [first]="first()"
+    [rowsPerPageOptions]="rowsPerPageOptions"
+    (onPage)="onRepositoryPageChange($event)"
+  >
     <ng-template #header>
       <p-skeleton styleClass="w-full !h-5" />
     </ng-template>
     <ng-template #grid let-projects>
-      <div class="grid auto-rows-auto gap-4 mt-4 max-w-[1600px] mx-auto" style="grid-template-columns: repeat(auto-fit, minmax(350px, 1fr))">
+      <div class="grid auto-rows-auto gap-4 mt-4 max-w-[1600px] mx-auto" style="grid-template-columns: repeat(auto-fit, minmax(400px, 1fr))">
         @for (project of projects; track project) {
-          <div class="flex gap-2 flex-col border border-muted-color rounded-2xl p-5 shadow-md min-w-[350px]">
+          <div class="flex gap-2 flex-col border border-muted-color rounded-2xl p-5 shadow-md min-w-[400px]">
             <div class="flex justify-between gap-2">
               <div class="flex gap-2 items-center">
                 <p-skeleton shape="circle" styleClass="!size-7" />
@@ -43,9 +51,19 @@
     </ng-template>
   </p-dataview>
 } @else {
-  <p-dataview #dataView [value]="query.data()" layout="grid" [paginator]="true" [rows]="6" filterBy="name">
+  <p-dataview
+    #dataView
+    [value]="query.data()"
+    layout="grid"
+    [paginator]="true"
+    [rows]="rows()"
+    [first]="first()"
+    [rowsPerPageOptions]="rowsPerPageOptions"
+    (onPage)="onRepositoryPageChange($event)"
+    filterBy="name"
+  >
     <ng-template #header>
-      <app-table-filter [input]="dataView" [searchTableService]="searchDataViewService" />
+      <app-table-filter [input]="dataView" [searchTableService]="searchDataViewService" (inputChanged)="onRepositoryFilterInput()" />
       <div class="mb-3"></div>
     </ng-template>
     <ng-template #grid let-projects>

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
 import { RepositoryInfoDto } from '@app/core/modules/openapi';
@@ -38,9 +38,12 @@ import {
 } from 'angular-tabler-icons/icons';
 import { DialogModule } from 'primeng/dialog';
 import { CarouselModule, CarouselPageEvent } from 'primeng/carousel';
+import { DataViewPageEvent } from 'primeng/dataview';
 import { connectionSteps } from './connection-steps';
 
 const FILTER_OPTIONS = [{ name: 'All repositories', filter: (repos: RepositoryInfoDto[]) => repos }];
+const DEFAULT_REPOSITORY_ROWS = 12;
+const ROWS_PER_PAGE_OPTIONS = [6, 12, 24, 48];
 
 @Component({
   selector: 'app-repository-overview',
@@ -92,6 +95,10 @@ export class RepositoryOverviewComponent {
   connectionSteps = connectionSteps;
   addRepositoryDialogVisible = signal(false);
   currentStep = signal(0);
+  rows = signal(DEFAULT_REPOSITORY_ROWS);
+  first = signal(0);
+  skeletonItems = computed(() => Array.from({ length: this.rows() }, (_, index) => index));
+  readonly rowsPerPageOptions = ROWS_PER_PAGE_OPTIONS;
 
   query = injectQuery(() => getAllRepositoriesOptions());
 
@@ -122,6 +129,20 @@ export class RepositoryOverviewComponent {
     console.log('Page changed:', event.page);
     this.currentStep.set(event.page || 0);
   }
+
+  onRepositoryPageChange(event: DataViewPageEvent): void {
+    if (event.rows <= 0) {
+      return;
+    }
+
+    this.rows.set(event.rows);
+    this.first.set(event.first);
+  }
+
+  onRepositoryFilterInput(): void {
+    this.first.set(0);
+  }
+
   openExternalLink(url: string): void {
     window.open(url, '_blank');
   }

--- a/client/src/app/pages/repository-overview/repository-overview.spec.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.spec.ts
@@ -2,24 +2,91 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RepositoryOverviewComponent } from './repository-overview.component';
 import { importProvidersFrom } from '@angular/core';
 import { TestModule } from '@app/test.module';
+import { By } from '@angular/platform-browser';
+import { RepositoryInfoDto } from '@app/core/modules/openapi';
+import { getAllRepositoriesQueryKey } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { QueryClient } from '@tanstack/angular-query-experimental';
+import { DataView } from 'primeng/dataview';
 
 describe('Integration Test Repository Overview Page', () => {
   let component: RepositoryOverviewComponent;
-  let fixture: ComponentFixture<RepositoryOverviewComponent>;
+  let fixture: ComponentFixture<RepositoryOverviewComponent> | undefined;
+  let queryClient: QueryClient;
+
+  const repositories: RepositoryInfoDto[] = Array.from({ length: 20 }, (_, index) => ({
+    id: index + 1,
+    name: `repo-${index + 1}`,
+    nameWithOwner: `ls1intum/repo-${index + 1}`,
+    description: `Repository ${index + 1}`,
+    htmlUrl: `https://github.com/ls1intum/repo-${index + 1}`,
+    updatedAt: new Date('2026-01-01T00:00:00Z').toISOString(),
+    stargazersCount: index,
+    pullRequestCount: index,
+    branchCount: index,
+    environmentCount: index,
+    latestReleaseTagName: index % 2 === 0 ? `v${index + 1}.0.0` : undefined,
+    contributors: [],
+  }));
+
+  const getDataView = () => fixture?.debugElement.query(By.directive(DataView)).componentInstance as DataView;
+
+  const createComponent = async (withRepositories = true) => {
+    queryClient.clear();
+    if (withRepositories) {
+      queryClient.setQueryData(getAllRepositoriesQueryKey(), repositories);
+    }
+
+    fixture = TestBed.createComponent(RepositoryOverviewComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [RepositoryOverviewComponent],
       providers: [importProvidersFrom(TestModule)],
     }).compileComponents();
+    queryClient = TestBed.inject(QueryClient);
+  });
 
-    fixture = TestBed.createComponent(RepositoryOverviewComponent);
-    component = fixture.componentInstance;
-
-    await fixture.whenStable();
+  afterEach(() => {
+    fixture?.destroy();
+    fixture = undefined;
+    queryClient.clear();
   });
 
   it('should create', () => {
+    queryClient.setQueryData(getAllRepositoriesQueryKey(), repositories);
+    fixture = TestBed.createComponent(RepositoryOverviewComponent);
+    component = fixture.componentInstance;
     expect(component).toBeTruthy();
+  });
+
+  it('uses the fixed default and binds paginator options', async () => {
+    await createComponent();
+
+    expect(component.rows()).toBe(12);
+    expect(getDataView().rows).toBe(12);
+    expect(getDataView().rowsPerPageOptions).toEqual([6, 12, 24, 48]);
+  });
+
+  it('renders loading placeholders with the active row count', async () => {
+    await createComponent(false);
+
+    expect(component.rows()).toBe(12);
+    expect(getDataView().value).toHaveLength(12);
+  });
+
+  it('updates paginator state from PrimeNG page events', async () => {
+    await createComponent();
+
+    component.onRepositoryPageChange({ first: 24, rows: 24 });
+    fixture?.detectChanges();
+
+    expect(component.rows()).toBe(24);
+    expect(component.first()).toBe(24);
   });
 });


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #710.

The repository overview currently paginates with a fixed page size of 6 repositories, which feels unusually low on larger screens and often leaves the second page half empty even when more cards would fit comfortably. This change makes the pagination behavior more practical and gives users control over how many repositories are shown per page.


### Description
<!-- Describe your changes in detail -->

- increase the default repository overview page size from 6 to 12
- add page size options so users can switch between 6, 12, 24, and 48 repositories per page
- keep the selected paginator state in the component and apply it to both the loaded and loading states
- update the loading skeletons to match the active page size for a more consistent UI
- add client tests covering the default paginator configuration, loading placeholder count, and page change handling

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:

- Helios client dependencies are installed
- A Helios instance with enough connected repositories to span multiple pages

#### Flow:

1. Start the client and log in to Helios as a Developer.
2. Open the repository overview page.
3. Verify that the initial page shows 12 repositories instead of 6.
4. Change the paginator page size and verify that the available options are 6, 12, 24, and 48.
5. Navigate between pages and confirm that the selected page size is applied correctly.
6. Verify that the pagination no longer leaves unexpectedly sparse pages when the repository list would fit on the current screen more naturally.
7. Run the repository overview tests and confirm the paginator-related test cases pass.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1425" height="636" alt="Screenshot 2026-03-14 at 16 33 30" src="https://github.com/user-attachments/assets/45f417f7-2537-4df5-beab-39153c95fc3b" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
