### PR TITLE
feat: track release creators and show deploy source branch

### DIFF
--- a/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.html
+++ b/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.html
@@ -18,6 +18,13 @@
     </ng-container>
   } @else {
     <div class="pt-2">
+      @if (sourceRef()) {
+        <div class="mb-4 rounded border border-surface-300 bg-surface-50 px-3 py-2 text-sm dark:border-surface-700 dark:bg-surface-900/60" data-testid="deploy-source-ref">
+          <span class="text-muted-color">Branch to deploy:</span>
+          <code class="ml-2 font-semibold">{{ sourceRef() }}</code>
+        </div>
+      }
+
       <!-- Environment banner -->
       <div
         class="p-4 rounded flex items-start space-x-3"

--- a/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.spec.ts
+++ b/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.spec.ts
@@ -1,0 +1,77 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom, signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { DeployConfirmationComponent } from './deploy-confirmation.component';
+import { TestModule } from '@app/test.module';
+import { EnvironmentDto, EnvironmentReviewersDto } from '@app/core/modules/openapi';
+
+describe('DeployConfirmationComponent', () => {
+  let component: DeployConfirmationComponent;
+  let fixture: ComponentFixture<DeployConfirmationComponent>;
+
+  const environment: EnvironmentDto = {
+    id: 1,
+    name: 'production',
+    displayName: 'Production',
+    type: 'PRODUCTION',
+    repository: {
+      id: 1,
+      name: 'Helios',
+      nameWithOwner: 'ls1intum/Helios',
+      htmlUrl: 'https://github.com/ls1intum/Helios',
+      updatedAt: '2026-03-09T10:00:00Z',
+    },
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeployConfirmationComponent],
+      providers: [importProvidersFrom(TestModule)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeployConfirmationComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('isVisible', true);
+    fixture.componentRef.setInput('environment', environment);
+    component.query = {
+      ...component.query,
+      data: signal<EnvironmentReviewersDto>({ reviewers: [] }),
+      isPending: signal(false),
+    } as typeof component.query;
+  });
+
+  it('shows the source ref when provided', async () => {
+    fixture.componentRef.setInput('sourceRef', 'main');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const sourceRef = fixture.nativeElement.querySelector('[data-testid="deploy-source-ref"]');
+
+    expect(sourceRef).toBeTruthy();
+    expect(sourceRef.textContent).toContain('Branch to deploy:');
+    expect(sourceRef.textContent).toContain('main');
+  });
+
+  it('omits the source ref block when no source ref is provided', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="deploy-source-ref"]')).toBeNull();
+  });
+
+  it('keeps the deploy button disabled until repository confirmation matches', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const buttons = fixture.debugElement.queryAll(By.css('button'));
+    const deployButton = buttons.find(button => button.nativeElement.textContent.includes('Deploy'))?.nativeElement as HTMLButtonElement;
+
+    expect(deployButton.disabled).toBe(true);
+
+    component.repoConfirm = 'ls1intum/Helios';
+    fixture.detectChanges();
+
+    expect(deployButton.disabled).toBe(false);
+  });
+});

