### PR TITLE
refactor: refine deployment tabs and environment list layout

### DIFF
--- a/client/src/app/components/deployment-history/deployment-history.component.html
+++ b/client/src/app/components/deployment-history/deployment-history.component.html
@@ -1,6 +1,3 @@
-<div class="mb-4">
-  <h3 class="text-xl mb-1">Deployment History</h3>
-</div>
 <div class="flex flex-col gap-2">
   <style>
     tr.lock-event td {

--- a/client/src/app/components/deployment-selection/deployment-selection.component.html
+++ b/client/src/app/components/deployment-selection/deployment-selection.component.html
@@ -1,5 +1,1 @@
-<div class="mb-4">
-  <h3 class="text-xl mb-1">Deploy</h3>
-</div>
-
 <app-environment-list-view [deployable]="true" [branchName]="branchName()" (deploy)="handleDeploy($event)" />

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
@@ -1,4 +1,4 @@
-<p-accordion-panel [value]="environment().id" [ngClass]="{ 'border-2 border-primary-400 rounded-lg': isLockedByCurrentUser(), 'border-none': !isLockedByCurrentUser() }">
+<p-accordion-panel [value]="environment().id">
   <p-accordion-header>
     <div class="flex gap-2 items-start w-full flex-wrap md:flex-nowrap flex-col md:items-center md:flex-row">
       <div class="flex flex-col gap-1 flex-wrap">

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.html
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.html
@@ -43,7 +43,7 @@
         @if (!environment().locked) {
           <p-button (click)="onLock($event)" [disabled]="!canUserDeploy()" [pTooltip]="getLockTooltip()" tooltipPosition="top">
             <div class="flex items-center">
-              <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-red-600" />
+              <i-tabler name="lock" class="w-4 h-4 flex-shrink-0 text-white" />
             </div>
           </p-button>
         } @else {

--- a/client/src/app/components/environments/environment-list/environment-list-view.component.html
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.html
@@ -72,35 +72,40 @@
     <div class="mt-6">
       @for (group of environmentGroups(); track group[0]) {
         @if (group[1].length > 0) {
-          <div class="mb-2 mt-2">
-            <div style="width: 100%" class="font-bold mx-auto">
-              <p-divider align="center">
-                <h4 class="m-0">{{ capitalizeFirstLetter(group[0]) }}</h4>
-              </p-divider>
+          <div class="mb-4 mt-6">
+            <div class="mb-4 flex items-center justify-center gap-4">
+              <div class="h-px flex-1 bg-surface-200 dark:bg-surface-700"></div>
+              <div class="text-center">
+                <div class="text-sm font-bold uppercase tracking-[0.24em] text-surface-700 dark:text-surface-200">
+                  {{ capitalizeFirstLetter(group[0]) }}
+                </div>
+              </div>
+              <div class="h-px flex-1 bg-surface-200 dark:bg-surface-700"></div>
             </div>
 
-            <p-accordion [multiple]="true">
-              @for (environment of group[1]; track environment.id; let isLast = $last; let isFirst = $first) {
-                @if (!isFirst) {
-                  <!-- Divider -->
-                  <div class="flex justify-center">
-                    <p-divider class="w-full" />
-                  </div>
-                }
-
-                <app-environment-accordion
-                  [environment]="environment"
-                  [deployable]="!!deployable()"
-                  [canViewAllEnvironments]="!!canViewAllEnvironments()"
-                  [timeUntilReservationExpires]="timeUntilReservationExpires().get(environment.id)"
-                  [isLockedByCurrentUser]="isCurrentUserLocked(environment)"
-                  (deploy)="deployEnvironment($event)"
-                  (unlock)="onUnlockEnvironment($event.event, $event.environment)"
-                  (extend)="extendLock($event.event, $event.environment)"
-                  (lock)="lockEnvironment($event)"
-                  (cancelDeployment)="cancelDeployment($event)"
+            <p-accordion [multiple]="true" class="flex flex-col gap-3">
+              @for (environment of group[1]; track environment.id) {
+                <div
+                  class="rounded-xl shadow-sm overflow-hidden"
+                  [ngClass]="{
+                    'ring-2 ring-blue-500': isCurrentUserLocked(environment),
+                    'ring-1 ring-surface-200 dark:ring-surface-700': !isCurrentUserLocked(environment),
+                  }"
                 >
-                </app-environment-accordion>
+                  <app-environment-accordion
+                    [environment]="environment"
+                    [deployable]="!!deployable()"
+                    [canViewAllEnvironments]="!!canViewAllEnvironments()"
+                    [timeUntilReservationExpires]="timeUntilReservationExpires().get(environment.id)"
+                    [isLockedByCurrentUser]="isCurrentUserLocked(environment)"
+                    (deploy)="deployEnvironment($event)"
+                    (unlock)="onUnlockEnvironment($event.event, $event.environment)"
+                    (extend)="extendLock($event.event, $event.environment)"
+                    (lock)="lockEnvironment($event)"
+                    (cancelDeployment)="cancelDeployment($event)"
+                  >
+                  </app-environment-accordion>
+                </div>
               }
             </p-accordion>
           </div>

--- a/client/src/app/pages/branch-details/branch-details.component.html
+++ b/client/src/app/pages/branch-details/branch-details.component.html
@@ -47,22 +47,21 @@
   <app-pipeline [selector]="pipelineSelector()" />
   <app-pipeline-test-results [selector]="pipelineSelector()" />
   @if (query.data(); as branch) {
-    <div class="rounded-xl border border-surface-200 dark:border-surface-700 shadow-sm overflow-hidden">
-      <p-tabs [value]="deploymentTab()" (valueChange)="onDeploymentTabChange($event)">
-        <p-tablist>
-          <p-tab value="deploy">Deploy</p-tab>
-          <p-tab value="history">Deployment History</p-tab>
-        </p-tablist>
-        <p-tabpanels>
-          <p-tabpanel value="deploy">
-            <app-deployment-selection [branchName]="branch.name" [commitSha]="branch.commitSha" />
-          </p-tabpanel>
-          <p-tabpanel value="history">
-            <app-deployment-history [selector]="{ repositoryId: repositoryId(), branchName: branch.name }" />
-          </p-tabpanel>
-        </p-tabpanels>
-      </p-tabs>
-    </div>
+    <p-divider />
+    <p-tabs [value]="deploymentTab()" (valueChange)="onDeploymentTabChange($event)">
+      <p-tablist>
+        <p-tab value="deploy">Deploy</p-tab>
+        <p-tab value="history">Deployment History</p-tab>
+      </p-tablist>
+      <p-tabpanels>
+        <p-tabpanel value="deploy">
+          <app-deployment-selection [branchName]="branch.name" [commitSha]="branch.commitSha" />
+        </p-tabpanel>
+        <p-tabpanel value="history">
+          <app-deployment-history [selector]="{ repositoryId: repositoryId(), branchName: branch.name }" />
+        </p-tabpanel>
+      </p-tabpanels>
+    </p-tabs>
   }
 </div>
 

--- a/client/src/app/pages/branch-details/branch-details.component.html
+++ b/client/src/app/pages/branch-details/branch-details.component.html
@@ -47,23 +47,22 @@
   <app-pipeline [selector]="pipelineSelector()" />
   <app-pipeline-test-results [selector]="pipelineSelector()" />
   @if (query.data(); as branch) {
-    <div class="flex justify-center">
-      <p-divider class="w-full mt-4" />
+    <div class="rounded-xl border border-surface-200 dark:border-surface-700 shadow-sm overflow-hidden">
+      <p-tabs [value]="deploymentTab()" (valueChange)="onDeploymentTabChange($event)">
+        <p-tablist>
+          <p-tab value="deploy">Deploy</p-tab>
+          <p-tab value="history">Deployment History</p-tab>
+        </p-tablist>
+        <p-tabpanels>
+          <p-tabpanel value="deploy">
+            <app-deployment-selection [branchName]="branch.name" [commitSha]="branch.commitSha" />
+          </p-tabpanel>
+          <p-tabpanel value="history">
+            <app-deployment-history [selector]="{ repositoryId: repositoryId(), branchName: branch.name }" />
+          </p-tabpanel>
+        </p-tabpanels>
+      </p-tabs>
     </div>
-    <p-tabs [value]="deploymentTab()" (valueChange)="onDeploymentTabChange($event)">
-      <p-tablist>
-        <p-tab value="deploy">Deploy</p-tab>
-        <p-tab value="history">Deployment History</p-tab>
-      </p-tablist>
-      <p-tabpanels>
-        <p-tabpanel value="deploy">
-          <app-deployment-selection [branchName]="branch.name" [commitSha]="branch.commitSha" />
-        </p-tabpanel>
-        <p-tabpanel value="history">
-          <app-deployment-history [selector]="{ repositoryId: repositoryId(), branchName: branch.name }" />
-        </p-tabpanel>
-      </p-tabpanels>
-    </p-tabs>
   }
 </div>
 

--- a/client/src/app/pages/pull-request-details/pull-request-details.component.html
+++ b/client/src/app/pages/pull-request-details/pull-request-details.component.html
@@ -48,9 +48,7 @@
   <app-pipeline-test-results [selector]="pipelineSelector()" />
   @if (query.data(); as pr) {
     @if (pr.headRefRepoNameWithOwner === pr.repository?.nameWithOwner) {
-      <div class="flex justify-center">
-        <p-divider class="w-full mt-4" />
-      </div>
+      <p-divider />
       <p-tabs [value]="deploymentTab()" (valueChange)="onDeploymentTabChange($event)">
         <p-tablist>
           <p-tab value="deploy">Deploy</p-tab>


### PR DESCRIPTION
### Motivation

Related issue: #941

The current environment view is hard to scan because environments are not visually separated enough and the deployment area is surrounded by redundant headings and dividers. This makes it more difficult to distinguish environment groups and quickly understand the available deployment actions.

### Description

- Refined the environment list layout to make each environment appear more like a separate card with clearer visual grouping.
- Reworked the environment group headers to use a lighter section-divider style instead of the previous full-width divider layout.
- Simplified the deployment and deployment history sections by removing redundant headings and wrapping branch deployment tabs in a cleaner bordered container.
- Applied the same deployment tab cleanup to the pull request details view.

### Testing Instructions
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- A repository in Helios with multiple environments across different environment types
- At least one branch or pull request that can be opened in the repository detail views

#### Flow:
1. Log in to Helios as a Developer.
2. Navigate to a repository's environment list or deployment-related page.
3. Verify environments are grouped more clearly and each environment is visually separated like its own card.
4. Verify the section headers for environment groups are easier to scan than before.
5. Lock an environment as the current user and verify the locked environment is visually highlighted.
6. Open a branch details page and verify the `Deploy` and `Deployment History` tabs are shown in a cleaner container without redundant headings.
7. Open a pull request details page and verify the deployment tab area follows the updated layout there as well.
8. Verify the updated layout works without breaking deploy, lock, unlock, extend, or cancel deployment actions.

### Screenshots

https://github.com/user-attachments/assets/39f811d4-83b2-430b-b9f4-a76d9cb34ec2

<img width="2047" height="1035" alt="image" src="https://github.com/user-attachments/assets/f5f864d0-b607-4b37-bb5f-3279197272a5" />


### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.
