### PR TITLE
feat: add workflow runs by repository endpoint with pagination and filtering options

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -80,7 +80,7 @@ export const routes: Routes = [
             children: [
               {
                 path: '',
-                redirectTo: 'runs',
+                redirectTo: 'pr',
                 pathMatch: 'full',
               },
               {

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -80,8 +80,12 @@ export const routes: Routes = [
             children: [
               {
                 path: '',
-                redirectTo: 'pr',
+                redirectTo: 'runs',
                 pathMatch: 'full',
+              },
+              {
+                path: 'runs',
+                loadComponent: () => import('@app/pages/workflow-run-list/workflow-run-list.component').then(m => m.WorkflowRunListComponent),
               },
               {
                 path: 'pr',

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
@@ -1,0 +1,103 @@
+<p-table
+  #table
+  [rowHover]="true"
+  [value]="runs()"
+  [lazy]="true"
+  [totalRecords]="totalElements()"
+  [paginator]="true"
+  [rows]="paginationService.size()"
+  [first]="(paginationService.page() - 1) * paginationService.size()"
+  [rowsPerPageOptions]="[5, 10, 20, 30, 50]"
+  [loading]="query.isPending()"
+  (onPage)="onPage($event)"
+  (sortFunction)="onSort($event)"
+  [customSort]="true"
+  [sortField]="paginationService.sortField()"
+  [sortOrder]="paginationService.sortDirection() === 'asc' ? 1 : -1"
+>
+  <ng-template #header>
+    <tr>
+      <th>
+        <app-table-filter-paginated [paginationService]="typedPaginationService" [table]="table" />
+      </th>
+      <th class="hidden md:table-cell">Status</th>
+      <th class="hidden lg:table-cell">Tests</th>
+      <th class="hidden lg:table-cell">Started</th>
+      <th class="hidden lg:table-cell">Updated</th>
+    </tr>
+  </ng-template>
+
+  <ng-template pTemplate="body" let-run>
+    @if (query.isPending() || query.isError()) {
+      <tr>
+        <td colspan="5">
+          <div class="flex flex-col gap-2">
+            <p-skeleton class="w-80" />
+            <p-skeleton class="w-64" />
+          </div>
+        </td>
+      </tr>
+    } @else {
+      <tr>
+        <td class="px-2 py-2">
+          <div class="flex flex-col gap-2.5">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-bold truncate max-w-md">
+                {{ run.displayTitle || run.name }}
+              </span>
+              <p-button text (click)="openRunExternal($event, run)" styleClass="p-1" class="leading-none">
+                <i-tabler name="brand-github" class="!size-4" />
+              </p-button>
+              <p-tag [value]="run.label === 'TEST' ? 'Test' : 'General'" [severity]="run.label === 'TEST' ? 'info' : 'secondary'" rounded class="text-xs" />
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs text-muted-color">
+              @if (run.headBranch) {
+                <span>on {{ run.headBranch }}</span>
+              }
+              @if (run.headSha) {
+                <span class="font-mono">({{ run.headSha.slice(0, 7) }})</span>
+              }
+            </div>
+          </div>
+        </td>
+        <td class="hidden md:table-cell w-40">
+          <div class="flex items-center gap-2">
+            <i-tabler [name]="getWorkflowStatusIcon(run)" [class]="getWorkflowStatusClass(run)" class="!size-5" [pTooltip]="run.conclusion || run.status" />
+            <span class="text-sm">{{ run.conclusion || run.status }}</span>
+          </div>
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          @if (run.testProcessingStatus) {
+            <div class="flex items-center gap-2">
+              <i-tabler [name]="getTestStatusIcon(run)" [class]="getTestStatusClass(run)" class="!size-5" [pTooltip]="run.testProcessingStatus" />
+              <span class="text-sm">{{ run.testProcessingStatus }}</span>
+            </div>
+          } @else {
+            <span class="text-sm text-muted-color">—</span>
+          }
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          @if (run.runStartedAt) {
+            <span class="text-sm">{{ run.runStartedAt | timeAgo }}</span>
+          }
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          <span class="text-sm">{{ run.updatedAt | timeAgo }}</span>
+        </td>
+      </tr>
+    }
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="5">
+        <div class="flex flex-col gap-2 p-20 justify-center items-center">
+          <i-tabler name="git-pull-request" class="!h-20 !w-20 text-red-500" />
+          <span class="font-semibold text-xl">There are no workflow runs found matching your filter criteria.</span>
+          <span>Try clearing the filter or reloading the page.</span>
+          <p-button (click)="clearFilters()">Clear Filter</p-button>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
+</p-table>

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
@@ -92,7 +92,7 @@
     <tr>
       <td colspan="5">
         <div class="flex flex-col gap-2 p-20 justify-center items-center">
-          <i-tabler name="git-pull-request" class="!h-20 !w-20 text-red-500" />
+          <i-tabler name="player-play" class="!h-20 !w-20 text-red-500" />
           <span class="font-semibold text-xl">There are no workflow runs found matching your filter criteria.</span>
           <span>Try clearing the filter or reloading the page.</span>
           <p-button (click)="clearFilters()">Clear Filter</p-button>

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
@@ -1,0 +1,299 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideQueryClient, QueryClient } from '@tanstack/angular-query-experimental';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { vi } from 'vitest';
+
+import { WorkflowRunsTableComponent, createWorkflowRunsFilterOptions } from './workflow-runs-table.component';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import type { WorkflowRunDto } from '@app/core/modules/openapi';
+
+function createRun(overrides: Partial<WorkflowRunDto> = {}): WorkflowRunDto {
+  return {
+    id: 1,
+    name: 'CI',
+    displayTitle: 'CI',
+    status: 'COMPLETED',
+    workflowId: 10,
+    htmlUrl: 'https://github.com/org/repo/actions/runs/1',
+    label: 'TEST',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+type QueryData = {
+  runs?: WorkflowRunDto[];
+  totalElements?: number;
+};
+
+function setMockQuery(
+  component: WorkflowRunsTableComponent,
+  options: {
+    data?: QueryData | undefined;
+    isPending?: boolean;
+    isError?: boolean;
+    refetch?: () => void;
+  } = {}
+) {
+  const refetch = options.refetch ?? vi.fn();
+
+  Object.defineProperty(component, 'query', {
+    configurable: true,
+    value: {
+      data: () => options.data,
+      isPending: () => options.isPending ?? false,
+      isError: () => options.isError ?? false,
+      refetch,
+    },
+  });
+
+  return { refetch };
+}
+
+describe('WorkflowRunsTableComponent', () => {
+  let component: WorkflowRunsTableComponent;
+  let fixture: ComponentFixture<WorkflowRunsTableComponent>;
+
+  const keycloakMock = {
+    isLoggedIn: () => false,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkflowRunsTableComponent],
+      providers: [provideZonelessChangeDetection(), provideQueryClient(new QueryClient()), provideNoopAnimations(), { provide: KeycloakService, useValue: keycloakMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkflowRunsTableComponent);
+    component = fixture.componentInstance;
+
+    setMockQuery(component, { data: undefined, isPending: false, isError: false });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('runs() and totalElements()', () => {
+    it('should return empty array and 0 when query has no data', () => {
+      expect(component.runs()).toEqual([]);
+      expect(component.totalElements()).toBe(0);
+    });
+
+    it('returns runs and totalElements from query data', () => {
+      const runs = [createRun({ id: 1 }), createRun({ id: 2, name: 'Build' })];
+      setMockQuery(component, {
+        data: {
+          runs,
+          totalElements: 42,
+        },
+      });
+
+      expect(component.runs()).toEqual(runs);
+      expect(component.totalElements()).toBe(42);
+    });
+  });
+
+  describe('getWorkflowStatusIcon', () => {
+    type IconName = ReturnType<WorkflowRunsTableComponent['getWorkflowStatusIcon']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, IconName]> = [
+      [{ conclusion: 'SUCCESS' }, 'circle-check'],
+      [{ conclusion: 'FAILURE' }, 'circle-x'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'circle-x'],
+      [{ conclusion: 'TIMED_OUT' }, 'circle-x'],
+      [{ conclusion: 'CANCELLED' }, 'circle-x'],
+      [{ status: 'IN_PROGRESS' }, 'progress'],
+      [{ status: 'QUEUED' }, 'clock-hour-4'],
+      [{ status: 'WAITING' }, 'clock-hour-4'],
+      [{ status: 'PENDING' }, 'clock-hour-4'],
+      [{ status: 'REQUESTED' }, 'clock-hour-4'],
+      [{ status: 'ACTION_REQUIRED' }, 'alert-triangle'],
+      [{ conclusion: 'ACTION_REQUIRED' }, 'alert-triangle'],
+      [{ status: 'COMPLETED' }, 'circle-x'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, IconName]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual = component.getWorkflowStatusIcon(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('getWorkflowStatusClass', () => {
+    type WorkflowStatusClass = ReturnType<WorkflowRunsTableComponent['getWorkflowStatusClass']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, WorkflowStatusClass]> = [
+      [{ conclusion: 'SUCCESS' }, 'text-green-500'],
+      [{ conclusion: 'FAILURE' }, 'text-red-500'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'text-red-500'],
+      [{ conclusion: 'TIMED_OUT' }, 'text-red-500'],
+      [{ conclusion: 'CANCELLED' }, 'text-surface-500'],
+      [{ status: 'QUEUED' }, 'text-amber-500'],
+      [{ status: 'WAITING' }, 'text-amber-500'],
+      [{ status: 'PENDING' }, 'text-amber-500'],
+      [{ status: 'REQUESTED' }, 'text-amber-500'],
+      [{ status: 'ACTION_REQUIRED' }, 'text-orange-500'],
+      [{ conclusion: 'ACTION_REQUIRED' }, 'text-orange-500'],
+      [{ status: 'COMPLETED' }, 'text-surface-500'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, WorkflowStatusClass]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: WorkflowStatusClass = component.getWorkflowStatusClass(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('returns animated blue class for IN_PROGRESS', () => {
+      const actual: WorkflowStatusClass = component.getWorkflowStatusClass(createRun({ status: 'IN_PROGRESS' }));
+
+      expect(actual).toContain('text-blue-500');
+      expect(actual).toContain('animate-spin');
+    });
+  });
+
+  describe('getTestStatusIcon', () => {
+    type TestIcon = ReturnType<WorkflowRunsTableComponent['getTestStatusIcon']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, TestIcon]> = [
+      [{ testProcessingStatus: 'PROCESSED' }, 'circle-check'],
+      [{ testProcessingStatus: 'FAILED' }, 'alert-triangle'],
+      [{ testProcessingStatus: 'PROCESSING' }, 'progress'],
+      [{}, 'circle-check'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, TestIcon]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: TestIcon = component.getTestStatusIcon(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('getTestStatusClass', () => {
+    type TestStatusClass = ReturnType<WorkflowRunsTableComponent['getTestStatusClass']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, TestStatusClass]> = [
+      [{ testProcessingStatus: 'PROCESSED' }, 'text-green-500'],
+      [{ testProcessingStatus: 'FAILED' }, 'text-red-500'],
+      [{}, 'text-surface-500'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, TestStatusClass]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: TestStatusClass = component.getTestStatusClass(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('returns animated blue class for PROCESSING', () => {
+      const actual: TestStatusClass = component.getTestStatusClass(createRun({ testProcessingStatus: 'PROCESSING' }));
+
+      expect(actual).toContain('text-blue-500');
+      expect(actual).toContain('animate-spin');
+    });
+  });
+
+  describe('statusSeverity', () => {
+    type StatusSeverity = ReturnType<WorkflowRunsTableComponent['statusSeverity']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, StatusSeverity]> = [
+      [{ conclusion: 'SUCCESS' }, 'success'],
+      [{ conclusion: 'FAILURE' }, 'danger'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'danger'],
+      [{ conclusion: 'TIMED_OUT' }, 'danger'],
+      [{ conclusion: 'CANCELLED' }, 'secondary'],
+      [{ status: 'IN_PROGRESS' }, 'info'],
+      [{ status: 'QUEUED' }, 'warn'],
+      [{ status: 'WAITING' }, 'warn'],
+      [{ status: 'PENDING' }, 'warn'],
+      [{ status: 'REQUESTED' }, 'warn'],
+      [{ status: 'COMPLETED' }, 'secondary'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, StatusSeverity]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: StatusSeverity = component.statusSeverity(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('openRunExternal', () => {
+    it('opens run htmlUrl in new tab and stops propagation', () => {
+      const run = createRun({ htmlUrl: 'https://github.com/org/repo/actions/runs/42' });
+      const ev = new Event('click') as Event & { stopPropagation: () => void };
+      ev.stopPropagation = vi.fn();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      component.openRunExternal(ev, run);
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com/org/repo/actions/runs/42', '_blank');
+      expect(ev.stopPropagation).toHaveBeenCalled();
+    });
+  });
+
+  describe('onPage', () => {
+    it('calls pagination service onPage with the event', () => {
+      const onPageSpy = vi.spyOn(component.paginationService, 'onPage');
+      const refetchSpy = vi.fn();
+      setMockQuery(component, { refetch: refetchSpy });
+
+      const event = { first: 20, rows: 20, page: 1 };
+
+      component.onPage(event as Parameters<WorkflowRunsTableComponent['onPage']>[0]);
+
+      expect(onPageSpy).toHaveBeenCalledWith(event);
+      expect(refetchSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onSort', () => {
+    it('updates pagination sort state', () => {
+      const onSortSpy = vi.spyOn(component.paginationService, 'onSort');
+      const event = { field: 'name', order: 1 };
+
+      component.onSort(event as Parameters<WorkflowRunsTableComponent['onSort']>[0]);
+
+      expect(onSortSpy).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('clears filter component and pagination filters', () => {
+      const clearSearchSpy = vi.fn();
+      const clearFiltersSpy = vi.spyOn(component.paginationService, 'clearFilters');
+      (component as unknown as { filterComponent: { clearSearch: () => void } }).filterComponent = {
+        clearSearch: clearSearchSpy,
+      };
+
+      component.clearFilters();
+
+      expect(clearSearchSpy).toHaveBeenCalled();
+      expect(clearFiltersSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('createWorkflowRunsFilterOptions', () => {
+    it('exports filter options with expected labels and values', () => {
+      const options = createWorkflowRunsFilterOptions();
+
+      expect(options).toEqual([
+        { name: 'All runs', value: 'ALL' },
+        { name: 'Not started', value: 'NOT_STARTED' },
+        { name: 'In progress', value: 'IN_PROGRESS' },
+        { name: 'Succeeded', value: 'SUCCESS' },
+        { name: 'Failed', value: 'FAILURE' },
+        { name: 'Cancelled', value: 'CANCELLED' },
+        { name: 'Action required', value: 'ACTION_REQUIRED' },
+      ]);
+    });
+  });
+});

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
@@ -243,15 +243,12 @@ describe('WorkflowRunsTableComponent', () => {
   describe('onPage', () => {
     it('calls pagination service onPage with the event', () => {
       const onPageSpy = vi.spyOn(component.paginationService, 'onPage');
-      const refetchSpy = vi.fn();
-      setMockQuery(component, { refetch: refetchSpy });
 
       const event = { first: 20, rows: 20, page: 1 };
 
       component.onPage(event as Parameters<WorkflowRunsTableComponent['onPage']>[0]);
 
       expect(onPageSpy).toHaveBeenCalledWith(event);
-      expect(refetchSpy).toHaveBeenCalled();
     });
   });
 

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, ViewChild } from '@angular/core';
+import { Component, computed, inject, ViewChild } from '@angular/core';
 import { Table, TableModule, TablePageEvent } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
@@ -44,7 +44,7 @@ export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
       IconClockHour4,
       IconAlertTriangle,
       IconBrandGithub,
-      IconPlayerPlay
+      IconPlayerPlay,
     }),
   ],
   templateUrl: './workflow-runs-table.component.html',

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -1,0 +1,203 @@
+import { Component, computed, effect, inject, ViewChild } from '@angular/core';
+import { Table, TableModule, TablePageEvent } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
+import { SkeletonModule } from 'primeng/skeleton';
+import { ButtonModule } from 'primeng/button';
+import { DividerModule } from 'primeng/divider';
+import { SelectModule } from 'primeng/select';
+import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
+import { WorkflowRunDto } from '@app/core/modules/openapi';
+import { injectQuery } from '@tanstack/angular-query-experimental';
+import { getWorkflowRunsOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
+import { MessageService, SortMeta } from 'primeng/api';
+import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
+import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconGitPullRequest, IconProgress } from 'angular-tabler-icons/icons';
+
+export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
+  return [
+    { name: 'All runs', value: 'ALL' },
+    { name: 'Not started', value: 'NOT_STARTED' },
+    { name: 'In progress', value: 'IN_PROGRESS' },
+    { name: 'Succeeded', value: 'SUCCESS' },
+    { name: 'Failed', value: 'FAILURE' },
+    { name: 'Cancelled', value: 'CANCELLED' },
+    { name: 'Action required', value: 'ACTION_REQUIRED' },
+  ];
+}
+
+@Component({
+  selector: 'app-workflow-runs-table',
+  standalone: true,
+  imports: [TableModule, TagModule, TimeAgoPipe, SelectModule, TablerIconComponent, SkeletonModule, TooltipModule, ButtonModule, DividerModule, TableFilterPaginatedComponent],
+  providers: [
+    PaginatedTableService,
+    MessageService,
+    { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createWorkflowRunsFilterOptions },
+    provideTablerIcons({
+      IconFilterPlus,
+      IconGitPullRequest,
+      IconCircleCheck,
+      IconCircleX,
+      IconProgress,
+      IconClockHour4,
+      IconAlertTriangle,
+      IconBrandGithub,
+    }),
+  ],
+  templateUrl: './workflow-runs-table.component.html',
+})
+export class WorkflowRunsTableComponent {
+  @ViewChild('table') table!: Table;
+  @ViewChild(TableFilterPaginatedComponent) filterComponent!: TableFilterPaginatedComponent;
+
+  messageService = inject(MessageService);
+  paginationService = inject(PaginatedTableService);
+
+  queryOptions = computed(() => {
+    const paginationState = this.paginationService.paginationState();
+    const filterType = paginationState.filterType as 'ALL' | 'NOT_STARTED' | 'IN_PROGRESS' | 'CANCELLED' | 'SUCCESS' | 'FAILURE' | 'ACTION_REQUIRED' | undefined;
+
+    return getWorkflowRunsOptions({
+      query: {
+        page: paginationState.page,
+        size: paginationState.size,
+        sortField: paginationState.sortField,
+        sortDirection: paginationState.sortDirection,
+        filterType: filterType,
+        searchTerm: paginationState.searchTerm,
+      },
+    });
+  });
+
+  query = injectQuery(() => this.queryOptions());
+
+  constructor() {
+    effect(() => {
+      this.paginationService.paginationState();
+      if (this.query.data()) {
+        this.query.refetch();
+      }
+    });
+  }
+
+  get typedPaginationService() {
+    return this.paginationService as PaginatedTableService;
+  }
+
+  runs(): WorkflowRunDto[] {
+    // Backend returns a paginated response; keep type-safe access here.
+    // We intentionally type cast to `any` to avoid duplicating the generated type.
+    const data = this.query.data() as { runs?: WorkflowRunDto[] } | undefined;
+    return data?.runs ?? [];
+  }
+
+  totalElements(): number {
+    const data = this.query.data() as { totalElements?: number } | undefined;
+    return data?.totalElements ?? 0;
+  }
+
+  onPage(event: TablePageEvent) {
+    this.paginationService.onPage(event);
+    this.query.refetch();
+  }
+
+  onSort(event: SortMeta) {
+    this.paginationService.onSort(event);
+  }
+
+  clearFilters() {
+    this.filterComponent.clearSearch();
+    this.paginationService.clearFilters();
+  }
+
+  statusSeverity(run: WorkflowRunDto): 'success' | 'danger' | 'info' | 'warn' | 'secondary' {
+    if (run.conclusion === 'SUCCESS') return 'success';
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'danger';
+    }
+    if (run.conclusion === 'CANCELLED') return 'secondary';
+    if (run.status === 'IN_PROGRESS') return 'info';
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'warn';
+    }
+    return 'secondary';
+  }
+
+  openRunExternal(event: Event, run: WorkflowRunDto) {
+    window.open(run.htmlUrl, '_blank');
+    event.stopPropagation();
+  }
+
+  getWorkflowStatusIcon(run: WorkflowRunDto): string {
+    if (run.conclusion === 'SUCCESS') {
+      return 'circle-check';
+    }
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'circle-x';
+    }
+    if (run.conclusion === 'CANCELLED') {
+      return 'circle-x';
+    }
+    if (run.status === 'IN_PROGRESS') {
+      return 'progress';
+    }
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'clock-hour-4';
+    }
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') {
+      return 'alert-triangle';
+    }
+    return 'circle-x';
+  }
+
+  getWorkflowStatusClass(run: WorkflowRunDto): string {
+    if (run.conclusion === 'SUCCESS') {
+      return 'text-green-500';
+    }
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'text-red-500';
+    }
+    if (run.conclusion === 'CANCELLED') {
+      return 'text-surface-500';
+    }
+    if (run.status === 'IN_PROGRESS') {
+      return 'text-blue-500 animate-spin';
+    }
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'text-amber-500';
+    }
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') {
+      return 'text-orange-500';
+    }
+    return 'text-surface-500';
+  }
+
+  getTestStatusIcon(run: WorkflowRunDto): string {
+    if (run.testProcessingStatus === 'PROCESSED') {
+      return 'circle-check';
+    }
+    if (run.testProcessingStatus === 'FAILED') {
+      return 'alert-triangle';
+    }
+    if (run.testProcessingStatus === 'PROCESSING') {
+      return 'progress';
+    }
+    return 'circle-check';
+  }
+
+  getTestStatusClass(run: WorkflowRunDto): string {
+    if (run.testProcessingStatus === 'PROCESSED') {
+      return 'text-green-500';
+    }
+    if (run.testProcessingStatus === 'FAILED') {
+      return 'text-red-500';
+    }
+    if (run.testProcessingStatus === 'PROCESSING') {
+      return 'text-blue-500 animate-spin';
+    }
+    return 'text-surface-500';
+  }
+}

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -14,7 +14,7 @@ import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableSe
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { MessageService, SortMeta } from 'primeng/api';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconGitPullRequest, IconProgress } from 'angular-tabler-icons/icons';
+import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconPlayerPlay, IconProgress } from 'angular-tabler-icons/icons';
 
 export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
   return [
@@ -38,13 +38,13 @@ export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
     { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createWorkflowRunsFilterOptions },
     provideTablerIcons({
       IconFilterPlus,
-      IconGitPullRequest,
       IconCircleCheck,
       IconCircleX,
       IconProgress,
       IconClockHour4,
       IconAlertTriangle,
       IconBrandGithub,
+      IconPlayerPlay
     }),
   ],
   templateUrl: './workflow-runs-table.component.html',
@@ -74,15 +74,6 @@ export class WorkflowRunsTableComponent {
 
   query = injectQuery(() => this.queryOptions());
 
-  constructor() {
-    effect(() => {
-      this.paginationService.paginationState();
-      if (this.query.data()) {
-        this.query.refetch();
-      }
-    });
-  }
-
   get typedPaginationService() {
     return this.paginationService as PaginatedTableService;
   }
@@ -101,7 +92,6 @@ export class WorkflowRunsTableComponent {
 
   onPage(event: TablePageEvent) {
     this.paginationService.onPage(event);
-    this.query.refetch();
   }
 
   onSort(event: SortMeta) {

--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -55,6 +55,7 @@ import {
   getUserSettings,
   getWorkflowById,
   getWorkflowJobStatus,
+  getWorkflowRuns,
   getWorkflowsByRepositoryId,
   getWorkflowsByState,
   healthCheck,
@@ -160,6 +161,9 @@ import type {
   GetUserSettingsData,
   GetWorkflowByIdData,
   GetWorkflowJobStatusData,
+  GetWorkflowRunsData,
+  GetWorkflowRunsError,
+  GetWorkflowRunsResponse,
   GetWorkflowsByRepositoryIdData,
   GetWorkflowsByStateData,
   HealthCheckData,
@@ -881,6 +885,90 @@ export const getWorkflowsByStateOptions = (options: Options<GetWorkflowsByStateD
   });
 };
 
+export const getWorkflowRunsQueryKey = (options?: Options<GetWorkflowRunsData>) => createQueryKey('getWorkflowRuns', options);
+
+export const getWorkflowRunsOptions = (options?: Options<GetWorkflowRunsData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getWorkflowRuns({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getWorkflowRunsQueryKey(options),
+  });
+};
+
+const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
+  const params = {
+    ...queryKey[0],
+  };
+  if (page.body) {
+    params.body = {
+      ...(queryKey[0].body as any),
+      ...(page.body as any),
+    };
+  }
+  if (page.headers) {
+    params.headers = {
+      ...queryKey[0].headers,
+      ...page.headers,
+    };
+  }
+  if (page.path) {
+    params.path = {
+      ...(queryKey[0].path as any),
+      ...(page.path as any),
+    };
+  }
+  if (page.query) {
+    params.query = {
+      ...(queryKey[0].query as any),
+      ...(page.query as any),
+    };
+  }
+  return params as unknown as typeof page;
+};
+
+export const getWorkflowRunsInfiniteQueryKey = (options?: Options<GetWorkflowRunsData>): QueryKey<Options<GetWorkflowRunsData>> => createQueryKey('getWorkflowRuns', options, true);
+
+export const getWorkflowRunsInfiniteOptions = (options?: Options<GetWorkflowRunsData>) => {
+  return infiniteQueryOptions<
+    GetWorkflowRunsResponse,
+    GetWorkflowRunsError,
+    InfiniteData<GetWorkflowRunsResponse>,
+    QueryKey<Options<GetWorkflowRunsData>>,
+    number | Pick<QueryKey<Options<GetWorkflowRunsData>>[0], 'body' | 'headers' | 'path' | 'query'>
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<QueryKey<Options<GetWorkflowRunsData>>[0], 'body' | 'headers' | 'path' | 'query'> =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await getWorkflowRuns({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: getWorkflowRunsInfiniteQueryKey(options),
+    }
+  );
+};
+
 export const getWorkflowsByRepositoryIdQueryKey = (options: Options<GetWorkflowsByRepositoryIdData>) => createQueryKey('getWorkflowsByRepositoryId', options);
 
 export const getWorkflowsByRepositoryIdOptions = (options: Options<GetWorkflowsByRepositoryIdData>) => {
@@ -967,37 +1055,6 @@ export const getLatestTestResultsByPullRequestIdOptions = (options: Options<GetL
     },
     queryKey: getLatestTestResultsByPullRequestIdQueryKey(options),
   });
-};
-
-const createInfiniteParams = <K extends Pick<QueryKey<Options>[0], 'body' | 'headers' | 'path' | 'query'>>(queryKey: QueryKey<Options>, page: K) => {
-  const params = {
-    ...queryKey[0],
-  };
-  if (page.body) {
-    params.body = {
-      ...(queryKey[0].body as any),
-      ...(page.body as any),
-    };
-  }
-  if (page.headers) {
-    params.headers = {
-      ...queryKey[0].headers,
-      ...page.headers,
-    };
-  }
-  if (page.path) {
-    params.path = {
-      ...(queryKey[0].path as any),
-      ...(page.path as any),
-    };
-  }
-  if (page.query) {
-    params.query = {
-      ...(queryKey[0].query as any),
-      ...(page.query as any),
-    };
-  }
-  return params as unknown as typeof page;
 };
 
 export const getLatestTestResultsByPullRequestIdInfiniteQueryKey = (

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -808,6 +808,34 @@ export const CancelDeploymentRequestSchema = {
   required: ['workflowRunId'],
 } as const;
 
+export const PaginatedWorkflowRunsResponseSchema = {
+  type: 'object',
+  properties: {
+    runs: {
+      type: 'array',
+      items: {
+        $ref: '#/components/schemas/WorkflowRunDto',
+      },
+    },
+    page: {
+      type: 'integer',
+      format: 'int32',
+    },
+    size: {
+      type: 'integer',
+      format: 'int32',
+    },
+    totalElements: {
+      type: 'integer',
+      format: 'int64',
+    },
+    totalPages: {
+      type: 'integer',
+      format: 'int32',
+    },
+  },
+} as const;
+
 export const WorkflowRunDtoSchema = {
   type: 'object',
   properties: {
@@ -860,8 +888,26 @@ export const WorkflowRunDtoSchema = {
       type: 'string',
       enum: ['PROCESSING', 'PROCESSED', 'FAILED'],
     },
+    headBranch: {
+      type: 'string',
+    },
+    headSha: {
+      type: 'string',
+    },
+    runStartedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
+    createdAt: {
+      type: 'string',
+      format: 'date-time',
+    },
+    updatedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
   },
-  required: ['displayTitle', 'htmlUrl', 'id', 'label', 'name', 'status', 'workflowId'],
+  required: ['createdAt', 'displayTitle', 'htmlUrl', 'id', 'label', 'name', 'status', 'updatedAt', 'workflowId'],
 } as const;
 
 export const GitHubRepositoryRoleDtoSchema = {

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -156,6 +156,9 @@ import type {
   GetWorkflowJobStatusData,
   GetWorkflowJobStatusErrors,
   GetWorkflowJobStatusResponses,
+  GetWorkflowRunsData,
+  GetWorkflowRunsErrors,
+  GetWorkflowRunsResponses,
   GetWorkflowsByRepositoryIdData,
   GetWorkflowsByRepositoryIdErrors,
   GetWorkflowsByRepositoryIdResponses,
@@ -597,6 +600,13 @@ export const getWorkflowById = <ThrowOnError extends boolean = false>(options: O
 export const getWorkflowsByState = <ThrowOnError extends boolean = false>(options: Options<GetWorkflowsByStateData, ThrowOnError>) => {
   return (options.client ?? client).get<GetWorkflowsByStateResponses, GetWorkflowsByStateErrors, ThrowOnError>({
     url: '/api/workflows/state/{state}',
+    ...options,
+  });
+};
+
+export const getWorkflowRuns = <ThrowOnError extends boolean = false>(options?: Options<GetWorkflowRunsData, ThrowOnError>) => {
+  return (options?.client ?? client).get<GetWorkflowRunsResponses, GetWorkflowRunsErrors, ThrowOnError>({
+    url: '/api/workflows/runs',
     ...options,
   });
 };

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -270,6 +270,14 @@ export type CancelDeploymentRequest = {
   workflowRunId: number;
 };
 
+export type PaginatedWorkflowRunsResponse = {
+  runs?: Array<WorkflowRunDto>;
+  page?: number;
+  size?: number;
+  totalElements?: number;
+  totalPages?: number;
+};
+
 export type WorkflowRunDto = {
   id: number;
   name: string;
@@ -295,6 +303,11 @@ export type WorkflowRunDto = {
   htmlUrl: string;
   label: 'NONE' | 'TEST';
   testProcessingStatus?: 'PROCESSING' | 'PROCESSED' | 'FAILED';
+  headBranch?: string;
+  headSha?: string;
+  runStartedAt?: string;
+  createdAt: string;
+  updatedAt: string;
 };
 
 export type GitHubRepositoryRoleDto = {
@@ -1564,6 +1577,38 @@ export type GetWorkflowsByStateResponses = {
 };
 
 export type GetWorkflowsByStateResponse = GetWorkflowsByStateResponses[keyof GetWorkflowsByStateResponses];
+
+export type GetWorkflowRunsData = {
+  body?: never;
+  path?: never;
+  query?: {
+    page?: number;
+    size?: number;
+    sortField?: string;
+    sortDirection?: string;
+    filterType?: 'ALL' | 'NOT_STARTED' | 'IN_PROGRESS' | 'CANCELLED' | 'SUCCESS' | 'FAILURE' | 'ACTION_REQUIRED';
+    searchTerm?: string;
+  };
+  url: '/api/workflows/runs';
+};
+
+export type GetWorkflowRunsErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type GetWorkflowRunsError = GetWorkflowRunsErrors[keyof GetWorkflowRunsErrors];
+
+export type GetWorkflowRunsResponses = {
+  /**
+   * OK
+   */
+  200: PaginatedWorkflowRunsResponse;
+};
+
+export type GetWorkflowRunsResponse = GetWorkflowRunsResponses[keyof GetWorkflowRunsResponses];
 
 export type GetWorkflowsByRepositoryIdData = {
   body?: never;

--- a/client/src/app/pages/ci-cd/ci-cd.component.ts
+++ b/client/src/app/pages/ci-cd/ci-cd.component.ts
@@ -16,9 +16,9 @@ export class CiCdComponent implements OnInit, OnDestroy {
   repositoryId = input.required({ transform: numberAttribute });
 
   tabs = signal<{ label: string; id: string }[]>([
-    { label: 'Workflow Runs', id: 'runs' },
     { label: 'Pull Requests', id: 'pr' },
     { label: 'Branches', id: 'branch' },
+    { label: 'Workflow Runs', id: 'runs' },
   ]);
   activeTabId = signal(this.tabs()[0].id);
 

--- a/client/src/app/pages/ci-cd/ci-cd.component.ts
+++ b/client/src/app/pages/ci-cd/ci-cd.component.ts
@@ -16,6 +16,7 @@ export class CiCdComponent implements OnInit, OnDestroy {
   repositoryId = input.required({ transform: numberAttribute });
 
   tabs = signal<{ label: string; id: string }[]>([
+    { label: 'Workflow Runs', id: 'runs' },
     { label: 'Pull Requests', id: 'pr' },
     { label: 'Branches', id: 'branch' },
   ]);

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -57,7 +57,7 @@
                 <p-button text (click)="openProjectExternal($event, project)" styleClass="p-1" class="leading-none">
                   <i-tabler name="brand-github" class="!size-4" />
                 </p-button>
-                <div class="font-bold hover:underline cursor-pointer leading-none text-xl truncate" (click)="navigateToPullRequests(project)">{{ project.name }}</div>
+                <div class="font-bold hover:underline cursor-pointer leading-none text-xl truncate" (click)="navigateToWorkflowRuns(project)">{{ project.name }}</div>
                 @if (project.latestReleaseTagName) {
                   <p-tag rounded class="py-0.5 cursor-pointer hover:underline" (click)="navigateToReleases(project)"
                     ><i-tabler name="tag" class="!size-4" />{{ project.latestReleaseTagName }}</p-tag

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -138,6 +138,10 @@ export class RepositoryOverviewComponent {
     this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'pr']);
   }
 
+  navigateToWorkflowRuns(repository: RepositoryInfoDto) {
+    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'runs']);
+  }
+
   openProjectExternal(event: Event, repository: RepositoryInfoDto) {
     window.open(repository.htmlUrl, '_blank');
     event.stopPropagation();

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -139,7 +139,7 @@ export class RepositoryOverviewComponent {
   }
 
   navigateToWorkflowRuns(repository: RepositoryInfoDto) {
-    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'runs']);
+    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'pr']);
   }
 
   openProjectExternal(event: Event, repository: RepositoryInfoDto) {

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
@@ -1,0 +1,1 @@
+<app-workflow-runs-table />

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom } from '@angular/core';
+
+import { WorkflowRunListComponent } from './workflow-run-list.component';
+import { TestModule } from '@app/test.module';
+
+describe('Integration Test Workflow Run List Page', () => {
+  let component: WorkflowRunListComponent;
+  let fixture: ComponentFixture<WorkflowRunListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkflowRunListComponent],
+      providers: [importProvidersFrom(TestModule)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkflowRunListComponent);
+    component = fixture.componentInstance;
+
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the workflow runs table', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const hostElement: HTMLElement = fixture.nativeElement;
+    const tableElement = hostElement.querySelector('app-workflow-runs-table');
+
+    expect(tableElement).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { WorkflowRunsTableComponent } from '@app/components/workflow-runs-table/workflow-runs-table.component';
+
+@Component({
+  selector: 'app-workflow-runs',
+  standalone: true,
+  imports: [WorkflowRunsTableComponent],
+  templateUrl: './workflow-run-list.component.html',
+})
+export class WorkflowRunListComponent {}

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -963,6 +963,67 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/WorkflowDto"
+  /api/workflows/runs:
+    get:
+      tags:
+      - workflow-run-controller
+      operationId: getWorkflowRuns
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: sortField
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sortDirection
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: filterType
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - ALL
+          - NOT_STARTED
+          - IN_PROGRESS
+          - CANCELLED
+          - SUCCESS
+          - FAILURE
+          - ACTION_REQUIRED
+      - name: searchTerm
+        in: query
+        required: false
+        schema:
+          type: string
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PaginatedWorkflowRunsResponse"
   /api/workflows/repository/{repositoryId}:
     get:
       tags:
@@ -2509,6 +2570,25 @@ components:
           format: int64
       required:
       - workflowRunId
+    PaginatedWorkflowRunsResponse:
+      type: object
+      properties:
+        runs:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowRunDto"
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
     WorkflowRunDto:
       type: object
       properties:
@@ -2566,13 +2646,28 @@ components:
           - PROCESSING
           - PROCESSED
           - FAILED
+        headBranch:
+          type: string
+        headSha:
+          type: string
+        runStartedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
       required:
+      - createdAt
       - displayTitle
       - htmlUrl
       - id
       - label
       - name
       - status
+      - updatedAt
       - workflowId
     GitHubRepositoryRoleDto:
       type: object

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunController.java
@@ -1,5 +1,8 @@
 package de.tum.cit.aet.helios.workflow;
 
+import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunFilterType;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +18,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class WorkflowRunController {
 
   private final WorkflowRunService workflowRunService;
+
+  @GetMapping("/runs")
+  public ResponseEntity<PaginatedWorkflowRunsResponse> getWorkflowRuns(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "20") int size,
+      @RequestParam(required = false) String sortField,
+      @RequestParam(required = false) String sortDirection,
+      @RequestParam(required = false) WorkflowRunFilterType filterType,
+      @RequestParam(required = false) String searchTerm) {
+    WorkflowRunPageRequest pageRequest = WorkflowRunPageRequest.builder()
+        .page(page)
+        .size(size)
+        .sortField(sortField)
+        .sortDirection(sortDirection)
+        .filterType(filterType != null ? filterType : WorkflowRunFilterType.ALL)
+        .searchTerm(searchTerm)
+        .build();
+    return ResponseEntity.ok(workflowRunService.getPaginatedWorkflowRuns(pageRequest));
+  }
 
   @GetMapping("/pr/{pullRequestId}")
   public ResponseEntity<List<WorkflowRunDto>> getLatestWorkflowRunsByPullRequestIdAndHeadCommit(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunDto.java
@@ -2,7 +2,9 @@ package de.tum.cit.aet.helios.workflow;
 
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Conclusion;
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Status;
+import java.time.OffsetDateTime;
 import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
 
 public record WorkflowRunDto(
     @NonNull Long id,
@@ -13,7 +15,12 @@ public record WorkflowRunDto(
     Conclusion conclusion,
     @NonNull String htmlUrl,
     @NonNull Workflow.Label label,
-    WorkflowRun.TestProcessingStatus testProcessingStatus) {
+    @Nullable WorkflowRun.TestProcessingStatus testProcessingStatus,
+    @Nullable String headBranch,
+    @Nullable String headSha,
+    @Nullable OffsetDateTime runStartedAt,
+    @NonNull OffsetDateTime createdAt,
+    @NonNull OffsetDateTime updatedAt) {
   public static WorkflowRunDto fromWorkflowRun(WorkflowRun run) {
     return new WorkflowRunDto(
         run.getId(),
@@ -24,6 +31,11 @@ public record WorkflowRunDto(
         run.getConclusion().orElse(null),
         run.getHtmlUrl(),
         run.getWorkflow().getLabel(),
-        run.getTestProcessingStatus());
+        run.getTestProcessingStatus(),
+        run.getHeadBranch(),
+        run.getHeadSha(),
+        run.getRunStartedAt(),
+        run.getCreatedAt(),
+        run.getUpdatedAt());
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +12,8 @@ import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
 @Repository
-public interface WorkflowRunRepository extends JpaRepository<WorkflowRun, Long> {
+public interface WorkflowRunRepository
+    extends JpaRepository<WorkflowRun, Long>, JpaSpecificationExecutor<WorkflowRun> {
   Optional<WorkflowRun> findById(long id);
 
   @Query(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
@@ -3,12 +3,21 @@ package de.tum.cit.aet.helios.workflow;
 import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,6 +72,129 @@ public class WorkflowRunService {
     var latestRuns = getLatestWorkflowRuns(runs);
 
     return latestRuns.map(WorkflowRunDto::fromWorkflowRun).toList();
+  }
+
+  public PaginatedWorkflowRunsResponse getPaginatedWorkflowRuns(WorkflowRunPageRequest request) {
+    Long repositoryId = RepositoryContext.getRepositoryId();
+
+    Sort sort = resolveSort(request);
+    Pageable pageable = PageRequest.of(Math.max(request.getPage() - 1, 0), request.getSize(), sort);
+
+    Specification<WorkflowRun> spec = buildWorkflowRunSpecification(request, repositoryId);
+
+    Page<WorkflowRun> resultPage = workflowRunRepository.findAll(spec, pageable);
+
+    List<WorkflowRunDto> runs =
+        resultPage.getContent().stream().map(WorkflowRunDto::fromWorkflowRun).toList();
+
+    return new PaginatedWorkflowRunsResponse(
+        runs,
+        request.getPage(),
+        request.getSize(),
+        resultPage.getTotalElements(),
+        resultPage.getTotalPages());
+  }
+
+  private Specification<WorkflowRun> buildWorkflowRunSpecification(
+      WorkflowRunPageRequest request, Long repositoryId) {
+    return (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      // Always scope to current repository
+      predicates.add(cb.equal(root.get("repository").get("repositoryId"), repositoryId));
+
+      // Search term across a few meaningful fields
+      if (request.getSearchTerm() != null && !request.getSearchTerm().trim().isEmpty()) {
+        String term = "%" + request.getSearchTerm().trim().toLowerCase() + "%";
+        predicates.add(
+            cb.or(
+                cb.like(cb.lower(root.get("name")), term),
+                cb.like(cb.lower(root.get("displayTitle")), term),
+                cb.like(cb.lower(root.get("headBranch")), term),
+                cb.like(cb.lower(root.get("headSha")), term)));
+      }
+
+      // Filter by status/conclusion based on filter type
+      switch (request.getFilterType()) {
+        case NOT_STARTED:
+          predicates.add(
+              root.get("status")
+                  .in(
+                      WorkflowRun.Status.QUEUED,
+                      WorkflowRun.Status.WAITING,
+                      WorkflowRun.Status.REQUESTED,
+                      WorkflowRun.Status.PENDING));
+          break;
+        case IN_PROGRESS:
+          predicates.add(cb.equal(root.get("status"), WorkflowRun.Status.IN_PROGRESS));
+          break;
+        case CANCELLED:
+          predicates.add(cb.equal(root.get("conclusion"), WorkflowRun.Conclusion.CANCELLED));
+          break;
+        case SUCCESS:
+          predicates.add(cb.equal(root.get("conclusion"), WorkflowRun.Conclusion.SUCCESS));
+          break;
+        case FAILURE:
+          predicates.add(
+              root.get("conclusion")
+                  .in(
+                      WorkflowRun.Conclusion.FAILURE,
+                      WorkflowRun.Conclusion.STARTUP_FAILURE,
+                      WorkflowRun.Conclusion.TIMED_OUT));
+          break;
+        case ACTION_REQUIRED:
+          predicates.add(
+              cb.or(
+                  cb.equal(root.get("status"), WorkflowRun.Status.ACTION_REQUIRED),
+                  cb.equal(root.get("conclusion"), WorkflowRun.Conclusion.ACTION_REQUIRED)));
+          break;
+        case ALL:
+        default:
+          break;
+      }
+
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+
+  private Sort resolveSort(WorkflowRunPageRequest request) {
+    String sortField = request.getSortField();
+    String sortDirection = request.getSortDirection();
+
+    // Default: newest first by start time, then creation time
+    Sort defaultSort =
+        Sort.by(Sort.Direction.DESC, "runStartedAt").and(Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    if (sortField == null || sortField.isBlank()) {
+      return defaultSort;
+    }
+
+    String property;
+    // Map API sort fields to entity properties; fall back to default
+    switch (sortField) {
+      case "name":
+        property = "name";
+        break;
+      case "status":
+        property = "status";
+        break;
+      case "branch":
+        property = "headBranch";
+        break;
+      case "runStartedAt":
+        property = "runStartedAt";
+        break;
+      case "updatedAt":
+        property = "updatedAt";
+        break;
+      default:
+        return defaultSort;
+    }
+
+    Sort.Direction direction =
+        "asc".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+    return Sort.by(direction, property).and(defaultSort);
   }
 
   public void deleteWorkflowRun(Long workflowRunId) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/PaginatedWorkflowRunsResponse.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/PaginatedWorkflowRunsResponse.java
@@ -1,0 +1,12 @@
+package de.tum.cit.aet.helios.workflow.pagination;
+
+import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
+import java.util.List;
+
+public record PaginatedWorkflowRunsResponse(
+    List<WorkflowRunDto> runs,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages) {}
+

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunFilterType.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunFilterType.java
@@ -1,0 +1,23 @@
+package de.tum.cit.aet.helios.workflow.pagination;
+
+public enum WorkflowRunFilterType {
+  ALL,
+  NOT_STARTED,
+  IN_PROGRESS,
+  CANCELLED,
+  SUCCESS,
+  FAILURE,
+  ACTION_REQUIRED;
+
+  public static WorkflowRunFilterType from(String value) {
+    if (value == null) {
+      return ALL;
+    }
+
+    try {
+      return WorkflowRunFilterType.valueOf(value);
+    } catch (IllegalArgumentException e) {
+      return ALL;
+    }
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunPageRequest.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunPageRequest.java
@@ -1,0 +1,17 @@
+package de.tum.cit.aet.helios.workflow.pagination;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class WorkflowRunPageRequest {
+  private int page = 1;
+  private int size = 20;
+  private String sortField;
+  private String sortDirection;
+  private WorkflowRunFilterType filterType = WorkflowRunFilterType.ALL;
+  private String searchTerm;
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunPageRequest.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pagination/WorkflowRunPageRequest.java
@@ -8,10 +8,13 @@ import lombok.Setter;
 @Setter
 @Builder
 public class WorkflowRunPageRequest {
+  @Builder.Default
   private int page = 1;
+  @Builder.Default
   private int size = 20;
   private String sortField;
   private String sortDirection;
+  @Builder.Default
   private WorkflowRunFilterType filterType = WorkflowRunFilterType.ALL;
   private String searchTerm;
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunControllerTest.java
@@ -1,0 +1,153 @@
+package de.tum.cit.aet.helios.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import de.tum.cit.aet.helios.workflow.WorkflowRun.Conclusion;
+import de.tum.cit.aet.helios.workflow.WorkflowRun.Status;
+import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunFilterType;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc(addFilters = false)
+@ContextConfiguration(classes = WorkflowRunController.class)
+@WebMvcTest(WorkflowRunController.class)
+class WorkflowRunControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private WorkflowRunService workflowRunService;
+
+  private PaginatedWorkflowRunsResponse sampleResponse;
+
+  @BeforeEach
+  void setUp() {
+    OffsetDateTime now = OffsetDateTime.now();
+    WorkflowRunDto sampleRun = new WorkflowRunDto(
+        1L,
+        "Build",
+        "Build workflow",
+        Status.SUCCESS,
+        100L,
+        Conclusion.SUCCESS,
+        "https://github.com/owner/repo/actions/runs/1",
+        Workflow.Label.TEST,
+        WorkflowRun.TestProcessingStatus.PROCESSED,
+        "main",
+        "abc1234",
+        now.minusHours(1),
+        now.minusHours(2),
+        now);
+
+    sampleResponse =
+        new PaginatedWorkflowRunsResponse(List.of(sampleRun), 1, 20, 1L, 1);
+  }
+
+  @Test
+  void getWorkflowRuns_returnsPaginatedResponse() throws Exception {
+    when(workflowRunService.getPaginatedWorkflowRuns(any(WorkflowRunPageRequest.class)))
+        .thenReturn(sampleResponse);
+
+    mockMvc
+        .perform(get("/api/workflows/runs").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.runs").isArray())
+        .andExpect(jsonPath("$.runs.length()").value(1))
+        .andExpect(jsonPath("$.runs[0].id").value(1))
+        .andExpect(jsonPath("$.runs[0].name").value("Build"))
+        .andExpect(jsonPath("$.runs[0].displayTitle").value("Build workflow"))
+        .andExpect(jsonPath("$.runs[0].status").value("SUCCESS"))
+        .andExpect(jsonPath("$.runs[0].conclusion").value("SUCCESS"))
+        .andExpect(jsonPath("$.page").value(1))
+        .andExpect(jsonPath("$.size").value(20))
+        .andExpect(jsonPath("$.totalElements").value(1))
+        .andExpect(jsonPath("$.totalPages").value(1));
+
+    verify(workflowRunService).getPaginatedWorkflowRuns(any(WorkflowRunPageRequest.class));
+  }
+
+  @Test
+  void getWorkflowRuns_usesDefaultPaginationValues() throws Exception {
+    when(workflowRunService.getPaginatedWorkflowRuns(any(WorkflowRunPageRequest.class)))
+        .thenReturn(sampleResponse);
+
+    ArgumentCaptor<WorkflowRunPageRequest> requestCaptor =
+        ArgumentCaptor.forClass(WorkflowRunPageRequest.class);
+
+    mockMvc.perform(get("/api/workflows/runs").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    verify(workflowRunService).getPaginatedWorkflowRuns(requestCaptor.capture());
+
+    WorkflowRunPageRequest captured = requestCaptor.getValue();
+    assertEquals(1, captured.getPage());
+    assertEquals(20, captured.getSize());
+  }
+
+  @Test
+  void getWorkflowRuns_acceptsCustomPaginationAndSortAndFilter() throws Exception {
+    when(workflowRunService.getPaginatedWorkflowRuns(any(WorkflowRunPageRequest.class)))
+        .thenReturn(sampleResponse);
+
+    ArgumentCaptor<WorkflowRunPageRequest> requestCaptor =
+        ArgumentCaptor.forClass(WorkflowRunPageRequest.class);
+
+    mockMvc
+        .perform(
+            get("/api/workflows/runs")
+                .param("page", "2")
+                .param("size", "10")
+                .param("sortField", "name")
+                .param("sortDirection", "asc")
+                .param("filterType", "SUCCESS")
+                .param("searchTerm", "build")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk());
+
+    verify(workflowRunService).getPaginatedWorkflowRuns(requestCaptor.capture());
+
+    WorkflowRunPageRequest captured = requestCaptor.getValue();
+    assertEquals(2, captured.getPage());
+    assertEquals(10, captured.getSize());
+    assertEquals("name", captured.getSortField());
+    assertEquals("asc", captured.getSortDirection());
+    assertEquals(WorkflowRunFilterType.SUCCESS, captured.getFilterType());
+    assertEquals("build", captured.getSearchTerm());
+  }
+
+  @Test
+  void getWorkflowRuns_returnsEmptyPageWhenNoRuns() throws Exception {
+    PaginatedWorkflowRunsResponse empty =
+        new PaginatedWorkflowRunsResponse(List.of(), 1, 20, 0L, 0);
+
+    when(workflowRunService.getPaginatedWorkflowRuns(any(WorkflowRunPageRequest.class)))
+        .thenReturn(empty);
+
+    mockMvc
+        .perform(get("/api/workflows/runs").accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.runs").isArray())
+        .andExpect(jsonPath("$.runs.length()").value(0))
+        .andExpect(jsonPath("$.totalElements").value(0))
+        .andExpect(jsonPath("$.totalPages").value(0));
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
@@ -1,0 +1,173 @@
+package de.tum.cit.aet.helios.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.branch.BranchRepository;
+import de.tum.cit.aet.helios.filters.RepositoryContext;
+import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.helios.workflow.WorkflowRun.Conclusion;
+import de.tum.cit.aet.helios.workflow.WorkflowRun.Status;
+import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
+import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+
+@ExtendWith(MockitoExtension.class)
+public class WorkflowRunServiceTest {
+
+  @InjectMocks private WorkflowRunService workflowRunService;
+
+  @Mock private WorkflowRunRepository workflowRunRepository;
+  @Mock private PullRequestRepository pullRequestRepository;
+  @Mock private BranchRepository branchRepository;
+
+  @BeforeEach
+  public void setUp() {
+    RepositoryContext.setRepositoryId("1");
+  }
+
+  @Test
+  public void getPaginatedWorkflowRuns_returnsMappedRunsAndPageMetadata() {
+    WorkflowRun run1 = createWorkflowRun(
+        1L, "Build", "Build workflow", Status.SUCCESS, Conclusion.SUCCESS);
+    WorkflowRun run2 = createWorkflowRun(
+        2L, "Tests", "Test workflow", Status.FAILURE, Conclusion.FAILURE);
+
+    Page<WorkflowRun> page =
+        new PageImpl<>(List.of(run1, run2), Pageable.ofSize(20), 2);
+
+    when(workflowRunRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(page);
+
+    WorkflowRunPageRequest request = WorkflowRunPageRequest.builder()
+        .page(1)
+        .size(20)
+        .build();
+
+    PaginatedWorkflowRunsResponse response = workflowRunService.getPaginatedWorkflowRuns(request);
+
+    assertNotNull(response);
+    assertEquals(2, response.runs().size());
+    assertEquals(1L, response.runs().get(0).id());
+    assertEquals("Build", response.runs().get(0).name());
+    assertEquals(1, response.page());
+    assertEquals(20, response.size());
+    assertEquals(2, response.totalElements());
+    assertEquals(1, response.totalPages());
+  }
+
+  @Test
+  public void getPaginatedWorkflowRuns_usesDefaultSortingByRunStartedAtDescThenCreatedAtDesc() {
+    WorkflowRun run = createWorkflowRun(
+        1L, "Build", "Build workflow", Status.IN_PROGRESS, null);
+    Page<WorkflowRun> page = new PageImpl<>(List.of(run), Pageable.ofSize(20), 1);
+
+    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+    when(workflowRunRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(page);
+
+    WorkflowRunPageRequest request = WorkflowRunPageRequest.builder()
+        .page(1)
+        .size(20)
+        .sortField(null)
+        .sortDirection(null)
+        .build();
+
+    workflowRunService.getPaginatedWorkflowRuns(request);
+
+    verify(workflowRunRepository).findAll(any(Specification.class), pageableCaptor.capture());
+
+    Pageable pageable = pageableCaptor.getValue();
+    assertEquals(0, pageable.getPageNumber());
+    assertEquals(20, pageable.getPageSize());
+
+    Sort sort = pageable.getSort();
+    Sort.Order runStartedAtOrder = sort.getOrderFor("runStartedAt");
+    Sort.Order createdAtOrder = sort.getOrderFor("createdAt");
+
+    assertNotNull(runStartedAtOrder);
+    assertEquals(Sort.Direction.DESC, runStartedAtOrder.getDirection());
+
+    assertNotNull(createdAtOrder);
+    assertEquals(Sort.Direction.DESC, createdAtOrder.getDirection());
+  }
+
+  @Test
+  public void getPaginatedWorkflowRuns_usesCustomSortingWhenRequested() {
+    WorkflowRun run = createWorkflowRun(
+        1L, "Build", "Build workflow", Status.SUCCESS, Conclusion.SUCCESS);
+    Page<WorkflowRun> page = new PageImpl<>(List.of(run), Pageable.ofSize(10), 1);
+
+    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+
+    when(workflowRunRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(page);
+
+    WorkflowRunPageRequest request =
+        WorkflowRunPageRequest.builder()
+            .page(2)
+            .size(10)
+            .sortField("name")
+            .sortDirection("asc")
+            .build();
+
+    workflowRunService.getPaginatedWorkflowRuns(request);
+
+    verify(workflowRunRepository).findAll(any(Specification.class), pageableCaptor.capture());
+
+    Pageable pageable = pageableCaptor.getValue();
+    assertNotNull(pageable);
+    assertEquals(1, pageable.getPageNumber());
+    assertEquals(10, pageable.getPageSize());
+
+    Sort.Order nameOrder = pageable.getSort().getOrderFor("name");
+    assertNotNull(nameOrder);
+    assertEquals(Sort.Direction.ASC, nameOrder.getDirection());
+
+    // secondary default sort is still appended
+    assertNotNull(pageable.getSort().getOrderFor("runStartedAt"));
+    assertNotNull(pageable.getSort().getOrderFor("createdAt"));
+  }
+
+  private WorkflowRun createWorkflowRun(
+      Long id, String name, String displayTitle, Status status, Conclusion conclusion) {
+    WorkflowRun run = new WorkflowRun();
+    run.setId(id);
+    run.setName(name);
+    run.setDisplayTitle(displayTitle);
+    run.setStatus(status);
+    run.setConclusion(Optional.ofNullable(conclusion));
+    run.setHtmlUrl("https://example.com/workflows/" + id);
+    run.setHeadBranch("main");
+    run.setHeadSha("abcdef" + id);
+    run.setRunStartedAt(OffsetDateTime.now().minusHours(1));
+    run.setCreatedAt(OffsetDateTime.now().minusHours(2));
+    run.setUpdatedAt(OffsetDateTime.now());
+
+    Workflow workflow = new Workflow();
+    workflow.setId(100L);
+    workflow.setLabel(Workflow.Label.TEST);
+    run.setWorkflow(workflow);
+
+    return run;
+  }
+}
+


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This feature adds a paginated, filterable Workflow Runs listing under the CI/CD menu so users can inspect workflow executions across a repository, ordered by start time and with metadata like status and test processing status. This provides a centralized overview of CI activity beyond individual PRs/branches. #913

### Description
<!-- Describe your changes in detail -->
Since the feature contains a lot of changes, this PR includes only backend changes.

- Added `GET /api/workflows/runs` endpoint in `WorkflowRunController `returning a `PaginatedWorkflowRunsResponse` with:
  - `runs: List<WorkflowRunDto>`
  - `page, size, totalElements, totalPages`.
- Extended `WorkflowRunService` with `getPaginatedWorkflowRuns(WorkflowRunPageRequest)` that:
  - Scopes results to the current RepositoryContext repository.
  - Applies server-side search over name, displayTitle, headBranch, and headSha.
  - Applies high-level filters on status/conclusion via `WorkflowRunFilterType`.
  - Sorts by `runStartedAt DESC`, `createdAt DESC` by default, or by a requested field (`name, status, branch, runStartedAt, updatedAt`) with direction.
- Extended existing `WorkflowRunDto` to be suitable for list views:
  - Added testProcessingStatus, headBranch, headSha, runStartedAt, createdAt, updatedAt.
- Added `PaginatedWorkflowRunsResponse` record in workflow.pagination.
- Made `WorkflowRunRepository` extend `JpaSpecificationExecutor<WorkflowRun>` to support specifications and pageable queries (`findAll(Specification<WorkflowRun>, Pageable)`).

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- Helios running with a repository that has existing workflow runs.
- A user with access to that repository.
#### Flow:
1. Manual API verification
1.1. Start the application server.
1.2. Call GET `/api/workflows/runs` for a repository with a configured RepositoryContext.
1.3. Verify response shape:
runs array of WorkflowRunDto objects.
page = 1, size = 20, totalElements, totalPages set appropriately.
1.4. Confirm that runs are ordered by runStartedAt (then createdAt) descending.
1.5. Repeat the API calls with different `page, size, sortField, sortDirection, searchTerm` parameters.
2. Automated Tests: Open server directory and run the test cases by using `./gradlew :application-server:test` command.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.