--- a/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.ts
+++ b/client/src/app/components/dialogs/deploy-confirmation/deploy-confirmation.component.ts
@@ -32,6 +32,8 @@ export class DeployConfirmationComponent {
   isVisible = model.required<boolean>();
   /** The environment to deploy */
   environment = input.required<EnvironmentDto>();
+  /** Optional source ref shown for deploy flows that need extra context. */
+  sourceRef = input<string>();
   environmentName = computed(() => (this.environment().displayName?.trim() ? this.environment().displayName : (this.environment().name ?? '')));
 
   /** Emits true if Deploy clicked, false if Cancel */

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.html
@@ -82,6 +82,7 @@
         <app-deploy-confirmation
           [(isVisible)]="deployDialogVisible"
           [environment]="this.selectedEnvironment()!"
+          [sourceRef]="deploySourceRef()"
           (confirmed)="onDeployReleaseCandidateConfirmed($event)"
         ></app-deploy-confirmation>
       }

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.spec.ts
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.spec.ts
@@ -1,0 +1,112 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom, signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { QueryClient, provideQueryClient } from '@tanstack/angular-query-experimental';
+import { MessageService } from 'primeng/api';
+import { ReleaseCandidateDeploymentTableComponent } from './release-candidate-deployment-table.component';
+import { DeployConfirmationComponent } from '@app/components/dialogs/deploy-confirmation/deploy-confirmation.component';
+import { TestModule } from '@app/test.module';
+import { EnvironmentDto, ReleaseInfoDetailsDto } from '@app/core/modules/openapi';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { PermissionService } from '@app/core/services/permission.service';
+
+describe('ReleaseCandidateDeploymentTableComponent', () => {
+  let component: ReleaseCandidateDeploymentTableComponent;
+  let fixture: ComponentFixture<ReleaseCandidateDeploymentTableComponent>;
+
+  const environment: EnvironmentDto = {
+    id: 7,
+    name: 'production',
+    displayName: 'Production',
+    type: 'PRODUCTION',
+    repository: {
+      id: 1,
+      name: 'Helios',
+      nameWithOwner: 'ls1intum/Helios',
+      htmlUrl: 'https://github.com/ls1intum/Helios',
+      updatedAt: '2026-03-09T10:00:00Z',
+    },
+  };
+
+  const releaseCandidate: ReleaseInfoDetailsDto = {
+    name: 'rc-1',
+    commit: {
+      sha: 'abcdef1234567',
+    },
+    branch: {
+      name: 'release/1.2.3',
+      commitSha: 'abcdef1234567',
+    },
+    deployments: [],
+    evaluations: [],
+    createdAt: '2026-03-09T10:00:00Z',
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReleaseCandidateDeploymentTableComponent],
+      providers: [
+        importProvidersFrom(TestModule),
+        provideQueryClient(new QueryClient()),
+        MessageService,
+        {
+          provide: KeycloakService,
+          useValue: {
+            isLoggedIn: () => true,
+          },
+        },
+        {
+          provide: PermissionService,
+          useValue: {
+            isAdmin: signal(true),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReleaseCandidateDeploymentTableComponent);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('releaseCandidate', releaseCandidate);
+    component.environmentQuery = {
+      ...component.environmentQuery,
+      data: signal([environment]),
+      isPending: signal(false),
+      isError: signal(false),
+    } as typeof component.environmentQuery;
+    component.deployToEnvironment = {
+      ...component.deployToEnvironment,
+      isPending: signal(false),
+    } as typeof component.deployToEnvironment;
+  });
+
+  it('passes the release candidate branch to the deploy confirmation dialog', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const deployButton = fixture.debugElement.queryAll(By.css('button')).find(button => button.nativeElement.textContent.includes('Deploy'))?.nativeElement as HTMLButtonElement;
+    deployButton.click();
+    fixture.detectChanges();
+
+    const dialog = fixture.debugElement.query(By.directive(DeployConfirmationComponent)).componentInstance as DeployConfirmationComponent;
+
+    expect(component.deployDialogVisible()).toBe(true);
+    expect(dialog.sourceRef()).toBe('release/1.2.3');
+  });
+
+  it('falls back to the release candidate name when no branch is present', async () => {
+    fixture.componentRef.setInput('releaseCandidate', {
+      ...releaseCandidate,
+      branch: undefined,
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.deployReleaseCandidate(environment);
+    fixture.detectChanges();
+
+    const dialog = fixture.debugElement.query(By.directive(DeployConfirmationComponent)).componentInstance as DeployConfirmationComponent;
+
+    expect(dialog.sourceRef()).toBe('rc-1');
+  });
+});

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
@@ -65,6 +65,7 @@ export class ReleaseCandidateDeploymentTableComponent {
     const environments = this.environmentQuery.data() || [];
     return environments.map(env => ({ ...env, type: env.type || 'Ungrouped' }));
   });
