### PR TITLE
feat: keep flakiness in table and user server-side pagination for flakiness overview

### DIFF
--- a/client/src/app/components/pull-request-table/pull-request-table.component.ts
+++ b/client/src/app/components/pull-request-table/pull-request-table.component.ts
@@ -21,7 +21,7 @@ import { PullRequestStatusIconComponent } from '@app/components/pull-request-sta
 import { MessageService, SortMeta } from 'primeng/api';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconExternalLink, IconFilterPlus, IconGitPullRequest, IconPinned, IconPinnedOff, IconPoint, IconBrandGithub } from 'angular-tabler-icons/icons';
-import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PAGINATION_STORAGE_KEY_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { NgTemplateOutlet } from '@angular/common';
 
@@ -71,6 +71,7 @@ export function createPullRequestFilterOptions(keycloakService: KeycloakService)
   providers: [
     PaginatedTableService,
     { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createPullRequestFilterOptions, deps: [KeycloakService] },
+    { provide: PAGINATION_STORAGE_KEY_TOKEN, useValue: 'pullRequestPaginationState' },
     provideTablerIcons({
       IconFilterPlus,
       IconPoint,

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -10,7 +10,7 @@ import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
 import { WorkflowRunDto } from '@app/core/modules/openapi';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getWorkflowRunsOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
-import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PAGINATION_STORAGE_KEY_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { MessageService, SortMeta } from 'primeng/api';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
@@ -36,6 +36,7 @@ export function createWorkflowRunsFilterOptions(): PaginatedFilterOption[] {
     PaginatedTableService,
     MessageService,
     { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createWorkflowRunsFilterOptions },
+    { provide: PAGINATION_STORAGE_KEY_TOKEN, useValue: 'workflowRunsPaginationState' },
     provideTablerIcons({
       IconFilterPlus,
       IconCircleCheck,

--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -136,6 +136,8 @@ import type {
   GetFlakinessScoresError,
   GetFlakinessScoresResponse,
   GetFlakyTestsOverviewData,
+  GetFlakyTestsOverviewError,
+  GetFlakyTestsOverviewResponse,
   GetGitRepoSettingsData,
   GetGroupsWithWorkflowsData,
   GetLatestDeploymentByEnvironmentIdData,
@@ -1112,6 +1114,43 @@ export const getFlakyTestsOverviewOptions = (options?: Options<GetFlakyTestsOver
     },
     queryKey: getFlakyTestsOverviewQueryKey(options),
   });
+};
+
+export const getFlakyTestsOverviewInfiniteQueryKey = (options?: Options<GetFlakyTestsOverviewData>): QueryKey<Options<GetFlakyTestsOverviewData>> =>
+  createQueryKey('getFlakyTestsOverview', options, true);
+
+export const getFlakyTestsOverviewInfiniteOptions = (options?: Options<GetFlakyTestsOverviewData>) => {
+  return infiniteQueryOptions<
+    GetFlakyTestsOverviewResponse,
+    GetFlakyTestsOverviewError,
+    InfiniteData<GetFlakyTestsOverviewResponse>,
+    QueryKey<Options<GetFlakyTestsOverviewData>>,
+    number | Pick<QueryKey<Options<GetFlakyTestsOverviewData>>[0], 'body' | 'headers' | 'path' | 'query'>
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<QueryKey<Options<GetFlakyTestsOverviewData>>[0], 'body' | 'headers' | 'path' | 'query'> =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await getFlakyTestsOverview({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: getFlakyTestsOverviewInfiniteQueryKey(options),
+    }
+  );
 };
 
 export const getLatestTestResultsByBranchQueryKey = (options: Options<GetLatestTestResultsByBranchData>) => createQueryKey('getLatestTestResultsByBranch', options);

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -496,8 +496,12 @@ export const TestCaseIdentifierSchema = {
       type: 'string',
       minLength: 1,
     },
+    testSuiteName: {
+      type: 'string',
+      minLength: 1,
+    },
   },
-  required: ['className', 'testName'],
+  required: ['className', 'testName', 'testSuiteName'],
 } as const;
 
 export const TestFlakinessScoreRequestSchema = {
@@ -523,6 +527,9 @@ export const TestFlakinessScoreDtoSchema = {
     className: {
       type: 'string',
     },
+    testSuiteName: {
+      type: 'string',
+    },
     flakinessScore: {
       type: 'number',
       format: 'double',
@@ -536,7 +543,7 @@ export const TestFlakinessScoreDtoSchema = {
       format: 'double',
     },
   },
-  required: ['className', 'testName'],
+  required: ['className', 'testName', 'testSuiteName'],
 } as const;
 
 export const ReleaseCandidateCreateDtoSchema = {

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -1134,14 +1134,6 @@ export const FlakyTestDtoSchema = {
       type: 'number',
       format: 'double',
     },
-    totalRuns: {
-      type: 'integer',
-      format: 'int32',
-    },
-    failedRuns: {
-      type: 'integer',
-      format: 'int32',
-    },
     lastUpdated: {
       type: 'string',
       format: 'date-time',
@@ -1161,6 +1153,10 @@ export const FlakyTestOverviewDtoSchema = {
       items: {
         $ref: '#/components/schemas/FlakyTestDto',
       },
+    },
+    filteredCount: {
+      type: 'integer',
+      format: 'int64',
     },
   },
   required: ['flakyTests', 'summary'],

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -162,6 +162,7 @@ export type NotificationPreferencesWrapper = {
 export type TestCaseIdentifier = {
   testName: string;
   className: string;
+  testSuiteName: string;
 };
 
 export type TestFlakinessScoreRequest = {
@@ -171,6 +172,7 @@ export type TestFlakinessScoreRequest = {
 export type TestFlakinessScoreDto = {
   testName: string;
   className: string;
+  testSuiteName: string;
   flakinessScore?: number;
   defaultBranchFailureRate?: number;
   combinedFailureRate?: number;

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -377,14 +377,13 @@ export type FlakyTestDto = {
   flakinessScore?: number;
   defaultBranchFailureRate?: number;
   combinedFailureRate?: number;
-  totalRuns?: number;
-  failedRuns?: number;
   lastUpdated: string;
 };
 
 export type FlakyTestOverviewDto = {
   summary: FlakyTestSummary;
   flakyTests: Array<FlakyTestDto>;
+  filteredCount?: number;
 };
 
 export type FlakyTestSummary = {
@@ -1779,7 +1778,13 @@ export type GetLatestTestResultsByPullRequestIdResponse = GetLatestTestResultsBy
 export type GetFlakyTestsOverviewData = {
   body?: never;
   path?: never;
-  query?: never;
+  query?: {
+    page?: number;
+    size?: number;
+    sortDirection?: string;
+    filterType?: 'ALL' | 'HIGH' | 'MEDIUM' | 'LOW';
+    searchTerm?: string;
+  };
   url: '/api/tests/flaky';
 };
 

--- a/client/src/app/core/services/paginated-table.service.ts
+++ b/client/src/app/core/services/paginated-table.service.ts
@@ -15,6 +15,11 @@ export type PaginatedFilterOption = {
 // Define an injection token for filter options
 export const PAGINATED_FILTER_OPTIONS_TOKEN = new InjectionToken<PaginatedFilterOption[]>('paginatedFilterOptions');
 
+// Injection token for the localStorage key used to persist pagination state.
+// Each component that provides PaginatedTableService should supply its own unique key
+// via this token to prevent different tables from overwriting each other's state.
+export const PAGINATION_STORAGE_KEY_TOKEN = new InjectionToken<string>('paginationStorageKey');
+
 export interface PaginationState {
   page: number;
   size: number;
@@ -31,6 +36,8 @@ export class PaginatedTableService {
 
   // Inject filter options
   filterOptions = inject<PaginatedFilterOption[]>(PAGINATED_FILTER_OPTIONS_TOKEN);
+
+  private storageKey = inject(PAGINATION_STORAGE_KEY_TOKEN);
 
   // Pagination state
   page = signal(1);
@@ -66,7 +73,7 @@ export class PaginatedTableService {
   }
 
   private loadPaginationFromLocalStorage(): void {
-    const storedStateStr = localStorage.getItem('pullRequestPaginationState');
+    const storedStateStr = localStorage.getItem(this.storageKey);
     if (!storedStateStr) {
       console.log('No pagination state found in localStorage');
       return;
@@ -108,7 +115,7 @@ export class PaginatedTableService {
   }
 
   private savePaginationToLocalStorage(state: PaginationState): void {
-    localStorage.setItem('pullRequestPaginationState', JSON.stringify(state));
+    localStorage.setItem(this.storageKey, JSON.stringify(state));
   }
 
   filterType(): string {

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
@@ -56,7 +56,7 @@
     [loading]="query.isPending()"
     (onPage)="onPage($event)"
     (onSort)="onSort($event)"
-    [sortField]="paginationService.sortField()"
+    [sortField]="paginationService.sortField() || 'flakinessScore'"
     [sortOrder]="paginationService.sortDirection() === 'asc' ? 1 : -1"
     [scrollable]="true"
     styleClass="p-datatable-sm p-datatable-striped mt-6"

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
@@ -5,7 +5,7 @@
   <span description>Identify and monitor tests that fail intermittently across your project. Tests are ranked by flakiness score.</span>
 </app-page-heading>
 
-@if (flakyTestsQuery.isPending()) {
+@if (query.isPending()) {
   <div class="flex flex-col gap-4 mt-4">
     <div class="flex gap-4">
       @for (_ of [1, 2, 3, 4, 5]; track $index) {
@@ -14,7 +14,7 @@
     </div>
     <p-skeleton width="100%" height="400px" />
   </div>
-} @else if (flakyTestsQuery.data(); as data) {
+} @else if (query.data(); as data) {
   <!-- Summary Cards -->
   <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 mt-4">
     <div class="border border-surface rounded-xl p-4 flex flex-col gap-1">
@@ -42,85 +42,85 @@
     </div>
   </div>
 
-  <!-- Filters -->
-  <div class="flex flex-wrap items-center gap-3 mt-6 mb-4">
-    <span class="p-input-icon-left">
-      <i-tabler name="search" class="!size-4" />
-      <input type="text" pInputText placeholder="Search by test or class name..." class="w-80" [ngModel]="searchTerm()" (ngModelChange)="onSearchChange($event)" />
-    </span>
+  <!-- Flakiness Data Table -->
+  <p-table
+    #table
+    [rowHover]="true"
+    [value]="flakyTests()"
+    [lazy]="true"
+    [totalRecords]="totalElements()"
+    [paginator]="true"
+    [rows]="paginationService.size()"
+    [first]="(paginationService.page() - 1) * paginationService.size()"
+    [rowsPerPageOptions]="[10, 20, 50, 100]"
+    [loading]="query.isPending()"
+    (onPage)="onPage($event)"
+    (onSort)="onSort($event)"
+    [sortField]="paginationService.sortField()"
+    [sortOrder]="paginationService.sortDirection() === 'asc' ? 1 : -1"
+    [scrollable]="true"
+    styleClass="p-datatable-sm p-datatable-striped mt-6"
+  >
+    <ng-template #header>
+      <tr>
+        <th colspan="8">
+          <app-table-filter-paginated [paginationService]="typedPaginationService" [table]="table" />
+        </th>
+      </tr>
+      <tr>
+        <th style="min-width: 200px">Test Name</th>
+        <th style="min-width: 150px">Class</th>
+        <th style="min-width: 140px">Suite</th>
+        <th style="width: 160px" pSortableColumn="flakinessScore">
+          Flakiness Score
+          <p-sortIcon field="flakinessScore" />
+        </th>
+        <th style="width: 140px">Default Rate</th>
+        <th style="width: 140px">Combined Rate</th>
+        <th style="width: 140px">Last Updated</th>
+      </tr>
+    </ng-template>
 
-    <div class="flex gap-1 ml-auto">
-      <p-button
-        [outlined]="severityFilter() !== 'all'"
-        [severity]="severityFilter() === 'all' ? 'primary' : 'secondary'"
-        size="small"
-        label="All"
-        (click)="setSeverityFilter('all')"
-      />
-      <p-button [outlined]="severityFilter() !== 'high'" severity="danger" size="small" label="High" (click)="setSeverityFilter('high')" />
-      <p-button [outlined]="severityFilter() !== 'medium'" severity="warn" size="small" label="Medium" (click)="setSeverityFilter('medium')" />
-      <p-button [outlined]="severityFilter() !== 'low'" severity="info" size="small" label="Low" (click)="setSeverityFilter('low')" />
-    </div>
-  </div>
+    <ng-template pTemplate="body" let-test>
+      <tr>
+        <td class="font-mono text-sm">{{ test.testName }}</td>
+        <td class="text-sm text-muted-color">{{ test.className }}</td>
+        <td class="text-sm text-muted-color">{{ test.testSuiteName }}</td>
+        <td>
+          <div class="flex items-center gap-2">
+            <p-tag
+              [value]="formatScore(test.flakinessScore)"
+              [severity]="getSeverityTag(test.flakinessScore).severity"
+              [pTooltip]="getSeverityTag(test.flakinessScore).label + ' flakiness'"
+            />
+            <span class="text-xs text-muted-color">{{ getSeverityTag(test.flakinessScore).label }}</span>
+          </div>
+        </td>
+        <td class="text-sm">{{ formatRate(test.defaultBranchFailureRate) }}</td>
+        <td class="text-sm">{{ formatRate(test.combinedFailureRate) }}</td>
+        <td class="text-sm text-muted-color">{{ test.lastUpdated | date: 'short' }}</td>
+      </tr>
+    </ng-template>
 
-  <!-- Data Table -->
-  @if (paginatedFlakyTests().length === 0) {
-    <div class="flex flex-col items-center justify-center py-16 text-muted-color">
-      <i-tabler name="bug" class="!size-12 mb-4 opacity-40" />
-      @if (data.summary.flakyTestCount === 0) {
-        <p class="text-lg font-medium">No flaky tests detected</p>
-        <p class="text-sm">All tracked tests have stable results.</p>
-      } @else {
-        <p class="text-lg font-medium">No tests match your filters</p>
-        <p class="text-sm">Try adjusting the search or severity filter.</p>
-      }
-    </div>
-  } @else {
-    <p-table [value]="paginatedFlakyTests()" [scrollable]="true" styleClass="p-datatable-sm p-datatable-striped">
-      <ng-template #header>
-        <tr>
-          <th style="min-width: 200px">Test Name</th>
-          <th style="min-width: 150px">Class</th>
-          <th style="min-width: 140px">Suite</th>
-          <th style="width: 160px">Flakiness Score</th>
-          <th style="width: 140px">Default Rate</th>
-          <th style="width: 140px">Combined Rate</th>
-          <th style="width: 100px">Runs</th>
-          <th style="width: 140px">Last Updated</th>
-        </tr>
-      </ng-template>
-      <ng-template #body let-test>
-        <tr>
-          <td class="font-mono text-sm">{{ test.testName }}</td>
-          <td class="text-sm text-muted-color">{{ test.className }}</td>
-          <td class="text-sm text-muted-color">{{ test.testSuiteName }}</td>
-          <td>
-            <div class="flex items-center gap-2">
-              <p-tag
-                [value]="formatScore(test.flakinessScore)"
-                [severity]="getSeverityTag(test.flakinessScore).severity"
-                [pTooltip]="getSeverityTag(test.flakinessScore).label + ' flakiness'"
-              />
-              <span class="text-xs text-muted-color">{{ getSeverityTag(test.flakinessScore).label }}</span>
-            </div>
-          </td>
-          <td class="text-sm">{{ formatRate(test.defaultBranchFailureRate) }}</td>
-          <td class="text-sm">{{ formatRate(test.combinedFailureRate) }}</td>
-          <td class="text-sm">{{ test.totalRuns }}</td>
-          <td class="text-sm text-muted-color">{{ test.lastUpdated | date: 'short' }}</td>
-        </tr>
-      </ng-template>
-    </p-table>
-
-    <p-paginator
-      [rows]="pageSize()"
-      [totalRecords]="totalRecords()"
-      [first]="currentPage() * pageSize()"
-      [rowsPerPageOptions]="[5, 10, 20, 50]"
-      (onPageChange)="onPageChange($event)"
-    />
-  }
-} @else if (flakyTestsQuery.isError()) {
+    <ng-template pTemplate="emptymessage">
+      <tr>
+        <td colspan="7">
+          <div class="flex flex-col items-center justify-center py-16 text-muted-color">
+            <i-tabler name="bug" class="!size-12 mb-4 opacity-40" />
+            @if ((data.summary.flakyTestCount ?? 0) === 0) {
+              <p class="text-lg font-medium">No flaky tests detected</p>
+              <p class="text-sm">All tracked tests have stable results.</p>
+            } @else {
+              <p class="text-lg font-medium">No tests match your filters</p>
+              <p class="text-sm">Try adjusting the search or severity filter.</p>
+              <p-button class="mt-4" size="small" (click)="clearFilters()">Clear Filters</p-button>
+            }
+          </div>
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+} @else if (query.isError()) {
   <div class="flex flex-col items-center justify-center py-16 text-muted-color">
     <i-tabler name="alert-triangle" class="!size-12 mb-4 opacity-40" />
     <p class="text-lg font-medium">Failed to load flaky tests</p>

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.spec.ts
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.spec.ts
@@ -1,7 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FlakyTestsOverviewComponent } from './flaky-tests-overview.component';
-import { importProvidersFrom, signal } from '@angular/core';
+import { importProvidersFrom } from '@angular/core';
 import { TestModule } from '@app/test.module';
+import { SortMeta } from 'primeng/api';
+import { TablePageEvent } from 'primeng/table';
+import { expect, vi } from 'vitest';
+
+import type { FlakyTestOverviewDto, GetFlakyTestsOverviewData } from '@app/core/modules/openapi';
 
 const mockFlakyTests = [
   {
@@ -33,7 +38,7 @@ const mockFlakyTests = [
   },
 ];
 
-const mockOverview = {
+const mockOverview: FlakyTestOverviewDto = {
   summary: {
     totalTrackedTests: 10,
     flakyTestCount: 3,
@@ -42,7 +47,19 @@ const mockOverview = {
     lowFlakinessCount: 1,
   },
   flakyTests: mockFlakyTests,
+  filteredCount: 3,
 };
+
+function setMockQuery(component: FlakyTestsOverviewComponent, data: FlakyTestOverviewDto | undefined = mockOverview, options: { isPending?: boolean; isError?: boolean } = {}) {
+  Object.defineProperty(component, 'query', {
+    configurable: true,
+    value: {
+      data: () => data,
+      isPending: () => options.isPending ?? false,
+      isError: () => options.isError ?? false,
+    },
+  });
+}
 
 describe('FlakyTestsOverviewComponent', () => {
   let component: FlakyTestsOverviewComponent;
@@ -58,14 +75,7 @@ describe('FlakyTestsOverviewComponent', () => {
     component = fixture.componentInstance;
 
     fixture.componentRef.setInput('repositoryId', 1);
-
-    // Mock TanStack query for testing
-    component.query = {
-      ...component.query,
-      data: signal(mockOverview),
-      isPending: signal(false),
-      isError: signal(false),
-    } as unknown as typeof component.query;
+    setMockQuery(component);
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -78,6 +88,7 @@ describe('FlakyTestsOverviewComponent', () => {
   it('should expose flaky tests from query data', () => {
     expect(component.query.data()).toEqual(mockOverview);
     expect(component.flakyTests().length).toBe(3);
+    expect(component.totalElements()).toBe(3);
   });
 
   describe('getSeverityTag', () => {
@@ -103,6 +114,107 @@ describe('FlakyTestsOverviewComponent', () => {
   describe('formatRate', () => {
     it('should format rate as percentage', () => {
       expect(component.formatRate(0.05)).toBe('5.0%');
+    });
+  });
+
+  describe('onPage', () => {
+    it('calls paginationService.onPage with the event', () => {
+      const onPageSpy = vi.spyOn(component.paginationService, 'onPage');
+      const event = { first: 20, rows: 10 };
+
+      component.onPage(event as TablePageEvent);
+
+      expect(onPageSpy).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe('onSort', () => {
+    it('calls paginationService.onSort with the event', () => {
+      const onSortSpy = vi.spyOn(component.paginationService, 'onSort');
+      const event: SortMeta = { field: 'flakinessScore', order: 1 };
+
+      component.onSort(event);
+
+      expect(onSortSpy).toHaveBeenCalledWith(event);
+    });
+  });
+
+  describe('clearFilters', () => {
+    it('clears filter component search and pagination filters', () => {
+      const clearSearchSpy = vi.fn();
+      const clearFiltersSpy = vi.spyOn(component.paginationService, 'clearFilters');
+      (component as unknown as { filterComponent: { clearSearch: () => void } }).filterComponent = {
+        clearSearch: clearSearchSpy,
+      };
+
+      component.clearFilters();
+
+      expect(clearSearchSpy).toHaveBeenCalled();
+      expect(clearFiltersSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('queryOptions and pagination state', () => {
+    function resetPaginationToDefaults() {
+      const svc = component.paginationService;
+      svc.page.set(1);
+      svc.size.set(20);
+      svc.sortField.set(undefined);
+      svc.sortDirection.set('desc');
+      svc.searchTerm.set('');
+      svc.activeFilter.set(svc.filterOptions[0]);
+    }
+
+    function expectQueryKeyMatchesPaginationState() {
+      const state = component.paginationService.paginationState();
+      const filterType = state.filterType as NonNullable<GetFlakyTestsOverviewData['query']>['filterType'];
+      expect(component.queryOptions().queryKey[0].query).toEqual({
+        page: state.page,
+        size: state.size,
+        sortDirection: state.sortDirection,
+        filterType,
+        searchTerm: state.searchTerm,
+      });
+    }
+
+    beforeEach(() => {
+      resetPaginationToDefaults();
+    });
+
+    it('computed query key reflects page and size after onPage', () => {
+      component.paginationService.onPage({ first: 20, rows: 10 } as TablePageEvent);
+
+      expect(component.paginationService.page()).toBe(3);
+      expect(component.paginationService.size()).toBe(10);
+      expect(component.paginationService.paginationState()).toMatchObject({ page: 3, size: 10 });
+      expectQueryKeyMatchesPaginationState();
+    });
+
+    it('computed query key reflects sort direction after onSort', () => {
+      component.paginationService.onSort({ field: 'flakinessScore', order: 1 } as SortMeta);
+
+      expect(component.paginationService.sortField()).toBe('flakinessScore');
+      expect(component.paginationService.sortDirection()).toBe('asc');
+      expectQueryKeyMatchesPaginationState();
+    });
+
+    it('computed query key reflects reset state after clearFilters', () => {
+      component.paginationService.setSearchTerm('myTest');
+      component.paginationService.setFilterType('HIGH');
+      component.paginationService.onPage({ first: 30, rows: 10 } as TablePageEvent);
+
+      const clearSearchSpy = vi.fn();
+      (component as unknown as { filterComponent: { clearSearch: () => void } }).filterComponent = {
+        clearSearch: clearSearchSpy,
+      };
+
+      component.clearFilters();
+
+      expect(clearSearchSpy).toHaveBeenCalled();
+      expect(component.paginationService.page()).toBe(1);
+      expect(component.paginationService.searchTerm()).toBe('');
+      expect(component.paginationService.activeFilter().value).toBe('ALL');
+      expectQueryKeyMatchesPaginationState();
     });
   });
 });

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.spec.ts
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.spec.ts
@@ -11,8 +11,6 @@ const mockFlakyTests = [
     flakinessScore: 85,
     defaultBranchFailureRate: 0.03,
     combinedFailureRate: 0.05,
-    totalRuns: 320,
-    failedRuns: 12,
     lastUpdated: '2025-03-10T12:00:00Z',
   },
   {
@@ -22,8 +20,6 @@ const mockFlakyTests = [
     flakinessScore: 45,
     defaultBranchFailureRate: 0.04,
     combinedFailureRate: 0.07,
-    totalRuns: 280,
-    failedRuns: 16,
     lastUpdated: '2025-03-10T11:00:00Z',
   },
   {
@@ -33,8 +29,6 @@ const mockFlakyTests = [
     flakinessScore: 15,
     defaultBranchFailureRate: 0.01,
     combinedFailureRate: 0.02,
-    totalRuns: 500,
-    failedRuns: 5,
     lastUpdated: '2025-03-10T10:00:00Z',
   },
 ];
@@ -43,7 +37,6 @@ const mockOverview = {
   summary: {
     totalTrackedTests: 10,
     flakyTestCount: 3,
-    averageFlakinessScore: 48.3,
     highFlakinessCount: 1,
     mediumFlakinessCount: 1,
     lowFlakinessCount: 1,
@@ -66,13 +59,13 @@ describe('FlakyTestsOverviewComponent', () => {
 
     fixture.componentRef.setInput('repositoryId', 1);
 
-    // Mock query for testing
-    component.flakyTestsQuery = {
-      ...component.flakyTestsQuery,
+    // Mock TanStack query for testing
+    component.query = {
+      ...component.query,
       data: signal(mockOverview),
       isPending: signal(false),
       isError: signal(false),
-    } as unknown as typeof component.flakyTestsQuery;
+    } as unknown as typeof component.query;
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -82,9 +75,9 @@ describe('FlakyTestsOverviewComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display summary from query data', () => {
-    expect(component.flakyTestsQuery.data()).toEqual(mockOverview);
-    expect(component.filteredFlakyTests().length).toBe(3);
+  it('should expose flaky tests from query data', () => {
+    expect(component.query.data()).toEqual(mockOverview);
+    expect(component.flakyTests().length).toBe(3);
   });
 
   describe('getSeverityTag', () => {
@@ -110,72 +103,6 @@ describe('FlakyTestsOverviewComponent', () => {
   describe('formatRate', () => {
     it('should format rate as percentage', () => {
       expect(component.formatRate(0.05)).toBe('5.0%');
-    });
-  });
-
-  describe('filtering', () => {
-    it('should filter by search term (test name)', () => {
-      component.debouncedSearch.set('database');
-      fixture.detectChanges();
-      expect(component.filteredFlakyTests().length).toBe(1);
-      expect(component.filteredFlakyTests()[0].testName).toBe('testDatabaseConnection');
-    });
-
-    it('should filter by search term (class name)', () => {
-      component.debouncedSearch.set('WebSocket');
-      fixture.detectChanges();
-      expect(component.filteredFlakyTests().length).toBe(1);
-      expect(component.filteredFlakyTests()[0].className).toBe('WebSocketClientTest');
-    });
-
-    it('should filter by severity high', () => {
-      component.setSeverityFilter('high');
-      fixture.detectChanges();
-      expect(component.filteredFlakyTests().length).toBe(1);
-      expect(component.filteredFlakyTests()[0].flakinessScore).toBe(85);
-    });
-
-    it('should filter by severity medium', () => {
-      component.setSeverityFilter('medium');
-      fixture.detectChanges();
-      expect(component.filteredFlakyTests().length).toBe(1);
-      expect(component.filteredFlakyTests()[0].flakinessScore).toBe(45);
-    });
-
-    it('should filter by severity low', () => {
-      component.setSeverityFilter('low');
-      fixture.detectChanges();
-      expect(component.filteredFlakyTests().length).toBe(1);
-      expect(component.filteredFlakyTests()[0].flakinessScore).toBe(15);
-    });
-  });
-
-  describe('pagination', () => {
-    it('should paginate results', () => {
-      component.pageSize.set(2);
-      fixture.detectChanges();
-      expect(component.paginatedFlakyTests().length).toBe(2);
-      expect(component.totalRecords()).toBe(3);
-    });
-
-    it('should update page on onPageChange', () => {
-      component.onPageChange({ page: 1, rows: 10, first: 10, pageCount: 1 });
-      expect(component.currentPage()).toBe(1);
-      expect(component.pageSize()).toBe(10);
-    });
-  });
-
-  describe('onSearchChange', () => {
-    it('should update searchTerm immediately', () => {
-      component.onSearchChange('foo');
-      expect(component.searchTerm()).toBe('foo');
-    });
-
-    it('should reset page to 0 after debounce', async () => {
-      component.currentPage.set(1);
-      component.onSearchChange('foo');
-      await new Promise(resolve => setTimeout(resolve, 350));
-      expect(component.currentPage()).toBe(0);
     });
   });
 });

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
@@ -10,7 +10,7 @@ import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getFlakyTestsOverviewOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconAlertTriangle, IconBug } from 'angular-tabler-icons/icons';
-import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PAGINATION_STORAGE_KEY_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
 import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
 import { SortMeta } from 'primeng/api';
 import { FlakyTestDto } from '@app/core/modules/openapi';
@@ -27,7 +27,12 @@ function createFlakinessFilterOptions(): PaginatedFilterOption[] {
 @Component({
   selector: 'app-flaky-tests-overview',
   imports: [CommonModule, TableModule, TagModule, TooltipModule, ButtonModule, SkeletonModule, PageHeadingComponent, TablerIconComponent, TableFilterPaginatedComponent],
-  providers: [PaginatedTableService, { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createFlakinessFilterOptions }, provideTablerIcons({ IconBug, IconAlertTriangle })],
+  providers: [
+    PaginatedTableService,
+    { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createFlakinessFilterOptions },
+    { provide: PAGINATION_STORAGE_KEY_TOKEN, useValue: 'flakyTestsPaginationState' },
+    provideTablerIcons({ IconBug, IconAlertTriangle }),
+  ],
   templateUrl: './flaky-tests-overview.component.html',
 })
 export class FlakyTestsOverviewComponent {

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
@@ -1,105 +1,82 @@
-import { Component, computed, input, numberAttribute, signal } from '@angular/core';
+import { Component, computed, inject, input, numberAttribute, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { TableModule } from 'primeng/table';
+import { Table, TableModule, TablePageEvent } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
-import { InputTextModule } from 'primeng/inputtext';
 import { ButtonModule } from 'primeng/button';
 import { SkeletonModule } from 'primeng/skeleton';
-import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { getFlakyTestsOverviewOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import { IconAlertTriangle, IconBug, IconSearch } from 'angular-tabler-icons/icons';
+import { IconAlertTriangle, IconBug } from 'angular-tabler-icons/icons';
+import { PAGINATED_FILTER_OPTIONS_TOKEN, PaginatedFilterOption, PaginatedTableService } from '@app/core/services/paginated-table.service';
+import { TableFilterPaginatedComponent } from '@app/components/table-filter-paginated/table-filter-paginated.component';
+import { SortMeta } from 'primeng/api';
+import { FlakyTestDto } from '@app/core/modules/openapi';
 
-type SeverityFilter = 'all' | 'high' | 'medium' | 'low';
+function createFlakinessFilterOptions(): PaginatedFilterOption[] {
+  return [
+    { name: 'All', value: 'ALL' },
+    { name: 'High (> 70)', value: 'HIGH' },
+    { name: 'Medium (30 – 70)', value: 'MEDIUM' },
+    { name: 'Low (1 – 30)', value: 'LOW' },
+  ];
+}
 
 @Component({
   selector: 'app-flaky-tests-overview',
-  imports: [
-    CommonModule,
-    FormsModule,
-    TableModule,
-    TagModule,
-    TooltipModule,
-    InputTextModule,
-    ButtonModule,
-    SkeletonModule,
-    PaginatorModule,
-    PageHeadingComponent,
-    TablerIconComponent,
-  ],
-  providers: [
-    provideTablerIcons({
-      IconBug,
-      IconAlertTriangle,
-      IconSearch,
-    }),
-  ],
+  imports: [CommonModule, TableModule, TagModule, TooltipModule, ButtonModule, SkeletonModule, PageHeadingComponent, TablerIconComponent, TableFilterPaginatedComponent],
+  providers: [PaginatedTableService, { provide: PAGINATED_FILTER_OPTIONS_TOKEN, useFactory: createFlakinessFilterOptions }, provideTablerIcons({ IconBug, IconAlertTriangle })],
   templateUrl: './flaky-tests-overview.component.html',
 })
 export class FlakyTestsOverviewComponent {
+  @ViewChild('table') table!: Table;
+  @ViewChild(TableFilterPaginatedComponent) filterComponent!: TableFilterPaginatedComponent;
+
   repositoryId = input.required({ transform: numberAttribute });
 
-  currentPage = signal(0);
-  pageSize = signal(10);
-  searchTerm = signal('');
-  severityFilter = signal<SeverityFilter>('all');
+  paginationService = inject(PaginatedTableService);
 
-  private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-  debouncedSearch = signal('');
-
-  flakyTestsQuery = injectQuery(() => getFlakyTestsOverviewOptions());
-
-  filteredFlakyTests = computed(() => {
-    const data = this.flakyTestsQuery.data()?.flakyTests ?? [];
-    const search = this.debouncedSearch().toLowerCase();
-    const severity = this.severityFilter();
-
-    let filtered = data;
-    if (search) {
-      filtered = filtered.filter(t => t.testName.toLowerCase().includes(search) || t.className.toLowerCase().includes(search) || t.testSuiteName.toLowerCase().includes(search));
-    }
-    if (severity !== 'all') {
-      filtered = filtered.filter(t => {
-        const score = t.flakinessScore ?? 0;
-        if (severity === 'high') return score > 70;
-        if (severity === 'medium') return score > 30 && score <= 70;
-        return score <= 30;
-      });
-    }
-    return filtered;
+  queryOptions = computed(() => {
+    const state = this.paginationService.paginationState();
+    const filterType = state.filterType as 'ALL' | 'HIGH' | 'MEDIUM' | 'LOW' | undefined;
+    return getFlakyTestsOverviewOptions({
+      query: {
+        page: state.page,
+        size: state.size,
+        sortDirection: state.sortDirection,
+        filterType,
+        searchTerm: state.searchTerm,
+      },
+    });
   });
 
-  paginatedFlakyTests = computed(() => {
-    const filtered = this.filteredFlakyTests();
-    const start = this.currentPage() * this.pageSize();
-    return filtered.slice(start, start + this.pageSize());
-  });
+  query = injectQuery(() => this.queryOptions());
 
-  totalRecords = computed(() => this.filteredFlakyTests().length);
-
-  onSearchChange(value: string) {
-    this.searchTerm.set(value);
-    if (this.searchDebounceTimer) {
-      clearTimeout(this.searchDebounceTimer);
-    }
-    this.searchDebounceTimer = setTimeout(() => {
-      this.debouncedSearch.set(value);
-      this.currentPage.set(0);
-    }, 300);
+  get typedPaginationService() {
+    return this.paginationService as PaginatedTableService;
   }
 
-  onPageChange(event: PaginatorState) {
-    this.currentPage.set(event.page ?? 0);
-    this.pageSize.set(event.rows ?? 10);
+  flakyTests(): FlakyTestDto[] {
+    return this.query.data()?.flakyTests ?? [];
   }
 
-  setSeverityFilter(filter: SeverityFilter) {
-    this.severityFilter.set(filter);
-    this.currentPage.set(0);
+  totalElements(): number {
+    return this.query.data()?.filteredCount ?? 0;
+  }
+
+  onPage(event: TablePageEvent) {
+    this.paginationService.onPage(event);
+  }
+
+  onSort(event: SortMeta) {
+    this.paginationService.onSort(event);
+  }
+
+  clearFilters() {
+    this.filterComponent.clearSearch();
+    this.paginationService.clearFilters();
   }
 
   getSeverityTag(score: number): { label: string; severity: 'danger' | 'warn' | 'info' } {

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -2379,9 +2379,13 @@ components:
         className:
           type: string
           minLength: 1
+        testSuiteName:
+          type: string
+          minLength: 1
       required:
       - className
       - testName
+      - testSuiteName
     TestFlakinessScoreRequest:
       type: object
       properties:
@@ -2399,6 +2403,8 @@ components:
           type: string
         className:
           type: string
+        testSuiteName:
+          type: string
         flakinessScore:
           type: number
           format: double
@@ -2411,6 +2417,7 @@ components:
       required:
       - className
       - testName
+      - testSuiteName
     ReleaseCandidateCreateDto:
       type: object
       properties:

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -1177,6 +1177,41 @@ paths:
       tags:
       - test-result-controller
       operationId: getFlakyTestsOverview
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - name: sortDirection
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: filterType
+        in: query
+        required: false
+        schema:
+          type: string
+          enum:
+          - ALL
+          - HIGH
+          - MEDIUM
+          - LOW
+      - name: searchTerm
+        in: query
+        required: false
+        schema:
+          type: string
       responses:
         "409":
           description: Conflict
@@ -2882,12 +2917,6 @@ components:
         combinedFailureRate:
           type: number
           format: double
-        totalRuns:
-          type: integer
-          format: int32
-        failedRuns:
-          type: integer
-          format: int32
         lastUpdated:
           type: string
           format: date-time
@@ -2905,6 +2934,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FlakyTestDto"
+        filteredCount:
+          type: integer
+          format: int64
       required:
       - flakyTests
       - summary

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/FlakyTestOverviewDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/FlakyTestOverviewDto.java
@@ -6,7 +6,8 @@ import org.springframework.lang.NonNull;
 
 public record FlakyTestOverviewDto(
     @NonNull FlakyTestSummary summary,
-    @NonNull List<FlakyTestDto> flakyTests) {
+    @NonNull List<FlakyTestDto> flakyTests,
+    long filteredCount) {
 
   public record FlakyTestDto(
       @NonNull String testName,
@@ -15,16 +16,17 @@ public record FlakyTestOverviewDto(
       double flakinessScore,
       double defaultBranchFailureRate,
       double combinedFailureRate,
-      int totalRuns,
-      int failedRuns,
       @NonNull OffsetDateTime lastUpdated) {
 
-    public static FlakyTestDto from(
-        TestCaseStatistics stat, TestCaseStatisticsService.FlakinessInfo info) {
+    public static FlakyTestDto from(TestCaseFlakiness flakiness) {
       return new FlakyTestDto(
-          stat.getTestName(), stat.getClassName(), stat.getTestSuiteName(),
-          info.flakinessScore(), info.defaultBranchFailureRate(), info.combinedFailureRate(),
-          stat.getTotalRuns(), stat.getFailedRuns(), stat.getLastUpdated());
+          flakiness.getTestName(),
+          flakiness.getClassName(),
+          flakiness.getTestSuiteName(),
+          flakiness.getFlakinessScore(),
+          flakiness.getDefaultBranchFailureRate(),
+          flakiness.getCombinedFailureRate(),
+          flakiness.getLastUpdated());
     }
   }
 
@@ -33,27 +35,5 @@ public record FlakyTestOverviewDto(
       int flakyTestCount,
       int highFlakinessCount,
       int mediumFlakinessCount,
-      int lowFlakinessCount) {
-
-    public static FlakyTestSummary buildSummary(
-        int totalTrackedTests, List<FlakyTestDto> flakyTests) {
-      int highCount = 0;
-      int mediumCount = 0;
-      int lowCount = 0;
-
-      for (FlakyTestDto t : flakyTests) {
-        if (t.flakinessScore() > 70) {
-          highCount++;
-        } else if (t.flakinessScore() > 30) {
-          mediumCount++;
-        } else {
-          lowCount++;
-        }
-      }
-
-      return new FlakyTestSummary(
-          totalTrackedTests, flakyTests.size(), highCount, mediumCount, lowCount);
-    }
-  }
-
+      int lowFlakinessCount) {}
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakiness.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakiness.java
@@ -1,0 +1,75 @@
+package de.tum.cit.aet.helios.tests;
+
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.hibernate.annotations.Filter;
+
+/**
+ * Precomputed flakiness metric for test cases, stored in a separate table for efficient retrieval.
+ *
+ * <p>One row per unique (repository, test_name, class_name, test_suite_name) combination.
+ * Updated whenever new test statistics are computed, allowing for quick access to flakiness scores
+ * without needing to recompute them on the fly.
+ */
+@Entity
+@Table(
+    name = "test_case_flakiness",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_test_case_flakiness",
+          columnNames = {"repository_id", "test_name", "class_name", "test_suite_name"})
+    },
+    indexes = {
+      @Index(name = "idx_flakiness_repo_score", columnList = "repository_id,flakiness_score DESC")
+    })
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@Filter(name = "gitRepositoryFilter")
+public class TestCaseFlakiness {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne
+  @JoinColumn(name = "repository_id")
+  @ToString.Exclude
+  private GitRepository repository;
+
+  @Column(nullable = false, name = "test_name")
+  private String testName;
+
+  @Column(nullable = false, name = "class_name")
+  private String className;
+
+  @Column(nullable = false, name = "test_suite_name")
+  private String testSuiteName;
+
+  @Column(nullable = false, name = "flakiness_score")
+  private double flakinessScore;
+
+  @Column(nullable = false, name = "default_branch_failure_rate")
+  private double defaultBranchFailureRate;
+
+  @Column(nullable = false, name = "combined_failure_rate")
+  private double combinedFailureRate;
+
+  @Column(nullable = false, name = "last_updated")
+  private OffsetDateTime lastUpdated;
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -48,9 +48,11 @@ public interface TestCaseFlakinessRepository
           + " WHERE t.repository.repositoryId = :repositoryId"
           + "   AND t.testName = :testName"
           + "   AND t.className = :className"
+          + "   AND t.testSuiteName = :suiteName"
           + " ORDER BY t.flakinessScore DESC")
-  List<TestCaseFlakiness> findByRepositoryIdAndTestNameAndClassName(
+  List<TestCaseFlakiness> findByRepositoryIdAndTestNameAndClassNameAndSuiteName(
       @Param("repositoryId") Long repositoryId,
       @Param("testName") String testName,
-      @Param("className") String className);
+      @Param("className") String className,
+      @Param("suiteName") String suiteName);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -13,7 +13,7 @@ public interface TestCaseFlakinessRepository
     extends JpaRepository<TestCaseFlakiness, Long>, JpaSpecificationExecutor<TestCaseFlakiness> {
 
   /**
-   * Total number of flaky tests tracked for a repository.
+   * Total number of flaky tests for a repository, regardless of flakiness score.
    */
   long countByRepositoryRepositoryId(Long repositoryId);
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.helios.tests;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -32,11 +32,11 @@ public interface TestCaseFlakinessRepository
       Long repositoryId, double minScore, double maxScore);
 
   /**
-   * Finds the existing flakiness record for a specific test in a repository, if any.
+   * Batch-fetches all flakiness records that belong to any of the given suite names in a
+   * repository. Used to pre-index flakiness data before per-test annotation loops.
    */
-  Optional<TestCaseFlakiness>
-      findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
-          String testName, String className, String testSuiteName, Long repositoryId);
+  List<TestCaseFlakiness> findByTestSuiteNameInAndRepositoryRepositoryId(
+      Collection<String> suiteNames, Long repositoryId);
 
   /**
    * Finds flakiness records matching a test name and class name for a repository, ordered by

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -1,0 +1,56 @@
+package de.tum.cit.aet.helios.tests;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestCaseFlakinessRepository
+    extends JpaRepository<TestCaseFlakiness, Long>, JpaSpecificationExecutor<TestCaseFlakiness> {
+
+  /**
+   * Total number of flaky tests tracked for a repository.
+   */
+  long countByRepositoryRepositoryId(Long repositoryId);
+
+  /**
+   * Number of flaky tests with flakiness score strictly greater than {@code minScore}.
+   * Use {@code minScore = 70.0} to count high-flakiness tests.
+   */
+  long countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(
+      Long repositoryId, double minScore);
+
+  /**
+   * Number of flaky tests with flakiness score in the range ({@code minScore}, {@code maxScore}].
+   * Use {@code minScore = 30.0, maxScore = 70.0} to count medium-flakiness tests.
+   */
+  long countByRepositoryRepositoryIdAndFlakinessScoreGreaterThanAndFlakinessScoreLessThanEqual(
+      Long repositoryId, double minScore, double maxScore);
+
+  /**
+   * Finds the existing flakiness record for a specific test in a repository, if any.
+   */
+  Optional<TestCaseFlakiness>
+      findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
+          String testName, String className, String testSuiteName, Long repositoryId);
+
+  /**
+   * Finds flakiness records matching a test name and class name for a repository, ordered by
+   * flakiness score descending. Used by the CI per-test flakiness endpoint where the test suite
+   * name is not known.
+   */
+  @Query(
+      "SELECT t FROM TestCaseFlakiness t"
+          + " WHERE t.repository.repositoryId = :repositoryId"
+          + "   AND t.testName = :testName"
+          + "   AND t.className = :className"
+          + " ORDER BY t.flakinessScore DESC")
+  List<TestCaseFlakiness> findByRepositoryIdAndTestNameAndClassName(
+      @Param("repositoryId") Long repositoryId,
+      @Param("testName") String testName,
+      @Param("className") String className);
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
   @Query(
       "SELECT tc FROM TestCase tc "
-          + "JOIN tc.testSuite ts "
+          + "JOIN FETCH tc.testSuite ts "
           + "WHERE ts.workflowRun.id = :workflowRunId "
           + "AND ts.name IN :classNames "
           + "AND ts.testType.id = :testTypeId")
@@ -22,7 +22,7 @@ public interface TestCaseRepository extends JpaRepository<TestCase, Long> {
 
   @Query(
       "SELECT tc FROM TestCase tc "
-          + "JOIN tc.testSuite ts "
+          + "JOIN FETCH tc.testSuite ts "
           + "WHERE ts.workflowRun.id = :workflowRunId "
           + "AND ts.name IN :classNames "
           + "AND ts.testType.id = :testTypeId "

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatistics.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatistics.java
@@ -40,8 +40,7 @@ import org.hibernate.annotations.Filter;
       @Index(
           name = "idx_test_case_statistics",
           columnList = "test_name,class_name,test_suite_name,branch_name,repository_id"),
-      @Index(name = "idx_branch_name", columnList = "branch_name,repository_id"),
-      @Index(name = "idx_is_flaky", columnList = "branch_name,is_flaky,repository_id")
+      @Index(name = "idx_branch_name", columnList = "branch_name,repository_id")
     })
 @Getter
 @Setter

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
@@ -64,13 +64,4 @@ public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStat
    */
   List<TestCaseStatistics> findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
       Collection<String> testSuiteNames, String branchName, Long repositoryId);
-
-  /**
-   * Counts all statistics rows matching a branch and repository.
-   *
-   * @param branchName the branch name (use "combined" for total unique test count)
-   * @param repositoryId the repository ID
-   * @return count of matching rows
-   */
-  long countByBranchNameAndRepositoryRepositoryId(String branchName, Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
@@ -64,4 +64,13 @@ public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStat
    */
   List<TestCaseStatistics> findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
       Collection<String> testSuiteNames, String branchName, Long repositoryId);
+
+  /**
+   * Counts all statistics rows matching a branch and repository.
+   *
+   * @param branchName the branch name (use "combined" for total unique test count)
+   * @param repositoryId the repository ID
+   * @return count of matching rows
+   */
+  long countByBranchNameAndRepositoryRepositoryId(String branchName, Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -1,19 +1,20 @@
 package de.tum.cit.aet.helios.tests;
 
-import static de.tum.cit.aet.helios.tests.FlakyTestOverviewDto.FlakyTestSummary.buildSummary;
-
-import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 /** Service for managing test case statistics and detecting flaky tests. */
@@ -22,8 +23,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TestCaseStatisticsService {
 
+  public static final double HIGH_FLAKINESS_THRESHOLD = 70.0;
+  public static final double LOW_FLAKINESS_THRESHOLD = 30.0;
   private final TestCaseStatisticsRepository statisticsRepository;
-  private final BranchRepository branchRepository;
+  private final TestCaseFlakinessRepository flakinessRepository;
+
   private static final double DEFAULT_BRANCH_WEIGHT = 0.7;
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
@@ -100,6 +104,93 @@ public class TestCaseStatisticsService {
   }
 
   /**
+   * Recomputes and persists flakiness scores for all tests belonging to the given suites.
+   * Reads statistics for the default branch and combined branches to compute scores, then updates
+   * the {@code test_case_flakiness} table accordingly. Tests that are no longer flaky (score <= 0)
+   * will have their flakiness record removed to keep the table focused on only flaky tests.
+   *
+   * @param testSuites the suites processed in this run
+   * @param defaultBranch the repository's default branch name
+   * @param repository the repository
+   */
+  public void updateFlakinessForTestSuite(
+      List<TestSuite> testSuites, String defaultBranch, GitRepository repository) {
+
+    var suiteClassNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
+
+    List<TestCaseStatistics> defaultBranchStats =
+        statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            suiteClassNames, defaultBranch, repository.getRepositoryId());
+
+    List<TestCaseStatistics> combinedStats =
+        statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            suiteClassNames, "combined", repository.getRepositoryId());
+
+    for (TestSuite suite : testSuites) {
+      for (TestCase testCase : suite.getTestCases()) {
+        var flakinessInfo =
+            computeFlakinessInfo(
+                testCase.getName(), testCase.getClassName(), defaultBranchStats, combinedStats);
+        double flakinessScore = flakinessInfo.flakinessScore();
+
+        if (flakinessScore <= 0.0) {
+          // Test is not flaky anymore; remove any existing flakiness record so the
+          // precomputed table only contains genuinely flaky tests.
+          flakinessRepository
+              .findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
+                  testCase.getName(),
+                  testCase.getClassName(),
+                  suite.getName(),
+                  repository.getRepositoryId())
+              .ifPresent(flakinessRepository::delete);
+          continue;
+        }
+
+        upsertFlakiness(
+            testCase.getName(),
+            testCase.getClassName(),
+            suite.getName(),
+            flakinessScore,
+            flakinessInfo.defaultBranchFailureRate(),
+            flakinessInfo.combinedFailureRate(),
+            repository);
+      }
+    }
+  }
+
+  /**
+   * Inserts or updates a flakiness record for a single test.
+   */
+  private void upsertFlakiness(
+      String testName,
+      String className,
+      String testSuiteName,
+      double score,
+      double defaultRate,
+      double combinedRate,
+      GitRepository repository) {
+    TestCaseFlakiness flakiness =
+        flakinessRepository
+            .findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
+                testName, className, testSuiteName, repository.getRepositoryId())
+            .orElseGet(
+                () -> {
+                  TestCaseFlakiness f = new TestCaseFlakiness();
+                  f.setTestName(testName);
+                  f.setClassName(className);
+                  f.setTestSuiteName(testSuiteName);
+                  f.setRepository(repository);
+                  return f;
+                });
+
+    flakiness.setFlakinessScore(score);
+    flakiness.setDefaultBranchFailureRate(defaultRate);
+    flakiness.setCombinedFailureRate(combinedRate);
+    flakiness.setLastUpdated(OffsetDateTime.now());
+    flakinessRepository.save(flakiness);
+  }
+
+  /**
    * Gets statistics for a specific test case on a specific branch.
    *
    * @param testName the name of the test
@@ -115,19 +206,8 @@ public class TestCaseStatisticsService {
   }
 
   /**
-   * Gets all statistics for a specific branch.
-   *
-   * @param branchName the branch name
-   * @param repositoryId the repository ID
-   * @return list of statistics for all tests on the branch
-   */
-  public List<TestCaseStatistics> getStatisticsForBranch(String branchName, Long repositoryId) {
-    return statisticsRepository.findByBranchNameAndRepositoryRepositoryId(branchName, repositoryId);
-  }
-
-  /**
    * Returns flakiness scores for the requested test cases identified by testName + className.
-   * Matches against accumulated default-branch and combined-branch statistics.
+   * Reads directly from the precomputed {@code test_case_flakiness} table.
    *
    * @param repositoryId the repository ID
    * @param testIdentifiers the list of test case identifiers to look up
@@ -135,94 +215,85 @@ public class TestCaseStatisticsService {
    */
   public List<TestFlakinessScoreDto> getFlakinessScoresForTests(
       Long repositoryId, List<TestFlakinessScoreRequest.TestCaseIdentifier> testIdentifiers) {
-    String defaultBranchName = getDefaultBranchName(repositoryId);
-    List<TestCaseStatistics> defaultBranchStats =
-        getStatisticsForBranch(defaultBranchName, repositoryId);
-    List<TestCaseStatistics> combinedStats = getStatisticsForBranch("combined", repositoryId);
-
     return testIdentifiers.stream()
-        .map(identifier -> {
-          FlakinessInfo info = computeFlakinessInfo(
-              identifier.testName(), identifier.className(), defaultBranchStats, combinedStats);
-          return new TestFlakinessScoreDto(
-              identifier.testName(), identifier.className(),
-              info.flakinessScore(), info.defaultBranchFailureRate(), info.combinedFailureRate());
-        })
+        .map(
+            identifier -> {
+              List<TestCaseFlakiness> matches =
+                  flakinessRepository.findByRepositoryIdAndTestNameAndClassName(
+                      repositoryId, identifier.testName(), identifier.className());
+
+              if (!matches.isEmpty()) {
+                TestCaseFlakiness best = matches.getFirst();
+                return new TestFlakinessScoreDto(
+                    identifier.testName(),
+                    identifier.className(),
+                    best.getFlakinessScore(),
+                    best.getDefaultBranchFailureRate(),
+                    best.getCombinedFailureRate());
+              }
+              return new TestFlakinessScoreDto(
+                  identifier.testName(), identifier.className(), 0.0, 0.0, 0.0);
+            })
         .toList();
   }
 
   /**
    * Builds a project-wide overview of all flaky tests for a repository.
+   * Reads from the precomputed {@code test_case_flakiness} table — no full stats scan.
+   * {@code totalRuns} is resolved in a single batch query against {@code test_case_statistics}
+   * (combined branch) scoped to only the suites that have flaky tests.
    *
    * @param repositoryId the repository ID
+   * @param request the pagination and filtering parameters
    * @return aggregated flaky test overview
    */
-  public FlakyTestOverviewDto getFlakyTestsOverview(Long repositoryId) {
-    String defaultBranchName = getDefaultBranchName(repositoryId);
-    List<TestCaseStatistics> defaultBranchStats =
-        getStatisticsForBranch(defaultBranchName, repositoryId);
-    List<TestCaseStatistics> combinedStats = getStatisticsForBranch("combined", repositoryId);
+  public FlakyTestOverviewDto getFlakyTestsOverview(
+      Long repositoryId, FlakyTestsPageRequest request) {
+    Sort sort = resolveSort(request);
+    // Frontend sends 1-based page numbers; convert to 0-based for Spring Data.
+    int zeroBasedPage = Math.max(0, request.getPage() - 1);
+    Pageable pageable = PageRequest.of(zeroBasedPage, request.getSize(), sort);
 
-    Set<TestCaseStatistics> matchedDefaults = new HashSet<>();
-    List<FlakyTestOverviewDto.FlakyTestDto> flakyTests = new ArrayList<>();
+    Specification<TestCaseFlakiness> spec = buildTestCaseFlakinessSpecification(
+        request, repositoryId);
 
-    for (TestCaseStatistics combined : combinedStats) {
-      findMatchingStatistic(combined, defaultBranchStats).ifPresent(matchedDefaults::add);
+    Page<TestCaseFlakiness> resultPage = flakinessRepository.findAll(spec, pageable);
+    List<TestCaseFlakiness> flakyTests = resultPage.getContent();
+    List<FlakyTestOverviewDto.FlakyTestDto> flakyTestDtos =
+        flakyTests.stream().map(FlakyTestOverviewDto.FlakyTestDto::from).toList();
 
-      FlakinessInfo info = computeFlakinessInfo(
-          combined.getTestName(), combined.getClassName(), defaultBranchStats, combinedStats);
-      if (info.flakinessScore() > 0) {
-        flakyTests.add(FlakyTestOverviewDto.FlakyTestDto.from(combined, info));
-      }
-    }
+    FlakyTestOverviewDto.FlakyTestSummary summary = buildGlobalSummary(repositoryId);
 
-    for (TestCaseStatistics defaultStat : defaultBranchStats) {
-      if (matchedDefaults.contains(defaultStat)) {
-        continue;
-      }
-      FlakinessInfo info = computeFlakinessInfo(
-          defaultStat.getTestName(), defaultStat.getClassName(), defaultBranchStats, combinedStats);
-      if (info.flakinessScore() > 0) {
-        flakyTests.add(FlakyTestOverviewDto.FlakyTestDto.from(defaultStat, info));
-      }
-    }
-
-    flakyTests.sort(
-        Comparator.comparingDouble(FlakyTestOverviewDto.FlakyTestDto::flakinessScore).reversed());
-
-    int totalTrackedTests =
-        combinedStats.size() + defaultBranchStats.size() - matchedDefaults.size();
-    return new FlakyTestOverviewDto(buildSummary(totalTrackedTests, flakyTests), flakyTests);
+    return new FlakyTestOverviewDto(summary, flakyTestDtos, resultPage.getTotalElements());
   }
 
-  private String getDefaultBranchName(Long repositoryId) {
-    return branchRepository
-        .findFirstByRepositoryRepositoryIdAndIsDefaultTrue(repositoryId)
-        .orElseThrow()
-        .getName();
-  }
+  private FlakyTestOverviewDto.FlakyTestSummary buildGlobalSummary(Long repositoryId) {
+    int totalTrackedTests = (int) statisticsRepository
+        .countByBranchNameAndRepositoryRepositoryId("combined", repositoryId);
+    int totalFlakyTests = (int) flakinessRepository.countByRepositoryRepositoryId(repositoryId);
+    int highFlakinessCount = (int) flakinessRepository
+        .countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(
+            repositoryId, HIGH_FLAKINESS_THRESHOLD);
+    int mediumFlakinessCount = (int) flakinessRepository
+        .countByRepositoryRepositoryIdAndFlakinessScoreGreaterThanAndFlakinessScoreLessThanEqual(
+            repositoryId, LOW_FLAKINESS_THRESHOLD, HIGH_FLAKINESS_THRESHOLD);
+    int lowFlakinessCount = totalFlakyTests - highFlakinessCount - mediumFlakinessCount;
 
-  private static Optional<TestCaseStatistics> findMatchingStatistic(
-      TestCaseStatistics target, List<TestCaseStatistics> stats) {
-    return stats.stream()
-        .filter(s -> s.getTestName().equals(target.getTestName())
-            && s.getClassName().equals(target.getClassName())
-            && s.getTestSuiteName().equals(target.getTestSuiteName()))
-        .findFirst();
+    return new FlakyTestOverviewDto.FlakyTestSummary(
+        totalTrackedTests,
+        totalFlakyTests,
+        highFlakinessCount,
+        mediumFlakinessCount,
+        lowFlakinessCount);
   }
 
   /** Holds computed flakiness information for a single test case. */
   public record FlakinessInfo(
-      double flakinessScore,
-      double defaultBranchFailureRate,
-      double combinedFailureRate
-  ) {}
+      double flakinessScore, double defaultBranchFailureRate, double combinedFailureRate) {}
 
   /**
    * Computes flakiness information for a single test case from pre-fetched statistics lists.
-   * This is the shared core logic.
-   * Each caller pre-fetches the two stat lists (default branch + combined),
-   * then delegates the per-test-case score computation here.
+   * Used by {@link TestResultService} to annotate per-run test results.
    *
    * @param testName the test name to look up
    * @param className the class name to look up
@@ -283,5 +354,56 @@ public class TestCaseStatisticsService {
             * 100;
 
     return weightedScore;
+  }
+
+  private Sort resolveSort(FlakyTestsPageRequest request) {
+    String sortDirection = request.getSortDirection();
+    String sortField = "flakinessScore"; // Default sort field
+
+    Sort.Direction direction =
+        "asc".equalsIgnoreCase(sortDirection) ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+    return Sort.by(direction, sortField);
+  }
+
+  private Specification<TestCaseFlakiness> buildTestCaseFlakinessSpecification(
+      FlakyTestsPageRequest request, Long repositoryId) {
+    return (root, query, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      // Always scope to current repository
+      predicates.add(cb.equal(root.get("repository").get("repositoryId"), repositoryId));
+
+      // Search term across testName, className, and testSuiteName
+      if (request.getSearchTerm() != null && !request.getSearchTerm().trim().isEmpty()) {
+        String term = "%" + request.getSearchTerm().trim().toLowerCase() + "%";
+        predicates.add(
+            cb.or(
+                cb.like(cb.lower(root.get("testName")), term),
+                cb.like(cb.lower(root.get("className")), term),
+                cb.like(cb.lower(root.get("testSuiteName")), term)));
+      }
+
+      // Filter by flakiness score based on filter type
+      switch (request.getFilterType()) {
+        case HIGH:
+          predicates.add(cb.greaterThan(root.get("flakinessScore"), HIGH_FLAKINESS_THRESHOLD));
+          break;
+        case MEDIUM:
+          predicates.add(cb.and(
+              cb.greaterThan(root.get("flakinessScore"), LOW_FLAKINESS_THRESHOLD),
+              cb.lessThanOrEqualTo(root.get("flakinessScore"), HIGH_FLAKINESS_THRESHOLD)
+          ));
+          break;
+        case LOW:
+          predicates.add(cb.lessThanOrEqualTo(root.get("flakinessScore"), LOW_FLAKINESS_THRESHOLD));
+          break;
+        case ALL:
+        default:
+          break;
+      }
+
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -276,9 +276,9 @@ public class TestCaseStatisticsService {
   }
 
   private FlakyTestOverviewDto.FlakyTestSummary buildGlobalSummary(Long repositoryId) {
-    int totalTrackedTests = (int) statisticsRepository
-        .countByBranchNameAndRepositoryRepositoryId("combined", repositoryId);
-    int totalFlakyTests = (int) flakinessRepository.countByRepositoryRepositoryId(repositoryId);
+    int totalTrackedTests = (int) flakinessRepository.countByRepositoryRepositoryId(repositoryId);
+    int totalFlakyTests = (int) flakinessRepository
+        .countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(repositoryId, 0);
     int highFlakinessCount = (int) flakinessRepository
         .countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(
             repositoryId, HIGH_FLAKINESS_THRESHOLD);
@@ -373,6 +373,9 @@ public class TestCaseStatisticsService {
 
       // Always scope to current repository
       predicates.add(cb.equal(root.get("repository").get("repositoryId"), repositoryId));
+
+      // Retrieve only tests with a flakiness score greater than zero
+      predicates.add(cb.greaterThan(root.get("flakinessScore"), 0));
 
       // Search term across testName, className, and testSuiteName
       if (request.getSearchTerm() != null && !request.getSearchTerm().trim().isEmpty()) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -207,20 +207,25 @@ public class TestCaseStatisticsService {
         .map(
             identifier -> {
               List<TestCaseFlakiness> matches =
-                  flakinessRepository.findByRepositoryIdAndTestNameAndClassName(
-                      repositoryId, identifier.testName(), identifier.className());
+                  flakinessRepository.findByRepositoryIdAndTestNameAndClassNameAndSuiteName(
+                      repositoryId,
+                      identifier.testName(),
+                      identifier.className(),
+                      identifier.testSuiteName());
 
               if (!matches.isEmpty()) {
                 TestCaseFlakiness best = matches.getFirst();
                 return new TestFlakinessScoreDto(
                     identifier.testName(),
                     identifier.className(),
+                    identifier.testSuiteName(),
                     best.getFlakinessScore(),
                     best.getDefaultBranchFailureRate(),
                     best.getCombinedFailureRate());
               }
               return new TestFlakinessScoreDto(
-                  identifier.testName(), identifier.className(), 0.0, 0.0, 0.0);
+                  identifier.testName(), identifier.className(), identifier.testSuiteName(),
+                  0.0, 0.0, 0.0);
             })
         .toList();
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -6,8 +6,11 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
@@ -25,13 +28,35 @@ public class TestCaseStatisticsService {
 
   public static final double HIGH_FLAKINESS_THRESHOLD = 70.0;
   public static final double LOW_FLAKINESS_THRESHOLD = 30.0;
-  private final TestCaseStatisticsRepository statisticsRepository;
-  private final TestCaseFlakinessRepository flakinessRepository;
-
   private static final double DEFAULT_BRANCH_WEIGHT = 0.7;
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
   private static final double MAX_FLAKY_RATE = 0.5; // 50%
+
+  private final TestCaseStatisticsRepository statisticsRepository;
+  private final TestCaseFlakinessRepository flakinessRepository;
+
+  /**
+   * Composite key uniquely identifying one test case within a suite.
+   * Package-private so {@link TestResultService} can build index keys without an extra lookup.
+   */
+  record StatsKey(String testName, String className, String testSuiteName) {}
+
+  /**
+   * Converts a flat list of {@link TestCaseStatistics} into a {@code Map} keyed by
+   * {@link StatsKey} for O(1) per-test lookups.
+   *
+   * @param stats the statistics rows to index
+   * @return map of composite key to failure rate
+   */
+  public static Map<StatsKey, Double> indexFailureRates(List<TestCaseStatistics> stats) {
+    return stats.stream()
+        .collect(
+            Collectors.toMap(
+                s -> new StatsKey(s.getTestName(), s.getClassName(), s.getTestSuiteName()),
+                TestCaseStatistics::getFailureRate,
+                (a, b) -> a));
+  }
 
   /**
    * Updates statistics for a test case, creating a new entry if it doesn't exist.
@@ -105,92 +130,82 @@ public class TestCaseStatisticsService {
 
   /**
    * Recomputes and persists flakiness scores for all tests belonging to the given suites.
-   * Reads statistics for the default branch and combined branches to compute scores, then updates
-   * the {@code test_case_flakiness} table accordingly. Scores are persisted even when equal to
-   * zero so consumers can distinguish "known non-flaky" from "no record yet".
+   *
+   * <p>All statistics and existing flakiness records are fetched in two bulk queries and indexed
+   * into {@link Map}s before the test-case loop, making per-test lookups O(1). Scores are persisted
+   * even when equal to zero so consumers can distinguish "known non-flaky" from "no record yet".
    *
    * @param testSuites the suites processed in this run
    * @param defaultBranch the repository's default branch name
    * @param repository the repository
    */
+  @Transactional
   public void updateFlakinessForTestSuite(
       List<TestSuite> testSuites, String defaultBranch, GitRepository repository) {
 
     var suiteNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
 
-    List<TestCaseStatistics> defaultBranchStats =
-        statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-            suiteNames, defaultBranch, repository.getRepositoryId());
+    // Two bulk DB reads and index into Maps for O(1) per-test lookup
+    Map<StatsKey, Double> defaultRates =
+        indexFailureRates(
+            statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+                suiteNames, defaultBranch, repository.getRepositoryId()));
 
-    List<TestCaseStatistics> combinedStats =
-        statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-            suiteNames, "combined", repository.getRepositoryId());
+    Map<StatsKey, Double> combinedRates =
+        indexFailureRates(
+            statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+                suiteNames, "combined", repository.getRepositoryId()));
 
+    // One bulk read for existing flakiness records to avoid N+1 SELECTs in the loop
+    Map<StatsKey, TestCaseFlakiness> existingFlakinessRecords = loadFlakinessIndex(
+        suiteNames, repository.getRepositoryId());
+
+    Map<StatsKey, TestCaseFlakiness> flakinessMapToSave = new LinkedHashMap<>();
     for (TestSuite suite : testSuites) {
       for (TestCase testCase : suite.getTestCases()) {
-        var flakinessInfo =
-            computeFlakinessInfo(
-                testCase.getName(), testCase.getClassName(), suite.getName(),
-                defaultBranchStats, combinedStats);
-        double flakinessScore = flakinessInfo.flakinessScore();
+        var key = new StatsKey(testCase.getName(), testCase.getClassName(), suite.getName());
+        var info = computeFlakinessInfo(
+            testCase.getName(), testCase.getClassName(), suite.getName(),
+            defaultRates, combinedRates);
 
-        upsertFlakiness(
-            testCase.getName(),
-            testCase.getClassName(),
-            suite.getName(),
-            flakinessScore,
-            flakinessInfo.defaultBranchFailureRate(),
-            flakinessInfo.combinedFailureRate(),
-            repository);
+        TestCaseFlakiness record = existingFlakinessRecords.getOrDefault(key, null);
+        if (record == null) {
+          record = new TestCaseFlakiness();
+          record.setTestName(key.testName());
+          record.setClassName(key.className());
+          record.setTestSuiteName(key.testSuiteName());
+          record.setRepository(repository);
+        }
+        record.setFlakinessScore(info.flakinessScore());
+        record.setDefaultBranchFailureRate(info.defaultBranchFailureRate());
+        record.setCombinedFailureRate(info.combinedFailureRate());
+        record.setLastUpdated(OffsetDateTime.now());
+        flakinessMapToSave.put(key, record);
       }
     }
+
+    flakinessRepository.saveAll(flakinessMapToSave.values());
   }
 
   /**
-   * Inserts or updates a flakiness record for a single test.
-   */
-  private void upsertFlakiness(
-      String testName,
-      String className,
-      String testSuiteName,
-      double score,
-      double defaultRate,
-      double combinedRate,
-      GitRepository repository) {
-    TestCaseFlakiness flakiness =
-        flakinessRepository
-            .findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
-                testName, className, testSuiteName, repository.getRepositoryId())
-            .orElseGet(
-                () -> {
-                  TestCaseFlakiness f = new TestCaseFlakiness();
-                  f.setTestName(testName);
-                  f.setClassName(className);
-                  f.setTestSuiteName(testSuiteName);
-                  f.setRepository(repository);
-                  return f;
-                });
-
-    flakiness.setFlakinessScore(score);
-    flakiness.setDefaultBranchFailureRate(defaultRate);
-    flakiness.setCombinedFailureRate(combinedRate);
-    flakiness.setLastUpdated(OffsetDateTime.now());
-    flakinessRepository.save(flakiness);
-  }
-
-  /**
-   * Gets statistics for a specific test case on a specific branch.
+   * Batch-fetches all {@link TestCaseFlakiness} rows for the given suite names and indexes them
+   * by {@link StatsKey} for O(1) lookup. Exposed so {@link TestResultService} can pre-load
+   * flakiness data before annotating per-run test cases.
    *
-   * @param testName the name of the test
-   * @param className the class name of the test
-   * @param testSuiteName the test suite name
-   * @param branchName the branch name
-   * @return the statistics if found
+   * @param suiteNames suite names to scope the query
+   * @param repositoryId the repository ID
+   * @return map of composite key to the matching flakiness record
    */
-  public Optional<TestCaseStatistics> getStatistics(
-      String testName, String className, String testSuiteName, String branchName) {
-    return statisticsRepository.findByTestNameAndClassNameAndTestSuiteNameAndBranchName(
-        testName, className, testSuiteName, branchName);
+  public Map<StatsKey, TestCaseFlakiness> loadFlakinessIndex(
+      List<String> suiteNames, Long repositoryId) {
+    return flakinessRepository
+        .findByTestSuiteNameInAndRepositoryRepositoryId(suiteNames, repositoryId)
+        .stream()
+        .collect(
+            Collectors.toMap(
+                f -> new StatsKey(f.getTestName(), f.getClassName(), f.getTestSuiteName()),
+                f -> f,
+                (a, b) -> a));
   }
 
   /**
@@ -232,7 +247,7 @@ public class TestCaseStatisticsService {
 
   /**
    * Builds a project-wide overview of all flaky tests for a repository.
-   * Reads from the precomputed {@code test_case_flakiness} table — no full stats scan.
+   * Reads from the precomputed {@code test_case_flakiness} table - no full stats scan.
    * {@code totalRuns} is resolved in a single batch query against {@code test_case_statistics}
    * (combined branch) scoped to only the suites that have flaky tests.
    *
@@ -285,41 +300,26 @@ public class TestCaseStatisticsService {
       double flakinessScore, double defaultBranchFailureRate, double combinedFailureRate) {}
 
   /**
-   * Computes flakiness information for a single test case from pre-fetched statistics lists.
-   * Used by {@link TestResultService} to annotate per-run test results.
+   * Computes flakiness information for a single test case using pre-indexed failure-rate maps.
+   * Both maps should be built via {@link #indexFailureRates} before entering any per-test loop
+   * so that each call here is O(1).
    *
    * @param testName the test name to look up
    * @param className the class name to look up
-   * @param defaultBranchStats statistics for the default branch
-   * @param combinedStats statistics for the "combined" pseudo-branch
+   * @param suiteName the test suite name to look up
+   * @param defaultRates failure-rate index for the default branch
+   * @param combinedRates failure-rate index for the combined pseudo-branch
    * @return computed flakiness info
    */
   public FlakinessInfo computeFlakinessInfo(
       String testName,
       String className,
       String suiteName,
-      List<TestCaseStatistics> defaultBranchStats,
-      List<TestCaseStatistics> combinedStats) {
-    double defaultFailureRate =
-        defaultBranchStats.stream()
-            .filter(s ->
-                s.getTestName().equals(testName)
-                && s.getClassName().equals(className)
-                && s.getTestSuiteName().equals(suiteName))
-            .findFirst()
-            .map(TestCaseStatistics::getFailureRate)
-            .orElse(0.0);
-
-    double combinedFailureRate =
-        combinedStats.stream()
-            .filter(s ->
-                s.getTestName().equals(testName)
-                && s.getClassName().equals(className)
-                && s.getTestSuiteName().equals(suiteName))
-            .findFirst()
-            .map(TestCaseStatistics::getFailureRate)
-            .orElse(0.0);
-
+      Map<StatsKey, Double> defaultRates,
+      Map<StatsKey, Double> combinedRates) {
+    var key = new StatsKey(testName, className, suiteName);
+    double defaultFailureRate = defaultRates.getOrDefault(key, 0.0);
+    double combinedFailureRate = combinedRates.getOrDefault(key, 0.0);
     double flakinessScore = calculateFlakinessScore(defaultFailureRate, combinedFailureRate);
     return new FlakinessInfo(flakinessScore, defaultFailureRate, combinedFailureRate);
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -116,21 +116,22 @@ public class TestCaseStatisticsService {
   public void updateFlakinessForTestSuite(
       List<TestSuite> testSuites, String defaultBranch, GitRepository repository) {
 
-    var suiteClassNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
+    var suiteNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
 
     List<TestCaseStatistics> defaultBranchStats =
         statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-            suiteClassNames, defaultBranch, repository.getRepositoryId());
+            suiteNames, defaultBranch, repository.getRepositoryId());
 
     List<TestCaseStatistics> combinedStats =
         statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-            suiteClassNames, "combined", repository.getRepositoryId());
+            suiteNames, "combined", repository.getRepositoryId());
 
     for (TestSuite suite : testSuites) {
       for (TestCase testCase : suite.getTestCases()) {
         var flakinessInfo =
             computeFlakinessInfo(
-                testCase.getName(), testCase.getClassName(), defaultBranchStats, combinedStats);
+                testCase.getName(), testCase.getClassName(), suite.getName(),
+                defaultBranchStats, combinedStats);
         double flakinessScore = flakinessInfo.flakinessScore();
 
         if (flakinessScore <= 0.0) {
@@ -304,18 +305,25 @@ public class TestCaseStatisticsService {
   public FlakinessInfo computeFlakinessInfo(
       String testName,
       String className,
+      String suiteName,
       List<TestCaseStatistics> defaultBranchStats,
       List<TestCaseStatistics> combinedStats) {
     double defaultFailureRate =
         defaultBranchStats.stream()
-            .filter(s -> s.getTestName().equals(testName) && s.getClassName().equals(className))
+            .filter(s ->
+                s.getTestName().equals(testName)
+                && s.getClassName().equals(className)
+                && s.getTestSuiteName().equals(suiteName))
             .findFirst()
             .map(TestCaseStatistics::getFailureRate)
             .orElse(0.0);
 
     double combinedFailureRate =
         combinedStats.stream()
-            .filter(s -> s.getTestName().equals(testName) && s.getClassName().equals(className))
+            .filter(s ->
+                s.getTestName().equals(testName)
+                && s.getClassName().equals(className)
+                && s.getTestSuiteName().equals(suiteName))
             .findFirst()
             .map(TestCaseStatistics::getFailureRate)
             .orElse(0.0);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -106,8 +106,8 @@ public class TestCaseStatisticsService {
   /**
    * Recomputes and persists flakiness scores for all tests belonging to the given suites.
    * Reads statistics for the default branch and combined branches to compute scores, then updates
-   * the {@code test_case_flakiness} table accordingly. Tests that are no longer flaky (score <= 0)
-   * will have their flakiness record removed to keep the table focused on only flaky tests.
+   * the {@code test_case_flakiness} table accordingly. Scores are persisted even when equal to
+   * zero so consumers can distinguish "known non-flaky" from "no record yet".
    *
    * @param testSuites the suites processed in this run
    * @param defaultBranch the repository's default branch name
@@ -133,19 +133,6 @@ public class TestCaseStatisticsService {
                 testCase.getName(), testCase.getClassName(), suite.getName(),
                 defaultBranchStats, combinedStats);
         double flakinessScore = flakinessInfo.flakinessScore();
-
-        if (flakinessScore <= 0.0) {
-          // Test is not flaky anymore; remove any existing flakiness record so the
-          // precomputed table only contains genuinely flaky tests.
-          flakinessRepository
-              .findByTestNameAndClassNameAndTestSuiteNameAndRepositoryRepositoryId(
-                  testCase.getName(),
-                  testCase.getClassName(),
-                  suite.getName(),
-                  repository.getRepositoryId())
-              .ifPresent(flakinessRepository::delete);
-          continue;
-        }
 
         upsertFlakiness(
             testCase.getName(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreDto.java
@@ -5,6 +5,7 @@ import org.springframework.lang.NonNull;
 public record TestFlakinessScoreDto(
     @NonNull String testName,
     @NonNull String className,
+    @NonNull String testSuiteName,
     double flakinessScore,
     double defaultBranchFailureRate,
     double combinedFailureRate) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreRequest.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestFlakinessScoreRequest.java
@@ -11,5 +11,6 @@ public record TestFlakinessScoreRequest(
 
   public record TestCaseIdentifier(
       @NonNull @NotBlank String testName,
-      @NonNull @NotBlank String className) {}
+      @NonNull @NotBlank String className,
+      @NonNull @NotBlank String testSuiteName) {}
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
@@ -2,6 +2,8 @@ package de.tum.cit.aet.helios.tests;
 
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettings;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -81,15 +83,33 @@ public class TestResultController {
   }
 
   /**
-   * Get an overview of all flaky tests for the current repository.
+   * Get a paginated, optionally filtered overview of flaky tests for the current repository.
    *
+   * <p>The summary section always reflects global (unfiltered) counts. The {@code flakyTests}
+   * array contains only the requested page. Use {@code filteredCount} as the paginator total.
+   *
+   * @param page one-based page index (default 1, as used by the frontend PaginatedTableService)
+   * @param size page size (default 20)
+   * @param sortDirection optional sort direction ("asc" or "desc") by flakiness score
    * @return aggregated flaky test overview
    */
   @GetMapping("/flaky")
-  public ResponseEntity<FlakyTestOverviewDto> getFlakyTestsOverview() {
+  public ResponseEntity<FlakyTestOverviewDto> getFlakyTestsOverview(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "20") int size,
+      @RequestParam(required = false) String sortDirection,
+      @RequestParam(required = false) FlakyTestsFilterType filterType,
+      @RequestParam(required = false) String searchTerm) {
     Long repositoryId = RepositoryContext.getRepositoryId();
+    FlakyTestsPageRequest pageRequest = FlakyTestsPageRequest.builder()
+        .page(page)
+        .size(size)
+        .sortDirection(sortDirection)
+        .filterType(filterType != null ? filterType : FlakyTestsFilterType.ALL)
+        .searchTerm(searchTerm)
+        .build();
     return ResponseEntity.ok(
-        testCaseStatisticsService.getFlakyTestsOverview(repositoryId));
+        testCaseStatisticsService.getFlakyTestsOverview(repositoryId, pageRequest));
   }
 
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -289,6 +289,9 @@ public class TestResultProcessor {
           "combined",
           repository.get()); // update statistics for all the branches combined
       log.debug("Successfully updated test statistics for all branches combined");
+
+      updateFlakinessScores(testSuites, defaultBranch, repository.get());
+      log.debug("Successfully recomputed flakiness scores for affected tests");
     } catch (Exception e) {
       log.error("Error while trying to update test statistics", e);
       // Don't fail the overall process if statistics update fails
@@ -312,6 +315,29 @@ public class TestResultProcessor {
     } catch (Exception e) {
       log.error("Failed to update test statistics for branch: {}", branchName, e);
       // Don't fail the overall process if statistics update fails
+    }
+  }
+
+  /**
+   * Recomputes and persists flakiness scores for all tests belonging to the given suites.
+   * Called after both the default-branch and combined statistics have been updated for a run.
+   * Only fetches stats rows for the suite names present in the current run, keeping
+   * the query bounded.
+   *
+   * @param testSuites the suites processed in this run
+   * @param defaultBranchName the repository's default branch name
+   * @param repository the repository
+   */
+  public void updateFlakinessScores(
+      List<TestSuite> testSuites, String defaultBranchName, GitRepository repository) {
+    try {
+      statisticsService.updateFlakinessForTestSuite(testSuites, defaultBranchName, repository);
+      log.debug("Successfully updated flakiness info for repository: {}",
+          repository.getRepositoryId());
+    } catch (Exception e) {
+      log.error("Failed to update flakiness info for repository: {}",
+          repository.getRepositoryId(), e);
+      // Don't fail the overall process if flakiness update fails
     }
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -322,6 +322,7 @@ public class TestResultService {
 
     for (TestSuite suite : suites) {
       for (TestCase testCase : suite.getTestCases()) {
+        // TODO read flakiness info from precomputed table instead of computing on the fly
         var flakinessInfo =
             testCaseStatisticsService.computeFlakinessInfo(
                 testCase.getName(), testCase.getClassName(), defaultBranchStats, combinedStats);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -231,6 +232,7 @@ public class TestResultService {
       for (TestType type : run.getWorkflow().getTestTypes()) {
         var testTypeResults =
             getTestTypeResultsForRun(
+                run.getRepository().getRepositoryId(),
                 type,
                 run,
                 previousWorkflowRunByTestType.get(type),
@@ -273,6 +275,7 @@ public class TestResultService {
   }
 
   private TestTypeResults getTestTypeResultsForRun(
+      Long repositoryId,
       TestType type,
       WorkflowRun run,
       Long prevWorkflowRunId,
@@ -320,34 +323,56 @@ public class TestResultService {
         testCaseRepository.findByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
             prevWorkflowRunId, suiteClassNames, type.getId());
 
+    // Pre-index everything fetched above so the per-test-case loop below runs in O(1) per test
+    // instead of O(n) linear scans or individual DB queries.
+
+    // Precomputed flakiness table - one bulk fetch instead of N+1 individual SELECTs
+    Map<TestCaseStatisticsService.StatsKey, TestCaseFlakiness> flakinessIndex =
+        testCaseStatisticsService.loadFlakinessIndex(suiteClassNames, repositoryId);
+
+    // Fallback failure-rate indexes for tests that have no precomputed flakiness record yet
+    Map<TestCaseStatisticsService.StatsKey, Double> defaultRates =
+        TestCaseStatisticsService.indexFailureRates(defaultBranchStats);
+    Map<TestCaseStatisticsService.StatsKey, Double> combinedRates =
+        TestCaseStatisticsService.indexFailureRates(combinedStats);
+
+    // "test failed on default branch" set - O(1) contains() instead of O(n) anyMatch()
+    Set<TestCaseStatisticsService.StatsKey> failedInDefaultKeys =
+        failedTestsInDefault.stream()
+            .map(t -> new TestCaseStatisticsService.StatsKey(
+                t.getName(), t.getClassName(), t.getTestSuite().getName()))
+            .collect(Collectors.toSet());
+
+    // Previous-status map - O(1) get() instead of O(n) filter().findFirst()
+    Map<TestCaseStatisticsService.StatsKey, TestStatus> prevStatusByKey =
+        prevStateCandidates.stream()
+            .collect(
+                Collectors.toMap(
+                    t -> new TestCaseStatisticsService.StatsKey(
+                        t.getName(), t.getClassName(), t.getTestSuite().getName()),
+                    TestCase::getStatus,
+                    (a, b) -> a));
+
     for (TestSuite suite : suites) {
       for (TestCase testCase : suite.getTestCases()) {
-        // TODO read flakiness info from precomputed table instead of computing on the fly
-        var flakinessInfo =
-            testCaseStatisticsService.computeFlakinessInfo(
-                testCase.getName(), testCase.getClassName(), suite.getName(),
-                defaultBranchStats, combinedStats);
-        testCase.setFlakinessScore(flakinessInfo.flakinessScore());
-        testCase.setFailureRate(flakinessInfo.defaultBranchFailureRate());
-        testCase.setCombinedFailureRate(flakinessInfo.combinedFailureRate());
+        var key = new TestCaseStatisticsService.StatsKey(
+            testCase.getName(), testCase.getClassName(), suite.getName());
+        TestCaseFlakiness flakiness = flakinessIndex.get(key);
+        if (flakiness != null) {
+          testCase.setFlakinessScore(flakiness.getFlakinessScore());
+          testCase.setFailureRate(flakiness.getDefaultBranchFailureRate());
+          testCase.setCombinedFailureRate(flakiness.getCombinedFailureRate());
+        } else {
+          var flakinessInfo = testCaseStatisticsService.computeFlakinessInfo(
+              testCase.getName(), testCase.getClassName(), suite.getName(),
+              defaultRates, combinedRates);
+          testCase.setFlakinessScore(flakinessInfo.flakinessScore());
+          testCase.setFailureRate(flakinessInfo.defaultBranchFailureRate());
+          testCase.setCombinedFailureRate(flakinessInfo.combinedFailureRate());
+        }
 
-        boolean failsInDefaultBranch =
-            failedTestsInDefault.stream()
-                .anyMatch(
-                    failedTest ->
-                        failedTest.getName().equals(testCase.getName())
-                            && failedTest.getClassName().equals(testCase.getClassName()));
-        testCase.setFailsInDefaultBranch(failsInDefaultBranch);
-
-        testCase.setPreviousStatus(
-            prevStateCandidates.stream()
-                .filter(
-                    prevTestCase ->
-                        prevTestCase.getName().equals(testCase.getName())
-                            && prevTestCase.getClassName().equals(testCase.getClassName()))
-                .findFirst()
-                .map(TestCase::getStatus)
-                .orElse(null));
+        testCase.setFailsInDefaultBranch(failedInDefaultKeys.contains(key));
+        testCase.setPreviousStatus(prevStatusByKey.get(key));
       }
     }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -325,7 +325,8 @@ public class TestResultService {
         // TODO read flakiness info from precomputed table instead of computing on the fly
         var flakinessInfo =
             testCaseStatisticsService.computeFlakinessInfo(
-                testCase.getName(), testCase.getClassName(), defaultBranchStats, combinedStats);
+                testCase.getName(), testCase.getClassName(), suite.getName(),
+                defaultBranchStats, combinedStats);
         testCase.setFlakinessScore(flakinessInfo.flakinessScore());
         testCase.setFailureRate(flakinessInfo.defaultBranchFailureRate());
         testCase.setCombinedFailureRate(flakinessInfo.combinedFailureRate());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/pagination/FlakyTestsFilterType.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/pagination/FlakyTestsFilterType.java
@@ -1,0 +1,8 @@
+package de.tum.cit.aet.helios.tests.pagination;
+
+public enum FlakyTestsFilterType {
+  ALL,
+  HIGH,
+  MEDIUM,
+  LOW;
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/pagination/FlakyTestsPageRequest.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/pagination/FlakyTestsPageRequest.java
@@ -1,0 +1,14 @@
+package de.tum.cit.aet.helios.tests.pagination;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FlakyTestsPageRequest {
+  @Builder.Default private int page = 1;
+  @Builder.Default private int size = 20;
+  private String sortDirection;
+  @Builder.Default private FlakyTestsFilterType filterType = FlakyTestsFilterType.ALL;
+  private String searchTerm;
+}

--- a/server/application-server/src/main/resources/db/migration/V38__add_test_case_flakiness.sql
+++ b/server/application-server/src/main/resources/db/migration/V38__add_test_case_flakiness.sql
@@ -1,0 +1,21 @@
+-- One row per unique test per repository, replacing the expensive in-memory computation over
+-- the full test_case_statistics table on every overview request.
+CREATE TABLE test_case_flakiness (
+    id                          BIGSERIAL PRIMARY KEY,
+    repository_id               BIGINT NOT NULL,
+    test_name                   VARCHAR(255) NOT NULL,
+    class_name                  VARCHAR(255) NOT NULL,
+    test_suite_name             VARCHAR(255) NOT NULL,
+    flakiness_score             DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    default_branch_failure_rate DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    combined_failure_rate       DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    last_updated                TIMESTAMP WITH TIME ZONE NOT NULL,
+    CONSTRAINT uk_test_case_flakiness
+        UNIQUE (repository_id, test_name, class_name, test_suite_name),
+    CONSTRAINT fk_test_case_flakiness_repository
+        FOREIGN KEY (repository_id) REFERENCES repository (repository_id) ON DELETE CASCADE
+);
+
+-- Main query index: fetch all flaky tests for a repo, ordered by score descending.
+CREATE INDEX idx_flakiness_repo_score ON test_case_flakiness (repository_id, flakiness_score DESC);
+

--- a/server/application-server/src/main/resources/db/migration/V39__backfill_test_case_flakiness.sql
+++ b/server/application-server/src/main/resources/db/migration/V39__backfill_test_case_flakiness.sql
@@ -1,0 +1,116 @@
+-- Backfill flakiness scores from test_case_statistics into test_case_flakiness.
+-- Formula mirrors TestCaseStatisticsService.calculateFlakinessScore:
+--   default_flakiness  = (0.5 - default_rate) / 0.5   if default_rate  in (0.01, 0.5), else 0
+--   combined_flakiness = (0.5 - combined_rate) / 0.5  if combined_rate in (0.01, 0.5), else 0
+--   flakiness_score    = (default_flakiness * 0.7 + combined_flakiness * 0.3) * 100
+INSERT INTO test_case_flakiness (
+    repository_id,
+    test_name,
+    class_name,
+    test_suite_name,
+    flakiness_score,
+    default_branch_failure_rate,
+    combined_failure_rate,
+    last_updated
+)
+WITH combined_stats AS (
+    SELECT
+        repository_id,
+        test_name,
+        class_name,
+        test_suite_name,
+        CASE
+            WHEN total_runs > 0 THEN failed_runs::DOUBLE PRECISION / total_runs
+            ELSE 0.0
+        END AS failure_rate,
+        last_updated
+    FROM test_case_statistics
+    WHERE branch_name = 'combined'
+),
+default_stats AS (
+    SELECT
+        tcs.repository_id,
+        tcs.test_name,
+        tcs.class_name,
+        tcs.test_suite_name,
+        CASE
+            WHEN tcs.total_runs > 0 THEN tcs.failed_runs::DOUBLE PRECISION / tcs.total_runs
+            ELSE 0.0
+        END AS failure_rate
+    FROM test_case_statistics tcs
+    JOIN branch b
+        ON b.repository_id = tcs.repository_id
+       AND b.is_default = TRUE
+       AND tcs.branch_name = b.name
+),
+all_tests AS (
+    -- Tests that have a combined row (normal case; combined is written by ingestion).
+    SELECT
+        c.repository_id,
+        c.test_name,
+        c.class_name,
+        c.test_suite_name,
+        COALESCE(d.failure_rate, 0.0) AS default_rate,
+        c.failure_rate AS combined_rate,
+        c.last_updated
+    FROM combined_stats c
+    LEFT JOIN default_stats d
+        ON d.repository_id = c.repository_id
+       AND d.test_name = c.test_name
+       AND d.class_name = c.class_name
+       AND d.test_suite_name = c.test_suite_name
+
+    UNION ALL
+
+    -- Tests that only exist on the default branch (no combined row yet).
+    SELECT
+        d.repository_id,
+        d.test_name,
+        d.class_name,
+        d.test_suite_name,
+        d.failure_rate AS default_rate,
+        0.0 AS combined_rate,
+        CURRENT_TIMESTAMP AS last_updated
+    FROM default_stats d
+    LEFT JOIN combined_stats c
+        ON c.repository_id = d.repository_id
+       AND c.test_name = d.test_name
+       AND c.class_name = d.class_name
+       AND c.test_suite_name = d.test_suite_name
+    WHERE c.test_name IS NULL
+),
+scored AS (
+    SELECT
+        repository_id,
+        test_name,
+        class_name,
+        test_suite_name,
+        default_rate,
+        combined_rate,
+        last_updated,
+        CASE
+            WHEN default_rate > 0.01 AND default_rate < 0.5 THEN (0.5 - default_rate) / 0.5
+            ELSE 0.0
+        END AS default_flakiness,
+        CASE
+            WHEN combined_rate > 0.01 AND combined_rate < 0.5 THEN (0.5 - combined_rate) / 0.5
+            ELSE 0.0
+        END AS combined_flakiness
+    FROM all_tests
+)
+SELECT
+    repository_id,
+    test_name,
+    class_name,
+    test_suite_name,
+    (default_flakiness * 0.7 + combined_flakiness * 0.3) * 100 AS flakiness_score,
+    default_rate AS default_branch_failure_rate,
+    combined_rate AS combined_failure_rate,
+    last_updated
+FROM scored
+ON CONFLICT (repository_id, test_name, class_name, test_suite_name)
+DO UPDATE SET
+    flakiness_score = EXCLUDED.flakiness_score,
+    default_branch_failure_rate = EXCLUDED.default_branch_failure_rate,
+    combined_failure_rate = EXCLUDED.combined_failure_rate,
+    last_updated = EXCLUDED.last_updated;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -1,104 +1,116 @@
 package de.tum.cit.aet.helios.tests;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import de.tum.cit.aet.helios.branch.Branch;
-import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class TestCaseStatisticsServiceTest {
 
   @Mock private TestCaseStatisticsRepository statisticsRepository;
-  @Mock private BranchRepository branchRepository;
+  @Mock private TestCaseFlakinessRepository flakinessRepository;
 
   @InjectMocks private TestCaseStatisticsService service;
 
   private GitRepository repository;
-  private Branch defaultBranch;
 
   @BeforeEach
   void setUp() {
     repository = new GitRepository();
     repository.setRepositoryId(1L);
-
-    defaultBranch = new Branch();
-    defaultBranch.setName("main");
-    defaultBranch.setRepository(repository);
-    defaultBranch.setDefault(true);
   }
 
   @Test
-  void getFlakyTestsOverview_withCombinedAndDefaultStats_returnsSortedOverview() {
-    var combinedStat = createStat("testFlaky", "FlakyClass", "Suite1", "combined", 100, 5);
-    var defaultStat = createStat("testFlaky", "FlakyClass", "Suite1", "main", 50, 2);
+  void getFlakyTestsOverview_returnsPagedOverview() {
+    List<TestCaseFlakiness> flakinessList =
+        IntStream.range(0, 5)
+            .mapToObj(i -> createFlakiness("test" + i, "ClassA", "SuiteA", 82.0, 0.05, 0.10))
+            .toList();
 
-    when(branchRepository.findFirstByRepositoryRepositoryIdAndIsDefaultTrue(1L))
-        .thenReturn(Optional.of(defaultBranch));
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("main", 1L))
-        .thenReturn(List.of(defaultStat));
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("combined", 1L))
-        .thenReturn(List.of(combinedStat));
+    Page<TestCaseFlakiness> page = new PageImpl<>(
+        flakinessList,
+        Pageable.ofSize(5), 10);
 
-    FlakyTestOverviewDto result = service.getFlakyTestsOverview(1L);
+    when(flakinessRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(page);
 
-    assertEquals(1, result.summary().totalTrackedTests());
-    assertEquals(1, result.summary().flakyTestCount());
-    assertEquals(1, result.flakyTests().size());
-    assertEquals("testFlaky", result.flakyTests().get(0).testName());
-    assertEquals("FlakyClass", result.flakyTests().get(0).className());
-    assertEquals("Suite1", result.flakyTests().get(0).testSuiteName());
-    assertEquals(100, result.flakyTests().get(0).totalRuns());
-    assertEquals(5, result.flakyTests().get(0).failedRuns());
-  }
+    when(statisticsRepository.countByBranchNameAndRepositoryRepositoryId(
+        "combined", repository.getRepositoryId()))
+        .thenReturn(20L);
 
-  @Test
-  void getFlakyTestsOverview_withNoStats_returnsEmptyOverview() {
-    when(branchRepository.findFirstByRepositoryRepositoryIdAndIsDefaultTrue(1L))
-        .thenReturn(Optional.of(defaultBranch));
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("main", 1L))
-        .thenReturn(List.of());
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("combined", 1L))
-        .thenReturn(List.of());
+    when(flakinessRepository.countByRepositoryRepositoryId(repository.getRepositoryId()))
+        .thenReturn(5L);
 
-    FlakyTestOverviewDto result = service.getFlakyTestsOverview(1L);
+    when(flakinessRepository.countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(
+        repository.getRepositoryId(), TestCaseStatisticsService.HIGH_FLAKINESS_THRESHOLD))
+        .thenReturn(2L);
 
-    assertEquals(0, result.summary().totalTrackedTests());
-    assertEquals(0, result.summary().flakyTestCount());
-    assertEquals(0, result.flakyTests().size());
-  }
+    when(flakinessRepository
+        .countByRepositoryRepositoryIdAndFlakinessScoreGreaterThanAndFlakinessScoreLessThanEqual(
+            repository.getRepositoryId(),
+            TestCaseStatisticsService.LOW_FLAKINESS_THRESHOLD,
+            TestCaseStatisticsService.HIGH_FLAKINESS_THRESHOLD))
+        .thenReturn(2L);
 
-  @Test
-  void getFlakyTestsOverview_withNoDefaultBranch_throws() {
-    when(branchRepository.findFirstByRepositoryRepositoryIdAndIsDefaultTrue(1L))
-        .thenReturn(Optional.empty());
+    FlakyTestsPageRequest request = FlakyTestsPageRequest.builder()
+        .page(1)
+        .size(5)
+        .filterType(FlakyTestsFilterType.ALL)
+        .build();
 
-    assertThrows(Exception.class, () -> service.getFlakyTestsOverview(1L));
+    FlakyTestOverviewDto result =
+        service.getFlakyTestsOverview(repository.getRepositoryId(), request);
+
+    assertEquals(5, result.flakyTests().size());
+    assertEquals(10, result.filteredCount());
+
+    FlakyTestOverviewDto.FlakyTestDto dto = result.flakyTests().getFirst();
+
+    assertAll(
+        () -> assertEquals("test0", dto.testName()),
+        () -> assertEquals("ClassA", dto.className()),
+        () -> assertEquals("SuiteA", dto.testSuiteName()),
+        () -> assertEquals(82.0, dto.flakinessScore())
+    );
+
+    FlakyTestOverviewDto.FlakyTestSummary summary = result.summary();
+
+    assertAll(
+        () -> assertEquals(20, summary.totalTrackedTests()),
+        () -> assertEquals(5, summary.flakyTestCount()),
+        () -> assertEquals(2, summary.highFlakinessCount()),
+        () -> assertEquals(2, summary.mediumFlakinessCount()),
+        () -> assertEquals(1, summary.lowFlakinessCount())
+    );
   }
 
   @Test
   void getFlakinessScoresForTests_returnsScores() {
-    var combinedStat = createStat("test1", "Class1", "Suite1", "combined", 100, 5);
-    var defaultStat = createStat("test1", "Class1", "Suite1", "main", 50, 2);
-    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1");
+    TestCaseFlakiness flakiness = createFlakiness("test1", "Class1", "Suite1", 88.2, 0.05, 0.08);
+    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassName(1L, "test1", "Class1"))
+        .thenReturn(List.of(flakiness));
 
-    when(branchRepository.findFirstByRepositoryRepositoryIdAndIsDefaultTrue(1L))
-        .thenReturn(Optional.of(defaultBranch));
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("main", 1L))
-        .thenReturn(List.of(defaultStat));
-    when(statisticsRepository.findByBranchNameAndRepositoryRepositoryId("combined", 1L))
-        .thenReturn(List.of(combinedStat));
+    TestFlakinessScoreRequest.TestCaseIdentifier identifier =
+        new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1");
 
     List<TestFlakinessScoreDto> result =
         service.getFlakinessScoresForTests(1L, List.of(identifier));
@@ -106,8 +118,29 @@ class TestCaseStatisticsServiceTest {
     assertEquals(1, result.size());
     assertEquals("test1", result.getFirst().testName());
     assertEquals("Class1", result.getFirst().className());
-    assertEquals(0.04, result.getFirst().defaultBranchFailureRate());
-    assertEquals(0.05, result.getFirst().combinedFailureRate());
+    assertEquals(0.05, result.getFirst().defaultBranchFailureRate());
+    assertEquals(0.08, result.getFirst().combinedFailureRate());
+    assertEquals(88.2, result.getFirst().flakinessScore());
+  }
+
+  @Test
+  void getFlakinessScoresForTests_returnsZeroDtoWhenNoMatchExists() {
+    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassName(1L, "missing", "Class1"))
+        .thenReturn(List.of());
+
+    TestFlakinessScoreRequest.TestCaseIdentifier identifier =
+        new TestFlakinessScoreRequest.TestCaseIdentifier("missing", "Class1");
+
+    List<TestFlakinessScoreDto> result =
+        service.getFlakinessScoresForTests(1L, List.of(identifier));
+
+    assertEquals(1, result.size());
+    assertAll(
+        () -> assertEquals("missing", result.getFirst().testName()),
+        () -> assertEquals("Class1", result.getFirst().className()),
+        () -> assertEquals(0.0, result.getFirst().defaultBranchFailureRate()),
+        () -> assertEquals(0.0, result.getFirst().combinedFailureRate()),
+        () -> assertEquals(0.0, result.getFirst().flakinessScore()));
   }
 
   @Test
@@ -125,14 +158,15 @@ class TestCaseStatisticsServiceTest {
   @Test
   void computeFlakinessInfo_withMatchingStats_returnsInfo() {
     var defaultStat = createStat("test1", "Class1", "Suite1", "main", 100, 5);
-    var combinedStat = createStat("test1", "Class1", "Suite1", "combined", 200, 10);
+    var combinedStat = createStat("test1", "Class1", "Suite1", "combined", 200, 30);
 
     var info =
         service.computeFlakinessInfo(
             "test1", "Class1", List.of(defaultStat), List.of(combinedStat));
 
     assertEquals(0.05, info.defaultBranchFailureRate());
-    assertEquals(0.05, info.combinedFailureRate());
+    assertEquals(0.15, info.combinedFailureRate());
+    assertEquals(84.0, info.flakinessScore(), 0.1);
   }
 
   @Test
@@ -142,6 +176,25 @@ class TestCaseStatisticsServiceTest {
     assertEquals(0.0, info.defaultBranchFailureRate());
     assertEquals(0.0, info.combinedFailureRate());
     assertEquals(0.0, info.flakinessScore());
+  }
+
+  private TestCaseFlakiness createFlakiness(
+      String testName,
+      String className,
+      String suiteName,
+      double score,
+      double defaultRate,
+      double combinedRate) {
+    TestCaseFlakiness flakiness = new TestCaseFlakiness();
+    flakiness.setTestName(testName);
+    flakiness.setClassName(className);
+    flakiness.setTestSuiteName(suiteName);
+    flakiness.setFlakinessScore(score);
+    flakiness.setDefaultBranchFailureRate(defaultRate);
+    flakiness.setCombinedFailureRate(combinedRate);
+    flakiness.setRepository(repository);
+    flakiness.setLastUpdated(OffsetDateTime.now());
+    return flakiness;
   }
 
   private static TestCaseStatistics createStat(

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -9,7 +9,6 @@ import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,11 +105,12 @@ class TestCaseStatisticsServiceTest {
   @Test
   void getFlakinessScoresForTests_returnsScores() {
     TestCaseFlakiness flakiness = createFlakiness("test1", "Class1", "Suite1", 88.2, 0.05, 0.08);
-    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassName(1L, "test1", "Class1"))
+    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassNameAndSuiteName(
+        1L, "test1", "Class1", "Suite1"))
         .thenReturn(List.of(flakiness));
 
     TestFlakinessScoreRequest.TestCaseIdentifier identifier =
-        new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1");
+        new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1", "Suite1");
 
     List<TestFlakinessScoreDto> result =
         service.getFlakinessScoresForTests(1L, List.of(identifier));
@@ -125,11 +125,12 @@ class TestCaseStatisticsServiceTest {
 
   @Test
   void getFlakinessScoresForTests_returnsZeroDtoWhenNoMatchExists() {
-    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassName(1L, "missing", "Class1"))
+    when(flakinessRepository.findByRepositoryIdAndTestNameAndClassNameAndSuiteName(
+        1L, "missing", "Class1", "Suite1"))
         .thenReturn(List.of());
 
     TestFlakinessScoreRequest.TestCaseIdentifier identifier =
-        new TestFlakinessScoreRequest.TestCaseIdentifier("missing", "Class1");
+        new TestFlakinessScoreRequest.TestCaseIdentifier("missing", "Class1", "Suite1");
 
     List<TestFlakinessScoreDto> result =
         service.getFlakinessScoresForTests(1L, List.of(identifier));
@@ -138,6 +139,7 @@ class TestCaseStatisticsServiceTest {
     assertAll(
         () -> assertEquals("missing", result.getFirst().testName()),
         () -> assertEquals("Class1", result.getFirst().className()),
+        () -> assertEquals("Suite1", result.getFirst().testSuiteName()),
         () -> assertEquals(0.0, result.getFirst().defaultBranchFailureRate()),
         () -> assertEquals(0.0, result.getFirst().combinedFailureRate()),
         () -> assertEquals(0.0, result.getFirst().flakinessScore()));

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -10,6 +10,7 @@ import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -164,7 +165,9 @@ class TestCaseStatisticsServiceTest {
 
     var info =
         service.computeFlakinessInfo(
-            "test1", "Class1", "Suite1", List.of(defaultStat), List.of(combinedStat));
+            "test1", "Class1", "Suite1",
+            TestCaseStatisticsService.indexFailureRates(List.of(defaultStat)),
+            TestCaseStatisticsService.indexFailureRates(List.of(combinedStat)));
 
     assertEquals(0.05, info.defaultBranchFailureRate());
     assertEquals(0.15, info.combinedFailureRate());
@@ -173,7 +176,8 @@ class TestCaseStatisticsServiceTest {
 
   @Test
   void computeFlakinessInfo_withNoMatchingStats_returnsZeroRates() {
-    var info = service.computeFlakinessInfo("unknown", "Unknown", "Unknown", List.of(), List.of());
+    var info = service.computeFlakinessInfo(
+        "unknown", "Unknown", "Unknown", Map.of(), Map.of());
 
     assertEquals(0.0, info.defaultBranchFailureRate());
     assertEquals(0.0, info.combinedFailureRate());

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -53,11 +53,11 @@ class TestCaseStatisticsServiceTest {
     when(flakinessRepository.findAll(any(Specification.class), any(Pageable.class)))
         .thenReturn(page);
 
-    when(statisticsRepository.countByBranchNameAndRepositoryRepositoryId(
-        "combined", repository.getRepositoryId()))
+    when(flakinessRepository.countByRepositoryRepositoryId(repository.getRepositoryId()))
         .thenReturn(20L);
 
-    when(flakinessRepository.countByRepositoryRepositoryId(repository.getRepositoryId()))
+    when(flakinessRepository.countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(
+        repository.getRepositoryId(), 0))
         .thenReturn(5L);
 
     when(flakinessRepository.countByRepositoryRepositoryIdAndFlakinessScoreGreaterThan(

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -162,7 +162,7 @@ class TestCaseStatisticsServiceTest {
 
     var info =
         service.computeFlakinessInfo(
-            "test1", "Class1", List.of(defaultStat), List.of(combinedStat));
+            "test1", "Class1", "Suite1", List.of(defaultStat), List.of(combinedStat));
 
     assertEquals(0.05, info.defaultBranchFailureRate());
     assertEquals(0.15, info.combinedFailureRate());
@@ -171,7 +171,7 @@ class TestCaseStatisticsServiceTest {
 
   @Test
   void computeFlakinessInfo_withNoMatchingStats_returnsZeroRates() {
-    var info = service.computeFlakinessInfo("unknown", "Unknown", List.of(), List.of());
+    var info = service.computeFlakinessInfo("unknown", "Unknown", "Unknown", List.of(), List.of());
 
     assertEquals(0.0, info.defaultBranchFailureRate());
     assertEquals(0.0, info.combinedFailureRate());

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
@@ -62,10 +62,10 @@ class TestResultControllerTest {
 
   @Test
   void getFlakinessScores_withValidRequest_returnsScores() throws Exception {
-    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1");
+    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1", "Suite1");
     var request = new TestFlakinessScoreRequest(List.of(identifier));
 
-    var expectedDto = new TestFlakinessScoreDto("test1", "Class1", 63.0, 0.05, 0.0);
+    var expectedDto = new TestFlakinessScoreDto("test1", "Class1", "Suite1", 63.0, 0.05, 0.0);
 
     when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
         .thenReturn(List.of(expectedDto));
@@ -90,12 +90,12 @@ class TestResultControllerTest {
   void getFlakinessScores_withMultipleTests_returnsAllScores() throws Exception {
     var identifiers =
         List.of(
-            new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1"),
-            new TestFlakinessScoreRequest.TestCaseIdentifier("test2", "Class2"));
+            new TestFlakinessScoreRequest.TestCaseIdentifier("test1", "Class1", "Suite1"),
+            new TestFlakinessScoreRequest.TestCaseIdentifier("test2", "Class2", "Suite1"));
     var request = new TestFlakinessScoreRequest(identifiers);
 
-    var dto1 = new TestFlakinessScoreDto("test1", "Class1", 63.0, 0.05, 0.0);
-    var dto2 = new TestFlakinessScoreDto("test2", "Class2", 0.0, 0.0, 0.0);
+    var dto1 = new TestFlakinessScoreDto("test1", "Class1", "Suite1", 63.0, 0.05, 0.0);
+    var dto2 = new TestFlakinessScoreDto("test2", "Class2", "Suite1", 0.0, 0.0, 0.0);
 
     when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
         .thenReturn(List.of(dto1, dto2));
@@ -165,10 +165,11 @@ class TestResultControllerTest {
 
   @Test
   void getFlakinessScores_withNoMatchingTests_returnsZeroScores() throws Exception {
-    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier("unknownTest", "Unknown");
+    var identifier = new TestFlakinessScoreRequest.TestCaseIdentifier(
+        "unknownTest", "Unknown", "Unknown");
     var request = new TestFlakinessScoreRequest(List.of(identifier));
 
-    var zeroDto = new TestFlakinessScoreDto("unknownTest", "Unknown", 0.0, 0.0, 0.0);
+    var zeroDto = new TestFlakinessScoreDto("unknownTest", "Unknown", "Unknown", 0.0, 0.0, 0.0);
 
     when(testCaseStatisticsService.getFlakinessScoresForTests(eq(1L), anyList()))
         .thenReturn(List.of(zeroDto));

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultControllerTest.java
@@ -1,6 +1,7 @@
 package de.tum.cit.aet.helios.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettings;
+import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -186,8 +188,7 @@ class TestResultControllerTest {
 
   @Test
   void getFlakyTestsOverview_returnsOverview() throws Exception {
-    var summary =
-        new FlakyTestOverviewDto.FlakyTestSummary(10, 2, 1, 1, 0);
+    var summary = new FlakyTestOverviewDto.FlakyTestSummary(10, 2, 1, 1, 0);
     var flakyTest =
         new FlakyTestOverviewDto.FlakyTestDto(
             "testFlaky",
@@ -196,12 +197,12 @@ class TestResultControllerTest {
             85.0,
             0.03,
             0.05,
-            100,
-            5,
             OffsetDateTime.now());
-    var expected = new FlakyTestOverviewDto(summary, List.of(flakyTest));
+    var expected = new FlakyTestOverviewDto(summary, List.of(flakyTest), 2);
 
-    when(testCaseStatisticsService.getFlakyTestsOverview(1L)).thenReturn(expected);
+    when(testCaseStatisticsService.getFlakyTestsOverview(
+            eq(1L), any(FlakyTestsPageRequest.class)))
+        .thenReturn(expected);
 
     mockMvc
         .perform(get("/api/tests/flaky"))

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
@@ -108,6 +108,7 @@ class TestResultServiceTest {
     testCase.setId(1L);
     testCase.setName("test1");
     testCase.setClassName("TestClass1");
+    testCase.setTestSuite(testSuite);
     testCase.setStatus(TestStatus.PASSED);
     testCase.setTime(0.0);
     testSuite.setTestCases(List.of(testCase));
@@ -155,7 +156,7 @@ class TestResultServiceTest {
         .thenReturn(Collections.emptyList());
     lenient()
         .when(testCaseStatisticsService.computeFlakinessInfo(
-            anyString(), anyString(), anyList(), anyList()
+            anyString(), anyString(), anyString(), anyList(), anyList()
         ))
         .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
@@ -164,7 +165,7 @@ class TestResultServiceTest {
 
     // Verify the problematic call
     verify(testCaseStatisticsService).computeFlakinessInfo(
-        anyString(), anyString(), anyList(), anyList());
+        anyString(), anyString(), anyString(), anyList(), anyList());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());
@@ -213,14 +214,14 @@ class TestResultServiceTest {
         .thenReturn(Collections.emptyList());
     lenient()
         .when(testCaseStatisticsService.computeFlakinessInfo(
-            anyString(), anyString(), anyList(), anyList()))
+            anyString(), anyString(), anyString(), anyList(), anyList()))
         .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
     TestResultsDto result = testResultService.getLatestTestResultsForPr(1L, criteria);
 
     // Verify the problematic call
     verify(testCaseStatisticsService).computeFlakinessInfo(
-        anyString(), anyString(), anyList(), anyList());
+        anyString(), anyString(), anyString(), anyList(), anyList());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -154,18 +155,18 @@ class TestResultServiceTest {
     when(testCaseStatisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyList(), anyString(), anyLong()))
         .thenReturn(Collections.emptyList());
+    when(testCaseStatisticsService.loadFlakinessIndex(anyList(), anyLong()))
+        .thenReturn(Collections.emptyMap());
     lenient()
         .when(testCaseStatisticsService.computeFlakinessInfo(
-            anyString(), anyString(), anyString(), anyList(), anyList()
-        ))
+            anyString(), anyString(), anyString(), anyMap(), anyMap()))
         .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
     TestResultsDto result =
         testResultService.getLatestTestResultsForBranch("featureBranch", criteria);
 
-    // Verify the problematic call
     verify(testCaseStatisticsService).computeFlakinessInfo(
-        anyString(), anyString(), anyString(), anyList(), anyList());
+        anyString(), anyString(), anyString(), anyMap(), anyMap());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());
@@ -212,16 +213,17 @@ class TestResultServiceTest {
     when(testCaseStatisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyList(), anyString(), anyLong()))
         .thenReturn(Collections.emptyList());
+    when(testCaseStatisticsService.loadFlakinessIndex(anyList(), anyLong()))
+        .thenReturn(Collections.emptyMap());
     lenient()
         .when(testCaseStatisticsService.computeFlakinessInfo(
-            anyString(), anyString(), anyString(), anyList(), anyList()))
+            anyString(), anyString(), anyString(), anyMap(), anyMap()))
         .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
 
     TestResultsDto result = testResultService.getLatestTestResultsForPr(1L, criteria);
 
-    // Verify the problematic call
     verify(testCaseStatisticsService).computeFlakinessInfo(
-        anyString(), anyString(), anyString(), anyList(), anyList());
+        anyString(), anyString(), anyString(), anyMap(), anyMap());
 
     assertNotNull(result);
     assertFalse(result.testResults().isEmpty());


### PR DESCRIPTION


<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
After deploying Flakiness Overview feature to test environment, I realized that calculating flakiness score on the fly causes critical performance issue, even Java Heap Out of Memory error. Therefore, it is essential to keep flakiness score in the database and using server side pagination in flakiness overview implementation. #929

### Description
<!-- Describe your changes in detail -->
- Created `test_case_flakiness` table which keeps `flakiness_score, default_branch_failure_rate, combined_failure_rate`.
-  `test_case_flakiness` table is updated in `TestResultProcessor` after updating `test_case_statistics`.
- Added pagination to `getFlakyTestsOverview` service, which returns results in pages and sorted by flakiness_score.
-  In the frontend, Flakiness Overview page is updated with new API call and made compatible with server-side pagination.
- Flakiness computation process is optimized with map usage and bulk get queries on database.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- Access to a Helios with at least one repository with tests with different flakiness scores.

#### Flow:
1. Log in to Helios as a Developer
2. Currently `test_case_flakiness` is empty. Run a test workflow to calculate flaky tests. 
3. Navigate to the Flakiness Overview page for a repository
4. Verify:
4.1. Table loads successfully.
4.2. Search and severity filter still update the displayed page.
4.3. Pagination controls behave consistently with server-side results.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1460" height="766" alt="Screenshot 2026-03-18 at 23 09 54" src="https://github.com/user-attachments/assets/40f55199-0370-440b-9ec7-146fa0f16109" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.