### PR TITLE
feat: implement workflow runs menu and table component

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -80,7 +80,7 @@ export const routes: Routes = [
             children: [
               {
                 path: '',
-                redirectTo: 'runs',
+                redirectTo: 'pr',
                 pathMatch: 'full',
               },
               {

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -80,8 +80,12 @@ export const routes: Routes = [
             children: [
               {
                 path: '',
-                redirectTo: 'pr',
+                redirectTo: 'runs',
                 pathMatch: 'full',
+              },
+              {
+                path: 'runs',
+                loadComponent: () => import('@app/pages/workflow-run-list/workflow-run-list.component').then(m => m.WorkflowRunListComponent),
               },
               {
                 path: 'pr',

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
@@ -1,0 +1,103 @@
+<p-table
+  #table
+  [rowHover]="true"
+  [value]="runs()"
+  [lazy]="true"
+  [totalRecords]="totalElements()"
+  [paginator]="true"
+  [rows]="paginationService.size()"
+  [first]="(paginationService.page() - 1) * paginationService.size()"
+  [rowsPerPageOptions]="[5, 10, 20, 30, 50]"
+  [loading]="query.isPending()"
+  (onPage)="onPage($event)"
+  (sortFunction)="onSort($event)"
+  [customSort]="true"
+  [sortField]="paginationService.sortField()"
+  [sortOrder]="paginationService.sortDirection() === 'asc' ? 1 : -1"
+>
+  <ng-template #header>
+    <tr>
+      <th>
+        <app-table-filter-paginated [paginationService]="typedPaginationService" [table]="table" />
+      </th>
+      <th class="hidden md:table-cell">Status</th>
+      <th class="hidden lg:table-cell">Tests</th>
+      <th class="hidden lg:table-cell">Started</th>
+      <th class="hidden lg:table-cell">Updated</th>
+    </tr>
+  </ng-template>
+
+  <ng-template pTemplate="body" let-run>
+    @if (query.isPending() || query.isError()) {
+      <tr>
+        <td colspan="5">
+          <div class="flex flex-col gap-2">
+            <p-skeleton class="w-80" />
+            <p-skeleton class="w-64" />
+          </div>
+        </td>
+      </tr>
+    } @else {
+      <tr>
+        <td class="px-2 py-2">
+          <div class="flex flex-col gap-2.5">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-bold truncate max-w-md">
+                {{ run.displayTitle || run.name }}
+              </span>
+              <p-button text (click)="openRunExternal($event, run)" styleClass="p-1" class="leading-none">
+                <i-tabler name="brand-github" class="!size-4" />
+              </p-button>
+              <p-tag [value]="run.label === 'TEST' ? 'Test' : 'General'" [severity]="run.label === 'TEST' ? 'info' : 'secondary'" rounded class="text-xs" />
+            </div>
+            <div class="flex flex-wrap items-center gap-2 text-xs text-muted-color">
+              @if (run.headBranch) {
+                <span>on {{ run.headBranch }}</span>
+              }
+              @if (run.headSha) {
+                <span class="font-mono">({{ run.headSha.slice(0, 7) }})</span>
+              }
+            </div>
+          </div>
+        </td>
+        <td class="hidden md:table-cell w-40">
+          <div class="flex items-center gap-2">
+            <i-tabler [name]="getWorkflowStatusIcon(run)" [class]="getWorkflowStatusClass(run)" class="!size-5" [pTooltip]="run.conclusion || run.status" />
+            <span class="text-sm">{{ run.conclusion || run.status }}</span>
+          </div>
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          @if (run.testProcessingStatus) {
+            <div class="flex items-center gap-2">
+              <i-tabler [name]="getTestStatusIcon(run)" [class]="getTestStatusClass(run)" class="!size-5" [pTooltip]="run.testProcessingStatus" />
+              <span class="text-sm">{{ run.testProcessingStatus }}</span>
+            </div>
+          } @else {
+            <span class="text-sm text-muted-color">—</span>
+          }
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          @if (run.runStartedAt) {
+            <span class="text-sm">{{ run.runStartedAt | timeAgo }}</span>
+          }
+        </td>
+        <td class="hidden lg:table-cell w-40">
+          <span class="text-sm">{{ run.updatedAt | timeAgo }}</span>
+        </td>
+      </tr>
+    }
+  </ng-template>
+
+  <ng-template pTemplate="emptymessage">
+    <tr>
+      <td colspan="5">
+        <div class="flex flex-col gap-2 p-20 justify-center items-center">
+          <i-tabler name="git-pull-request" class="!h-20 !w-20 text-red-500" />
+          <span class="font-semibold text-xl">There are no workflow runs found matching your filter criteria.</span>
+          <span>Try clearing the filter or reloading the page.</span>
+          <p-button (click)="clearFilters()">Clear Filter</p-button>
+        </div>
+      </td>
+    </tr>
+  </ng-template>
+</p-table>

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
@@ -92,7 +92,7 @@
     <tr>
       <td colspan="5">
         <div class="flex flex-col gap-2 p-20 justify-center items-center">
-          <i-tabler name="git-pull-request" class="!h-20 !w-20 text-red-500" />
+          <i-tabler name="player-play" class="!h-20 !w-20 text-red-500" />
           <span class="font-semibold text-xl">There are no workflow runs found matching your filter criteria.</span>
           <span>Try clearing the filter or reloading the page.</span>
           <p-button (click)="clearFilters()">Clear Filter</p-button>

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
@@ -1,0 +1,299 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideQueryClient, QueryClient } from '@tanstack/angular-query-experimental';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { vi } from 'vitest';
+
+import { WorkflowRunsTableComponent, createWorkflowRunsFilterOptions } from './workflow-runs-table.component';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import type { WorkflowRunDto } from '@app/core/modules/openapi';
+
+function createRun(overrides: Partial<WorkflowRunDto> = {}): WorkflowRunDto {
+  return {
+    id: 1,
+    name: 'CI',
+    displayTitle: 'CI',
+    status: 'COMPLETED',
+    workflowId: 10,
+    htmlUrl: 'https://github.com/org/repo/actions/runs/1',
+    label: 'TEST',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+type QueryData = {
+  runs?: WorkflowRunDto[];
+  totalElements?: number;
+};
+
+function setMockQuery(
+  component: WorkflowRunsTableComponent,
+  options: {
+    data?: QueryData | undefined;
+    isPending?: boolean;
+    isError?: boolean;
+    refetch?: () => void;
+  } = {}
+) {
+  const refetch = options.refetch ?? vi.fn();
+
+  Object.defineProperty(component, 'query', {
+    configurable: true,
+    value: {
+      data: () => options.data,
+      isPending: () => options.isPending ?? false,
+      isError: () => options.isError ?? false,
+      refetch,
+    },
+  });
+
+  return { refetch };
+}
+
+describe('WorkflowRunsTableComponent', () => {
+  let component: WorkflowRunsTableComponent;
+  let fixture: ComponentFixture<WorkflowRunsTableComponent>;
+
+  const keycloakMock = {
+    isLoggedIn: () => false,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkflowRunsTableComponent],
+      providers: [provideZonelessChangeDetection(), provideQueryClient(new QueryClient()), provideNoopAnimations(), { provide: KeycloakService, useValue: keycloakMock }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkflowRunsTableComponent);
+    component = fixture.componentInstance;
+
+    setMockQuery(component, { data: undefined, isPending: false, isError: false });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('runs() and totalElements()', () => {
+    it('should return empty array and 0 when query has no data', () => {
+      expect(component.runs()).toEqual([]);
+      expect(component.totalElements()).toBe(0);
+    });
+
+    it('returns runs and totalElements from query data', () => {
+      const runs = [createRun({ id: 1 }), createRun({ id: 2, name: 'Build' })];
+      setMockQuery(component, {
+        data: {
+          runs,
+          totalElements: 42,
+        },
+      });
+
+      expect(component.runs()).toEqual(runs);
+      expect(component.totalElements()).toBe(42);
+    });
+  });
+
+  describe('getWorkflowStatusIcon', () => {
+    type IconName = ReturnType<WorkflowRunsTableComponent['getWorkflowStatusIcon']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, IconName]> = [
+      [{ conclusion: 'SUCCESS' }, 'circle-check'],
+      [{ conclusion: 'FAILURE' }, 'circle-x'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'circle-x'],
+      [{ conclusion: 'TIMED_OUT' }, 'circle-x'],
+      [{ conclusion: 'CANCELLED' }, 'circle-x'],
+      [{ status: 'IN_PROGRESS' }, 'progress'],
+      [{ status: 'QUEUED' }, 'clock-hour-4'],
+      [{ status: 'WAITING' }, 'clock-hour-4'],
+      [{ status: 'PENDING' }, 'clock-hour-4'],
+      [{ status: 'REQUESTED' }, 'clock-hour-4'],
+      [{ status: 'ACTION_REQUIRED' }, 'alert-triangle'],
+      [{ conclusion: 'ACTION_REQUIRED' }, 'alert-triangle'],
+      [{ status: 'COMPLETED' }, 'circle-x'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, IconName]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual = component.getWorkflowStatusIcon(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('getWorkflowStatusClass', () => {
+    type WorkflowStatusClass = ReturnType<WorkflowRunsTableComponent['getWorkflowStatusClass']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, WorkflowStatusClass]> = [
+      [{ conclusion: 'SUCCESS' }, 'text-green-500'],
+      [{ conclusion: 'FAILURE' }, 'text-red-500'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'text-red-500'],
+      [{ conclusion: 'TIMED_OUT' }, 'text-red-500'],
+      [{ conclusion: 'CANCELLED' }, 'text-surface-500'],
+      [{ status: 'QUEUED' }, 'text-amber-500'],
+      [{ status: 'WAITING' }, 'text-amber-500'],
+      [{ status: 'PENDING' }, 'text-amber-500'],
+      [{ status: 'REQUESTED' }, 'text-amber-500'],
+      [{ status: 'ACTION_REQUIRED' }, 'text-orange-500'],
+      [{ conclusion: 'ACTION_REQUIRED' }, 'text-orange-500'],
+      [{ status: 'COMPLETED' }, 'text-surface-500'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, WorkflowStatusClass]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: WorkflowStatusClass = component.getWorkflowStatusClass(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('returns animated blue class for IN_PROGRESS', () => {
+      const actual: WorkflowStatusClass = component.getWorkflowStatusClass(createRun({ status: 'IN_PROGRESS' }));
+
+      expect(actual).toContain('text-blue-500');
+      expect(actual).toContain('animate-spin');
+    });
+  });
+
+  describe('getTestStatusIcon', () => {
+    type TestIcon = ReturnType<WorkflowRunsTableComponent['getTestStatusIcon']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, TestIcon]> = [
+      [{ testProcessingStatus: 'PROCESSED' }, 'circle-check'],
+      [{ testProcessingStatus: 'FAILED' }, 'alert-triangle'],
+      [{ testProcessingStatus: 'PROCESSING' }, 'progress'],
+      [{}, 'circle-check'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, TestIcon]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: TestIcon = component.getTestStatusIcon(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('getTestStatusClass', () => {
+    type TestStatusClass = ReturnType<WorkflowRunsTableComponent['getTestStatusClass']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, TestStatusClass]> = [
+      [{ testProcessingStatus: 'PROCESSED' }, 'text-green-500'],
+      [{ testProcessingStatus: 'FAILED' }, 'text-red-500'],
+      [{}, 'text-surface-500'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, TestStatusClass]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: TestStatusClass = component.getTestStatusClass(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+
+    it('returns animated blue class for PROCESSING', () => {
+      const actual: TestStatusClass = component.getTestStatusClass(createRun({ testProcessingStatus: 'PROCESSING' }));
+
+      expect(actual).toContain('text-blue-500');
+      expect(actual).toContain('animate-spin');
+    });
+  });
+
+  describe('statusSeverity', () => {
+    type StatusSeverity = ReturnType<WorkflowRunsTableComponent['statusSeverity']>;
+
+    const cases: Array<[Partial<WorkflowRunDto>, StatusSeverity]> = [
+      [{ conclusion: 'SUCCESS' }, 'success'],
+      [{ conclusion: 'FAILURE' }, 'danger'],
+      [{ conclusion: 'STARTUP_FAILURE' }, 'danger'],
+      [{ conclusion: 'TIMED_OUT' }, 'danger'],
+      [{ conclusion: 'CANCELLED' }, 'secondary'],
+      [{ status: 'IN_PROGRESS' }, 'info'],
+      [{ status: 'QUEUED' }, 'warn'],
+      [{ status: 'WAITING' }, 'warn'],
+      [{ status: 'PENDING' }, 'warn'],
+      [{ status: 'REQUESTED' }, 'warn'],
+      [{ status: 'COMPLETED' }, 'secondary'],
+    ];
+
+    cases.forEach(([overrides, expected]: [Partial<WorkflowRunDto>, StatusSeverity]) => {
+      it(`returns ${expected} for ${JSON.stringify(overrides)}`, () => {
+        const actual: StatusSeverity = component.statusSeverity(createRun(overrides));
+        expect(actual).toBe(expected);
+      });
+    });
+  });
+
+  describe('openRunExternal', () => {
+    it('opens run htmlUrl in new tab and stops propagation', () => {
+      const run = createRun({ htmlUrl: 'https://github.com/org/repo/actions/runs/42' });
+      const ev = new Event('click') as Event & { stopPropagation: () => void };
+      ev.stopPropagation = vi.fn();
+      const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+      component.openRunExternal(ev, run);
+
+      expect(openSpy).toHaveBeenCalledWith('https://github.com/org/repo/actions/runs/42', '_blank');
+      expect(ev.stopPropagation).toHaveBeenCalled();
+    });
+  });
+
+  describe('onPage', () => {
+    it('calls pagination service onPage with the event', () => {
+      const onPageSpy = vi.spyOn(component.paginationService, 'onPage');
+      const refetchSpy = vi.fn();
+      setMockQuery(component, { refetch: refetchSpy });
+
+      const event = { first: 20, rows: 20, page: 1 };
+
+      component.onPage(event as Parameters<WorkflowRunsTableComponent['onPage']>[0]);
+
+      expect(onPageSpy).toHaveBeenCalledWith(event);
+      expect(refetchSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('onSort', () => {
+    it('updates pagination sort state', () => {
+      const onSortSpy = vi.spyOn(component.paginationService, 'onSort');
+      const event = { field: 'name', order: 1 };
+
+      component.onSort(event as Parameters<WorkflowRunsTableComponent['onSort']>[0]);
+
+      expect(onSortSpy).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('clears filter component and pagination filters', () => {
+      const clearSearchSpy = vi.fn();
+      const clearFiltersSpy = vi.spyOn(component.paginationService, 'clearFilters');
+      (component as unknown as { filterComponent: { clearSearch: () => void } }).filterComponent = {
+        clearSearch: clearSearchSpy,
+      };
+
+      component.clearFilters();
+
+      expect(clearSearchSpy).toHaveBeenCalled();
+      expect(clearFiltersSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('createWorkflowRunsFilterOptions', () => {
+    it('exports filter options with expected labels and values', () => {
+      const options = createWorkflowRunsFilterOptions();
+
+      expect(options).toEqual([
+        { name: 'All runs', value: 'ALL' },
+        { name: 'Not started', value: 'NOT_STARTED' },
+        { name: 'In progress', value: 'IN_PROGRESS' },
+        { name: 'Succeeded', value: 'SUCCESS' },
+        { name: 'Failed', value: 'FAILURE' },
+        { name: 'Cancelled', value: 'CANCELLED' },
+        { name: 'Action required', value: 'ACTION_REQUIRED' },
+      ]);
+    });
+  });
+});

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, ViewChild } from '@angular/core';
+import { Component, computed, inject, ViewChild } from '@angular/core';
 import { Table, TableModule, TablePageEvent } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
@@ -44,7 +44,7 @@ export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
       IconClockHour4,
       IconAlertTriangle,
       IconBrandGithub,
-      IconPlayerPlay
+      IconPlayerPlay,
     }),
   ],
   templateUrl: './workflow-runs-table.component.html',

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -1,0 +1,203 @@
+import { Component, computed, effect, inject, ViewChild } from '@angular/core';
+import { Table, TableModule, TablePageEvent } from 'primeng/table';
+import { TagModule } from 'primeng/tag';
+import { TooltipModule } from 'primeng/tooltip';
+import { SkeletonModule } from 'primeng/skeleton';
+import { ButtonModule } from 'primeng/button';
+import { DividerModule } from 'primeng/divider';
+import { SelectModule } from 'primeng/select';
+import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
+import { WorkflowRunDto } from '@app/core/modules/openapi';
+import { injectQuery } from '@tanstack/angular-query-experimental';
+import { getWorkflowRunsOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
+import { MessageService, SortMeta } from 'primeng/api';
+import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
+import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconGitPullRequest, IconProgress } from 'angular-tabler-icons/icons';
+
+export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
+  return [
+    { name: 'All runs', value: 'ALL' },
+    { name: 'Not started', value: 'NOT_STARTED' },
+    { name: 'In progress', value: 'IN_PROGRESS' },
+    { name: 'Succeeded', value: 'SUCCESS' },
+    { name: 'Failed', value: 'FAILURE' },
+    { name: 'Cancelled', value: 'CANCELLED' },
+    { name: 'Action required', value: 'ACTION_REQUIRED' },
+  ];
+}
+
+@Component({
+  selector: 'app-workflow-runs-table',
+  standalone: true,
+  imports: [TableModule, TagModule, TimeAgoPipe, SelectModule, TablerIconComponent, SkeletonModule, TooltipModule, ButtonModule, DividerModule, TableFilterPaginatedComponent],
+  providers: [
+    PaginatedTableService,
+    MessageService,
+    { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createWorkflowRunsFilterOptions },
+    provideTablerIcons({
+      IconFilterPlus,
+      IconGitPullRequest,
+      IconCircleCheck,
+      IconCircleX,
+      IconProgress,
+      IconClockHour4,
+      IconAlertTriangle,
+      IconBrandGithub,
+    }),
+  ],
+  templateUrl: './workflow-runs-table.component.html',
+})
+export class WorkflowRunsTableComponent {
+  @ViewChild('table') table!: Table;
+  @ViewChild(TableFilterPaginatedComponent) filterComponent!: TableFilterPaginatedComponent;
+
+  messageService = inject(MessageService);
+  paginationService = inject(PaginatedTableService);
+
+  queryOptions = computed(() => {
+    const paginationState = this.paginationService.paginationState();
+    const filterType = paginationState.filterType as 'ALL' | 'NOT_STARTED' | 'IN_PROGRESS' | 'CANCELLED' | 'SUCCESS' | 'FAILURE' | 'ACTION_REQUIRED' | undefined;
+
+    return getWorkflowRunsOptions({
+      query: {
+        page: paginationState.page,
+        size: paginationState.size,
+        sortField: paginationState.sortField,
+        sortDirection: paginationState.sortDirection,
+        filterType: filterType,
+        searchTerm: paginationState.searchTerm,
+      },
+    });
+  });
+
+  query = injectQuery(() => this.queryOptions());
+
+  constructor() {
+    effect(() => {
+      this.paginationService.paginationState();
+      if (this.query.data()) {
+        this.query.refetch();
+      }
+    });
+  }
+
+  get typedPaginationService() {
+    return this.paginationService as PaginatedTableService;
+  }
+
+  runs(): WorkflowRunDto[] {
+    // Backend returns a paginated response; keep type-safe access here.
+    // We intentionally type cast to `any` to avoid duplicating the generated type.
+    const data = this.query.data() as { runs?: WorkflowRunDto[] } | undefined;
+    return data?.runs ?? [];
+  }
+
+  totalElements(): number {
+    const data = this.query.data() as { totalElements?: number } | undefined;
+    return data?.totalElements ?? 0;
+  }
+
+  onPage(event: TablePageEvent) {
+    this.paginationService.onPage(event);
+    this.query.refetch();
+  }
+
+  onSort(event: SortMeta) {
+    this.paginationService.onSort(event);
+  }
+
+  clearFilters() {
+    this.filterComponent.clearSearch();
+    this.paginationService.clearFilters();
+  }
+
+  statusSeverity(run: WorkflowRunDto): 'success' | 'danger' | 'info' | 'warn' | 'secondary' {
+    if (run.conclusion === 'SUCCESS') return 'success';
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'danger';
+    }
+    if (run.conclusion === 'CANCELLED') return 'secondary';
+    if (run.status === 'IN_PROGRESS') return 'info';
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'warn';
+    }
+    return 'secondary';
+  }
+
+  openRunExternal(event: Event, run: WorkflowRunDto) {
+    window.open(run.htmlUrl, '_blank');
+    event.stopPropagation();
+  }
+
+  getWorkflowStatusIcon(run: WorkflowRunDto): string {
+    if (run.conclusion === 'SUCCESS') {
+      return 'circle-check';
+    }
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'circle-x';
+    }
+    if (run.conclusion === 'CANCELLED') {
+      return 'circle-x';
+    }
+    if (run.status === 'IN_PROGRESS') {
+      return 'progress';
+    }
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'clock-hour-4';
+    }
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') {
+      return 'alert-triangle';
+    }
+    return 'circle-x';
+  }
+
+  getWorkflowStatusClass(run: WorkflowRunDto): string {
+    if (run.conclusion === 'SUCCESS') {
+      return 'text-green-500';
+    }
+    if (run.conclusion === 'FAILURE' || run.conclusion === 'STARTUP_FAILURE' || run.conclusion === 'TIMED_OUT') {
+      return 'text-red-500';
+    }
+    if (run.conclusion === 'CANCELLED') {
+      return 'text-surface-500';
+    }
+    if (run.status === 'IN_PROGRESS') {
+      return 'text-blue-500 animate-spin';
+    }
+    if (run.status === 'QUEUED' || run.status === 'WAITING' || run.status === 'PENDING' || run.status === 'REQUESTED') {
+      return 'text-amber-500';
+    }
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') {
+      return 'text-orange-500';
+    }
+    return 'text-surface-500';
+  }
+
+  getTestStatusIcon(run: WorkflowRunDto): string {
+    if (run.testProcessingStatus === 'PROCESSED') {
+      return 'circle-check';
+    }
+    if (run.testProcessingStatus === 'FAILED') {
+      return 'alert-triangle';
+    }
+    if (run.testProcessingStatus === 'PROCESSING') {
+      return 'progress';
+    }
+    return 'circle-check';
+  }
+
+  getTestStatusClass(run: WorkflowRunDto): string {
+    if (run.testProcessingStatus === 'PROCESSED') {
+      return 'text-green-500';
+    }
+    if (run.testProcessingStatus === 'FAILED') {
+      return 'text-red-500';
+    }
+    if (run.testProcessingStatus === 'PROCESSING') {
+      return 'text-blue-500 animate-spin';
+    }
+    return 'text-surface-500';
+  }
+}

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -14,7 +14,7 @@ import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableSe
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { MessageService, SortMeta } from 'primeng/api';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconGitPullRequest, IconProgress } from 'angular-tabler-icons/icons';
+import { IconAlertTriangle, IconBrandGithub, IconCircleCheck, IconCircleX, IconClockHour4, IconFilterPlus, IconPlayerPlay, IconProgress } from 'angular-tabler-icons/icons';
 
 export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
   return [
@@ -38,13 +38,13 @@ export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
     { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createWorkflowRunsFilterOptions },
     provideTablerIcons({
       IconFilterPlus,
-      IconGitPullRequest,
       IconCircleCheck,
       IconCircleX,
       IconProgress,
       IconClockHour4,
       IconAlertTriangle,
       IconBrandGithub,
+      IconPlayerPlay
     }),
   ],
   templateUrl: './workflow-runs-table.component.html',
@@ -74,15 +74,6 @@ export class WorkflowRunsTableComponent {
 
   query = injectQuery(() => this.queryOptions());
 
-  constructor() {
-    effect(() => {
-      this.paginationService.paginationState();
-      if (this.query.data()) {
-        this.query.refetch();
-      }
-    });
-  }
-
   get typedPaginationService() {
     return this.paginationService as PaginatedTableService;
   }
@@ -101,7 +92,6 @@ export class WorkflowRunsTableComponent {
 
   onPage(event: TablePageEvent) {
     this.paginationService.onPage(event);
-    this.query.refetch();
   }
 
   onSort(event: SortMeta) {

--- a/client/src/app/pages/ci-cd/ci-cd.component.ts
+++ b/client/src/app/pages/ci-cd/ci-cd.component.ts
@@ -16,9 +16,9 @@ export class CiCdComponent implements OnInit, OnDestroy {
   repositoryId = input.required({ transform: numberAttribute });
 
   tabs = signal<{ label: string; id: string }[]>([
-    { label: 'Workflow Runs', id: 'runs' },
     { label: 'Pull Requests', id: 'pr' },
     { label: 'Branches', id: 'branch' },
+    { label: 'Workflow Runs', id: 'runs' },
   ]);
   activeTabId = signal(this.tabs()[0].id);
 

--- a/client/src/app/pages/ci-cd/ci-cd.component.ts
+++ b/client/src/app/pages/ci-cd/ci-cd.component.ts
@@ -16,6 +16,7 @@ export class CiCdComponent implements OnInit, OnDestroy {
   repositoryId = input.required({ transform: numberAttribute });
 
   tabs = signal<{ label: string; id: string }[]>([
+    { label: 'Workflow Runs', id: 'runs' },
     { label: 'Pull Requests', id: 'pr' },
     { label: 'Branches', id: 'branch' },
   ]);

--- a/client/src/app/pages/repository-overview/repository-overview.component.html
+++ b/client/src/app/pages/repository-overview/repository-overview.component.html
@@ -57,7 +57,7 @@
                 <p-button text (click)="openProjectExternal($event, project)" styleClass="p-1" class="leading-none">
                   <i-tabler name="brand-github" class="!size-4" />
                 </p-button>
-                <div class="font-bold hover:underline cursor-pointer leading-none text-xl truncate" (click)="navigateToPullRequests(project)">{{ project.name }}</div>
+                <div class="font-bold hover:underline cursor-pointer leading-none text-xl truncate" (click)="navigateToWorkflowRuns(project)">{{ project.name }}</div>
                 @if (project.latestReleaseTagName) {
                   <p-tag rounded class="py-0.5 cursor-pointer hover:underline" (click)="navigateToReleases(project)"
                     ><i-tabler name="tag" class="!size-4" />{{ project.latestReleaseTagName }}</p-tag

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -138,6 +138,10 @@ export class RepositoryOverviewComponent {
     this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'pr']);
   }
 
+  navigateToWorkflowRuns(repository: RepositoryInfoDto) {
+    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'runs']);
+  }
+
   openProjectExternal(event: Event, repository: RepositoryInfoDto) {
     window.open(repository.htmlUrl, '_blank');
     event.stopPropagation();

--- a/client/src/app/pages/repository-overview/repository-overview.component.ts
+++ b/client/src/app/pages/repository-overview/repository-overview.component.ts
@@ -139,7 +139,7 @@ export class RepositoryOverviewComponent {
   }
 
   navigateToWorkflowRuns(repository: RepositoryInfoDto) {
-    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'runs']);
+    this.router.navigate(['repo', repository.id.toString(), 'ci-cd', 'pr']);
   }
 
   openProjectExternal(event: Event, repository: RepositoryInfoDto) {

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
@@ -1,0 +1,1 @@
+<app-workflow-runs-table />

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { importProvidersFrom } from '@angular/core';
+
+import { WorkflowRunListComponent } from './workflow-run-list.component';
+import { TestModule } from '@app/test.module';
+
+describe('Integration Test Workflow Run List Page', () => {
+  let component: WorkflowRunListComponent;
+  let fixture: ComponentFixture<WorkflowRunListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkflowRunListComponent],
+      providers: [importProvidersFrom(TestModule)],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkflowRunListComponent);
+    component = fixture.componentInstance;
+
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the workflow runs table', async () => {
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const hostElement: HTMLElement = fixture.nativeElement;
+    const tableElement = hostElement.querySelector('app-workflow-runs-table');
+
+    expect(tableElement).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { WorkflowRunsTableComponent } from '@app/components/workflow-runs-table/workflow-runs-table.component';
+
+@Component({
+  selector: 'app-workflow-runs',
+  standalone: true,
+  imports: [WorkflowRunsTableComponent],
+  templateUrl: './workflow-run-list.component.html',
+})
+export class WorkflowRunListComponent {}


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This feature adds a paginated, filterable Workflow Runs listing under the CI/CD menu so users can inspect workflow executions across a repository, ordered by start time and with metadata like status and test processing status. This provides a centralized overview of CI activity beyond individual PRs/branches. #913

### Description
<!-- Describe your changes in detail -->
Workflow Run tab is added to CI/CD menu. Workflow runs can be view in timestamp descending order with 
name, status, test processing status, started at, updated at, branch and sha fields.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub repository connected to Helios with workflows configured.
- At least a few workflow runs existing in the repository.
- A user account that can log into Helios as a Developer.
#### Flow:
1. Log in to Helios as a Developer
2. Navigate to the target Repository.
3. Open the CI/CD section in the sidebar.
4. Ensure you land on the Workflow Runs tab.
5. Confirm a paginated table of workflow runs is displayed. 
6. Use the filter dropdown and verify the table updates as expected.
7. Change page size and navigate between pages to ensure server‑side pagination continues to work.
8. Click the GitHub button in a row and verify it opens the workflow run in GitHub in a new tab.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1447" height="833" alt="Screenshot 2026-03-14 at 10 48 42" src="https://github.com/user-attachments/assets/72862d0c-4b60-4a23-a6ff-03d4b0f1ae2a" />
<img width="788" height="579" alt="Screenshot 2026-03-14 at 10 49 04" src="https://github.com/user-attachments/assets/6a7e19a5-10e8-4680-bf25-993bd449b3aa" />
<img width="1453" height="703" alt="Screenshot 2026-03-14 at 10 49 22" src="https://github.com/user-attachments/assets/5b677ee5-e695-4abe-a1e4-e3ed768aa069" />
<img width="1439" height="518" alt="Screenshot 2026-03-14 at 10 51 03" src="https://github.com/user-attachments/assets/7fb90175-9c02-4f08-8527-73a6a63d67b0" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.