+  deploySourceRef = computed(() => this.releaseCandidate().branch?.name || this.releaseCandidate().name);
 
   deployToEnvironment = injectMutation(() => ({
     ...deployToEnvironmentMutation(),
@@ -91,7 +92,7 @@ export class ReleaseCandidateDeploymentTableComponent {
         {
           body: {
             environmentId: this.selectedEnvironment()!.id,
-            branchName: this.releaseCandidate().branch?.name || this.releaseCandidate().name,
+            branchName: this.deploySourceRef(),
             commitSha: this.releaseCandidate().commit.sha,
           },
         },

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -658,6 +658,9 @@ export const ReleaseDtoSchema = {
     githubUrl: {
       type: 'string',
     },
+    creator: {
+      $ref: '#/components/schemas/UserInfoDto',
+    },
   },
   required: ['body', 'githubUrl', 'isDraft', 'isPrerelease'],
 } as const;

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -220,6 +220,7 @@ export type ReleaseDto = {
   isPrerelease: boolean;
   body: string;
   githubUrl: string;
+  creator?: UserInfoDto;
 };
 
 export type ReleaseInfoDetailsDto = {

--- a/client/src/app/pages/release-candidate-details/release-candidate-details.component.html
+++ b/client/src/app/pages/release-candidate-details/release-candidate-details.component.html
@@ -58,6 +58,17 @@
           {{ releaseCandidate.createdBy?.login || 'Unknown' }}
           <span [pTooltip]="releaseCandidate.createdAt">{{ releaseCandidate.createdAt | timeAgo }}</span>
         </div>
+        @if (releaseCandidate.release?.creator; as releaseCreator) {
+          <div class="flex gap-1 items-center text-sm text-muted-color">
+            <div class="mr-1">release created by</div>
+            @if (releaseCreator.avatarUrl) {
+              <p-avatar class="size-4" shape="circle" [image]="releaseCreator.avatarUrl" />
+            } @else {
+              <i-tabler name="user" class="size-4 text-muted-color border-2 border-muted-color rounded-full" />
+            }
+            {{ releaseCreator.login }}
+          </div>
+        }
       </div>
     </div>
 

--- a/client/src/app/pages/release-candidate-details/release-candidate-details.spec.ts
+++ b/client/src/app/pages/release-candidate-details/release-candidate-details.spec.ts
@@ -1,16 +1,56 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom, signal } from '@angular/core';
 import { ReleaseCandidateDetailsComponent } from './release-candidate-details.component';
-import { importProvidersFrom } from '@angular/core';
+import { PermissionService } from '@app/core/services/permission.service';
 import { TestModule } from '@app/test.module';
+import { ReleaseInfoDetailsDto } from '@app/core/modules/openapi';
 
 describe('Integration Test Release Candidate Details Page', () => {
   let component: ReleaseCandidateDetailsComponent;
   let fixture: ComponentFixture<ReleaseCandidateDetailsComponent>;
 
+  const releaseCandidate: ReleaseInfoDetailsDto = {
+    name: 'test',
+    commit: {
+      sha: 'abcdef1234567',
+    },
+    deployments: [],
+    evaluations: [],
+    createdAt: '2026-03-09T10:00:00Z',
+    createdBy: {
+      id: 1,
+      login: 'candidate-owner',
+      avatarUrl: 'https://example.com/candidate.png',
+      name: 'Candidate Owner',
+      htmlUrl: 'https://github.com/candidate-owner',
+    },
+    release: {
+      isDraft: true,
+      isPrerelease: false,
+      body: 'Release notes',
+      githubUrl: 'https://github.com/ls1intum/Helios/releases/tag/test',
+      creator: {
+        id: 2,
+        login: 'release-owner',
+        avatarUrl: 'https://example.com/release.png',
+        name: 'Release Owner',
+        htmlUrl: 'https://github.com/release-owner',
+      },
+    },
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ReleaseCandidateDetailsComponent],
-      providers: [importProvidersFrom(TestModule)],
+      providers: [
+        importProvidersFrom(TestModule),
+        {
+          provide: PermissionService,
+          useValue: {
+            isAtLeastMaintainer: signal(false),
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ReleaseCandidateDetailsComponent);
@@ -18,11 +58,28 @@ describe('Integration Test Release Candidate Details Page', () => {
 
     // Set input properties
     fixture.componentRef.setInput('name', 'test');
+    component.releaseCandidateQuery = {
+      ...component.releaseCandidateQuery,
+      data: signal(releaseCandidate),
+      isPending: signal(false),
+      isError: signal(false),
+    } as typeof component.releaseCandidateQuery;
 
     await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders the published release creator separately from the release candidate creator', () => {
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent.replace(/\s+/g, ' ');
+
+    expect(text).toContain('created by');
+    expect(text).toContain('candidate-owner');
+    expect(text).toContain('release created by');
+    expect(text).toContain('release-owner');
   });
 });

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -2355,6 +2355,8 @@ components:
           type: string
         githubUrl:
           type: string
+        creator:
+          $ref: "#/components/schemas/UserInfoDto"
       required:
       - body
       - githubUrl

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoService.java
@@ -301,7 +301,7 @@ public class ReleaseInfoService {
         releaseNotes = generateReleaseNotes(tagName);
       }
 
-      // Get the current user's GitHub login
+      User releaseCreator = authService.getUserFromGithubId();
       String githubUserLogin = authService.getPreferredUsername();
 
       // Create the release using the user's token
@@ -317,7 +317,7 @@ public class ReleaseInfoService {
 
       // Process the release in the system
       gitHubReleaseSyncService.processRelease(
-          ghRelease, gitHubService.getRepository(repository.getNameWithOwner()));
+          ghRelease, gitHubService.getRepository(repository.getNameWithOwner()), releaseCreator);
 
     } catch (IOException e) {
       log.error("Failed to publish release: {}", e.getMessage());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/Release.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/Release.java
@@ -1,8 +1,12 @@
 package de.tum.cit.aet.helios.releaseinfo.release;
 
 import de.tum.cit.aet.helios.github.BaseGitServiceEntity;
+import de.tum.cit.aet.helios.user.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.OffsetDateTime;
@@ -42,4 +46,8 @@ public class Release extends BaseGitServiceEntity {
 
   @Column(name = "created_at")
   private OffsetDateTime createdAt;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "creator_id")
+  private User creator;
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/ReleaseDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/ReleaseDto.java
@@ -1,14 +1,20 @@
 package de.tum.cit.aet.helios.releaseinfo.release;
 
+import de.tum.cit.aet.helios.user.UserInfoDto;
 import org.springframework.lang.NonNull;
 
 public record ReleaseDto(
     @NonNull boolean isDraft,
     @NonNull boolean isPrerelease,
     @NonNull String body,
-    @NonNull String githubUrl) {
+    @NonNull String githubUrl,
+    UserInfoDto creator) {
   public static ReleaseDto fromRelease(@NonNull Release release) {
     return new ReleaseDto(
-        release.isDraft(), release.isPrerelease(), release.getBody(), release.getGithubUrl());
+        release.isDraft(),
+        release.isPrerelease(),
+        release.getBody(),
+        release.getGithubUrl(),
+        UserInfoDto.fromUser(release.getCreator()));
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
@@ -38,7 +38,8 @@ public class GitHubReleaseMessageHandler extends GitHubMessageHandler<GHEventPay
         return;
       }
       User creator =
-          eventPayload.getAction().equals("created") && eventPayload.getSender() != null
+          (eventPayload.getAction().equals("created") || eventPayload.getAction().equals("published"))
+              && eventPayload.getSender() != null
               ? gitHubUserSyncService.processUser(eventPayload.getSender())
               : null;
       repositorySyncService.processRepository(eventPayload.getRepository());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
@@ -33,12 +33,17 @@ public class GitHubReleaseMessageHandler extends GitHubMessageHandler<GHEventPay
         eventPayload.getAction());
     if (eventPayload.getAction().equals("created")
         || eventPayload.getAction().equals("edited")
-        || eventPayload.getAction().equals("published")) {
+        || eventPayload.getAction().equals("published")
+        || eventPayload.getAction().equals("prereleased")
+        || eventPayload.getAction().equals("released")) {
       if (eventPayload.getRelease().isDraft()) {
         return;
       }
       User creator =
-          (eventPayload.getAction().equals("created") || eventPayload.getAction().equals("published"))
+          (eventPayload.getAction().equals("created")
+                  || eventPayload.getAction().equals("published")
+                  || eventPayload.getAction().equals("prereleased")
+                  || eventPayload.getAction().equals("released"))
               && eventPayload.getSender() != null
               ? gitHubUserSyncService.processUser(eventPayload.getSender())
               : null;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseMessageHandler.java
@@ -4,6 +4,8 @@ import de.tum.cit.aet.helios.github.GitHubMessageHandler;
 import de.tum.cit.aet.helios.gitrepo.github.GitHubRepositorySyncService;
 import de.tum.cit.aet.helios.releaseinfo.release.ReleaseRepository;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidateRepository;
+import de.tum.cit.aet.helios.user.User;
+import de.tum.cit.aet.helios.user.github.GitHubUserSyncService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.kohsuke.github.GHEvent;
@@ -20,6 +22,7 @@ public class GitHubReleaseMessageHandler extends GitHubMessageHandler<GHEventPay
   private final GitHubRepositorySyncService repositorySyncService;
   private final ReleaseRepository releaseRepository;
   private final ReleaseCandidateRepository releaseCandidateRepository;
+  private final GitHubUserSyncService gitHubUserSyncService;
 
   @Override
   protected void handleInstalledRepositoryEvent(GHEventPayload.Release eventPayload) {
@@ -34,8 +37,13 @@ public class GitHubReleaseMessageHandler extends GitHubMessageHandler<GHEventPay
       if (eventPayload.getRelease().isDraft()) {
         return;
       }
+      User creator =
+          eventPayload.getAction().equals("created") && eventPayload.getSender() != null
+              ? gitHubUserSyncService.processUser(eventPayload.getSender())
+              : null;
       repositorySyncService.processRepository(eventPayload.getRepository());
-      releaseSyncService.processRelease(eventPayload.getRelease(), eventPayload.getRepository());
+      releaseSyncService.processRelease(
+          eventPayload.getRelease(), eventPayload.getRepository(), creator);
     } else if (eventPayload.getAction().equals("deleted")) {
       releaseCandidateRepository
           .findByRepositoryRepositoryIdAndReleaseId(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncService.java
@@ -8,6 +8,7 @@ import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.releaseinfo.release.ReleaseRepository;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidate;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidateRepository;
+import de.tum.cit.aet.helios.user.User;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -39,10 +40,24 @@ public class GitHubReleaseSyncService {
    */
   @Transactional
   public void processRelease(GHRelease ghRelease, GHRepository ghRepository) {
+    processRelease(ghRelease, ghRepository, null);
+  }
+
+  /**
+   * Processes a single GitHub release and stores the creator when the release is first seen.
+   *
+   * @param ghRelease the GitHub release to process
+   * @param ghRepository the repository that owns the release
+   * @param creator the creator to persist for newly created releases
+   */
+  @Transactional
+  public void processRelease(GHRelease ghRelease, GHRepository ghRepository, User creator) {
     var repository = gitRepoRepository.findByNameWithOwner(ghRepository.getFullName());
+    var existingRelease = releaseRepository.findById(ghRelease.getId());
+    boolean isNewRelease = existingRelease.isEmpty();
     var result =
-        releaseRepository
-            .findById(ghRelease.getId())
+        existingRelease
+            .map(release -> releaseConverter.update(ghRelease, release))
             .orElseGet(() -> releaseConverter.convert(ghRelease));
 
     if (result == null) {
@@ -50,6 +65,9 @@ public class GitHubReleaseSyncService {
     }
 
     result.setRepository(repository);
+    if (isNewRelease && creator != null) {
+      result.setCreator(creator);
+    }
 
     releaseRepository.saveAndFlush(result);
 

--- a/server/application-server/src/main/resources/db/migration/V37__add_release_creator.sql
+++ b/server/application-server/src/main/resources/db/migration/V37__add_release_creator.sql
@@ -1,0 +1,5 @@
+ALTER TABLE public.release ADD COLUMN creator_id bigint;
+
+ALTER TABLE public.release
+    ADD CONSTRAINT fk_release_creator
+    FOREIGN KEY (creator_id) REFERENCES public."user"(id);

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/ReleaseInfoServiceTest.java
@@ -503,6 +503,7 @@ class ReleaseInfoServiceTest {
     rel.setPrerelease(false);
     rel.setBody("Release notes");
     rel.setGithubUrl("http://github.com/release/1.0");
+    rel.setCreator(creator);
 
     // --- One evaluation ---
     ReleaseCandidateEvaluation eval = new ReleaseCandidateEvaluation();
@@ -559,6 +560,8 @@ class ReleaseInfoServiceTest {
     Assertions.assertNotNull(details.release());
     assertEquals("Release notes", details.release().body());
     assertEquals("http://github.com/release/1.0", details.release().githubUrl());
+    assertEquals(42L, details.release().creator().id());
+    assertEquals("testuser", details.release().creator().login());
 
     // Creator UserInfoDto
     assertEquals(42L, details.createdBy().id());
@@ -771,6 +774,9 @@ class ReleaseInfoServiceTest {
     when(gitRepoRepository.findById(repoId)).thenReturn(Optional.of(repo));
     when(releaseCandidateRepository.findByRepositoryRepositoryIdAndName(repoId, tagName))
         .thenReturn(Optional.of(rc));
+    User releaseCreator = new User();
+    releaseCreator.setId(7L);
+    when(authService.getUserFromGithubId()).thenReturn(releaseCreator);
     when(authService.getPreferredUsername()).thenReturn("testuser");
     // Spy to stub generateReleaseNotes
     ReleaseInfoService spyService = Mockito.spy(service);
@@ -785,7 +791,8 @@ class ReleaseInfoServiceTest {
     // Act
     spyService.publishReleaseDraft(tagName);
     // Assert
-    verify(gitHubReleaseSyncService).processRelease(eq(ghRelease), eq(mockGhRepo));
+    verify(gitHubReleaseSyncService)
+        .processRelease(eq(ghRelease), eq(mockGhRepo), eq(releaseCreator));
   }
 
   @Test
@@ -805,6 +812,9 @@ class ReleaseInfoServiceTest {
     when(gitRepoRepository.findById(repoId)).thenReturn(Optional.of(repo));
     when(releaseCandidateRepository.findByRepositoryRepositoryIdAndName(repoId, tagName))
         .thenReturn(Optional.of(rc));
+    User releaseCreator = new User();
+    releaseCreator.setId(7L);
+    when(authService.getUserFromGithubId()).thenReturn(releaseCreator);
     when(authService.getPreferredUsername()).thenReturn("testuser");
     // Spy to stub generateReleaseNotes
     ReleaseInfoService spyService = Mockito.spy(service);
@@ -838,6 +848,9 @@ class ReleaseInfoServiceTest {
     when(gitRepoRepository.findById(repoId)).thenReturn(Optional.of(repo));
     when(releaseCandidateRepository.findByRepositoryRepositoryIdAndName(repoId, tagName))
         .thenReturn(Optional.of(rc));
+    User releaseCreator = new User();
+    releaseCreator.setId(7L);
+    when(authService.getUserFromGithubId()).thenReturn(releaseCreator);
     when(authService.getPreferredUsername()).thenReturn("testuser");
 
     // Stub getRepository(...) to return a non‐null GHRepository
@@ -853,7 +866,8 @@ class ReleaseInfoServiceTest {
     service.publishReleaseDraft(tagName);
 
     // Assert: now second argument to processRelease(...) will be mockGhRepo instead of null
-    verify(gitHubReleaseSyncService).processRelease(eq(ghRelease), eq(mockGhRepo));
+    verify(gitHubReleaseSyncService)
+        .processRelease(eq(ghRelease), eq(mockGhRepo), eq(releaseCreator));
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.lenient;
 
 import de.tum.cit.aet.helios.commit.Commit;
 import de.tum.cit.aet.helios.commit.CommitRepository;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/releaseinfo/release/github/GitHubReleaseSyncServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import de.tum.cit.aet.helios.commit.Commit;
 import de.tum.cit.aet.helios.commit.CommitRepository;
@@ -19,6 +20,7 @@ import de.tum.cit.aet.helios.releaseinfo.release.Release;
 import de.tum.cit.aet.helios.releaseinfo.release.ReleaseRepository;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidate;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidateRepository;
+import de.tum.cit.aet.helios.user.User;
 import java.io.IOException;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,7 +84,8 @@ class GitHubReleaseSyncServiceTest {
 
     when(gitRepoRepository.findByNameWithOwner("owner/repo")).thenReturn(repository);
     when(releaseRepository.findById(1L)).thenReturn(Optional.of(release));
-    when(releaseRepository.saveAndFlush(release)).thenReturn(release);
+    lenient().when(releaseRepository.saveAndFlush(release)).thenReturn(release);
+    lenient().when(releaseConverter.update(ghRelease, release)).thenReturn(release);
     when(releaseCandidateRepository.findByRepositoryRepositoryIdAndName(42L, "v1.0.0"))
         .thenReturn(Optional.empty());
 
@@ -154,5 +157,42 @@ class GitHubReleaseSyncServiceTest {
     verify(commitSyncService).processCommit(ghCommit, ghRepository);
     verify(currentRepository, never()).getTagObject(anyString());
     verify(releaseCandidateRepository).saveAndFlush(any(ReleaseCandidate.class));
+  }
+
+  @Test
+  void processRelease_newRelease_setsCreatorOnce() throws IOException {
+    User creator = new User();
+    creator.setId(99L);
+
+    Release newRelease = new Release();
+    newRelease.setId(1L);
+
+    when(releaseRepository.findById(1L)).thenReturn(Optional.empty());
+    when(releaseConverter.convert(ghRelease)).thenReturn(newRelease);
+    when(releaseRepository.saveAndFlush(newRelease)).thenReturn(newRelease);
+    when(refObject.getType()).thenReturn("commit");
+    when(refObject.getSha()).thenReturn("missing-commit-sha");
+    when(commitRepository.findByShaAndRepositoryRepositoryId("missing-commit-sha", 42L))
+        .thenReturn(Optional.empty());
+    when(currentRepository.getCommit("missing-commit-sha"))
+        .thenThrow(new IOException("No commit found"));
+
+    service.processRelease(ghRelease, ghRepository, creator);
+
+    assertSame(creator, newRelease.getCreator());
+  }
+
+  @Test
+  void processRelease_existingRelease_preservesOriginalCreator() {
+    User originalCreator = new User();
+    originalCreator.setId(11L);
+    release.setCreator(originalCreator);
+
+    User newCreator = new User();
+    newCreator.setId(12L);
+
+    service.processRelease(ghRelease, ghRepository, newCreator);
+
+    assertSame(originalCreator, release.getCreator());
   }
 }


### PR DESCRIPTION


<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Release candidate details currently do not expose who created the underlying GitHub release, which makes it hard to distinguish the release publisher from the release candidate creator. The deploy confirmation dialog also lacks the source branch/ref, so reviewers do not get enough context before triggering a deployment. #621 


### Description
<!-- Describe your changes in detail -->

- Persist the release creator for newly synced/published releases and expose it via ReleaseDto and the generated OpenAPI client.
- Show the release creator separately on the release candidate details page, including avatar fallback handling.
- Pass the release candidate branch through the deployment flow and display it in the deploy confirmation dialog, with fallback to the release candidate name when no branch is available.
- Add backend and frontend tests covering creator persistence, DTO mapping, release details rendering, and deploy dialog source-ref behavior.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:

- Helios running with server and client changes from this branch
- A repository that has a release candidate and a synced or newly published GitHub release
- Maintainer/Admin access for publishing a release and triggering a deployment
- Developer access for verifying the read-only release candidate details view

#### Flow:

1. Log in to Helios and open a release candidate details page for a release that was created or synced after this change.
2. Verify the page still shows the release candidate creator and now also shows a separate release created by entry for the published release creator.
3. As a Maintainer/Admin, open the deploy action for that release candidate and verify the confirmation dialog shows Branch to deploy with the release candidate branch.
4. Repeat with a release candidate that has no branch metadata and verify the dialog falls back to the release candidate name.
5. Publish a new release draft from Helios or trigger a GitHub release sync, then reopen the release candidate details page and verify the release creator is populated for the newly created release.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="588" height="333" alt="Screenshot 2026-03-14 at 18 23 21" src="https://github.com/user-attachments/assets/3ac0bf92-2cd4-4b3b-8a04-39f47c37873e" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.
