### PR TITLE
feat: workflow run details page

### DIFF
--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -88,6 +88,10 @@ export const routes: Routes = [
                 pathMatch: 'full',
               },
               {
+                path: 'runs/:runId',
+                loadComponent: () => import('@app/pages/workflow-run-details/workflow-run-details.component').then(m => m.WorkflowRunDetailsComponent),
+              },
+              {
                 path: 'runs',
                 loadComponent: () => import('@app/pages/workflow-run-list/workflow-run-list.component').then(m => m.WorkflowRunListComponent),
               },

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.html
@@ -127,9 +127,7 @@
           <div class="flex-grow">
             <app-deployment-stepper [deployment]="environment().latestDeployment" class="w-full" />
 
-            @if (workflowRunId()) {
-              <app-workflow-jobs-status [workflowRunId]="workflowRunId()!" [latestDeployment]="environment().latestDeployment" />
-            }
+            <app-workflow-jobs-status [latestDeployment]="environment().latestDeployment" />
           </div>
         } @else {
           <app-environment-details [environment]="environment()" class="w-full" />

--- a/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
+++ b/client/src/app/components/environments/environment-accordion/environment-accordion.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, output } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
 import { DeploymentStepperComponent } from '../deployment-stepper/deployment-stepper.component';
 import { EnvironmentActionsComponent } from '../environment-actions/environment-actions.component';
@@ -130,15 +130,4 @@ export class EnvironmentAccordionComponent {
       window.open(url, '_blank');
     }
   }
-
-  workflowRunId = computed(() => {
-    const deployment = this.environment()?.latestDeployment;
-    if (!deployment?.workflowRunHtmlUrl) return undefined;
-
-    const matches = deployment.workflowRunHtmlUrl.match(/\/runs\/(\d+)$/);
-    if (matches && matches[1]) {
-      return parseInt(matches[1], 10);
-    }
-    return undefined;
-  });
 }

--- a/client/src/app/components/environments/workflow-job-status/workflow-jobs-status.component.html
+++ b/client/src/app/components/environments/workflow-job-status/workflow-jobs-status.component.html
@@ -1,121 +1,10 @@
-<div class="workflow-jobs-status w-full mb-4">
-  @if (jobs().length > 0 && !deploymentSuccessful()) {
+@if (jobs().length > 0 && !deploymentSuccessful()) {
+  <div class="workflow-jobs-status w-full mb-4">
     <div class="flex justify-between items-center mb-3">
       <h3 class="text-lg font-medium">Job Status</h3>
     </div>
 
-    <div class="grid">
-      @for (job of jobs(); track job.id) {
-        <div
-          class="workflow-job mb-4 border border-gray-200 dark:border-gray-700 rounded-lg p-3 bg-gray-50 dark:bg-gray-800"
-          [ngClass]="{
-            'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-900/30': job.conclusion === 'success',
-            'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-900/30': job.conclusion === 'failure',
-          }"
-        >
-          <div class="job-header flex justify-between items-center mb-2 cursor-pointer" (click)="toggleJobExpansion(job.id!)">
-            <div class="flex items-center gap-2">
-              <i-tabler [name]="isJobExpanded(job.id!) ? 'chevron-down' : 'chevron-right'" class="!size-5 text-gray-500"></i-tabler>
-              <i-tabler [name]="getStatusIcon(job.status, job.conclusion)" [ngClass]="getIconColorClass(job.status, job.conclusion)" class="!size-5"></i-tabler>
-              <span class="font-semibold">{{ job.name }}</span>
-              <span class="status-badge px-2 py-1 rounded-full text-xs font-medium" [ngClass]="getStatusClass(job.status, job.conclusion)">
-                {{ getStatusText(job.status, job.conclusion) }}
-              </span>
-            </div>
-            <div class="text-sm text-gray-500 flex items-center gap-2">
-              @if (job.startedAt) {
-                <span>Started: {{ formatTime(job.startedAt) }}</span>
-
-                @if (job.completedAt) {
-                  <span>• Completed: {{ formatTime(job.completedAt) }}</span>
-                  <span class="px-2 py-0.5 bg-gray-100 rounded-full">
-                    {{ getDuration(job.startedAt, job.completedAt) }}
-                  </span>
-                } @else {
-                  <span class="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full"> Running </span>
-                }
-              }
-              @if (!!job.htmlUrl) {
-                <p-button [link]="true" label="View Logs on Github" size="small" (click)="$event.stopPropagation(); openLink(job.htmlUrl)">
-                  <i-tabler name="external-link" class="!size-4"></i-tabler>
-                </p-button>
-              }
-            </div>
-          </div>
-
-          @if (isJobExpanded(job.id!)) {
-            <div class="job-details mt-3">
-              <!-- Runner Information -->
-              @if (job.runnerId) {
-                <div class="runner-info text-sm mb-2 flex flex-wrap items-center gap-2">
-                  <span class="text-gray-600">Runner:</span>
-                  <span class="font-medium">{{ job.runnerName || 'Unknown' }}</span>
-
-                  @if (job.labels && job.labels.length > 0) {
-                    <div class="runner-labels flex flex-wrap gap-1 ml-2">
-                      @for (label of job.labels; track label) {
-                        <span class="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-700">
-                          {{ label }}
-                        </span>
-                      }
-                    </div>
-                  }
-                </div>
-              }
-
-              <!-- Waiting for Runner Message -->
-              @if (job.status === 'queued' && !job.runnerId) {
-                <div class="waiting-for-runner text-sm mb-2">
-                  <span class="text-yellow-600 flex items-center">
-                    <i-tabler name="clock" class="mr-1"></i-tabler>
-                    Waiting for available runner...
-                  </span>
-                </div>
-              }
-
-              <!-- Waiting for Review Message -->
-              @if (job.status === 'waiting') {
-                <div class="waiting-for-runner text-sm mb-2">
-                  <span class="text-yellow-600 flex items-center">
-                    <i-tabler name="clock" class="mr-1"></i-tabler>
-                    Waiting for approval...
-                  </span>
-                </div>
-              }
-
-              <!-- Skipped Message -->
-              @if (job.conclusion === 'skipped') {
-                <div class="waiting-for-runner text-sm mb-2 ml-2">
-                  <span class="text-gray-600 dark:text-gray-400 flex items-center"> This job was skipped. </span>
-                </div>
-              }
-
-              @if (job.steps?.length) {
-                <div class="job-steps pl-4 border-l-2 border-gray-200 mt-3">
-                  @for (step of job.steps; track step.number) {
-                    <div class="step py-1 flex items-center gap-2">
-                      <span class="status-indicator size-2 rounded-full" [ngClass]="getStatusIndicatorClass(step.status, step.conclusion)"></span>
-                      <span class="step-name text-sm flex-grow">{{ step.name }}</span>
-
-                      <div class="flex items-center gap-2">
-                        @if (step.startedAt && step.completedAt) {
-                          <span class="text-xs text-gray-500">
-                            {{ getDuration(step.startedAt, step.completedAt) }}
-                          </span>
-                        }
-                        <span class="status-badge px-2 py-0.5 rounded-full text-xs" [ngClass]="getStatusClass(step.status, step.conclusion)">
-                          {{ getStatusText(step.status, step.conclusion) }}
-                        </span>
-                      </div>
-                    </div>
-                  }
-                </div>
-              }
-            </div>
-          }
-        </div>
-      }
-    </div>
+    <app-workflow-job-list [jobs]="jobs()" />
 
     @if (deploymentUnsuccessful() && !!latestDeployment()?.workflowRunHtmlUrl) {
       <div class="flex-col w-full justify-items-center">
@@ -125,5 +14,5 @@
         </p-button>
       </div>
     }
-  }
-</div>
+  </div>
+}

--- a/client/src/app/components/environments/workflow-job-status/workflow-jobs-status.component.ts
+++ b/client/src/app/components/environments/workflow-job-status/workflow-jobs-status.component.ts
@@ -1,66 +1,53 @@
-import { CommonModule, DatePipe } from '@angular/common';
 import { Component, computed, effect, inject, input, signal } from '@angular/core';
 import { EnvironmentDeployment, WorkflowJobDto } from '@app/core/modules/openapi';
 import { getWorkflowJobStatusOptions, getWorkflowJobStatusQueryKey } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { PermissionService } from '@app/core/services/permission.service';
+import { WorkflowJobListComponent } from '@app/components/workflow-job-list/workflow-job-list.component';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import {
-  IconBrandGithub,
-  IconCircleCheck,
-  IconCircleMinus,
-  IconCircleX,
-  IconClock,
-  IconExternalLink,
-  IconProgress,
-  IconChevronDown,
-  IconChevronRight,
-} from 'angular-tabler-icons/icons';
+import { IconBrandGithub } from 'angular-tabler-icons/icons';
 import { Button } from 'primeng/button';
 
 @Component({
   selector: 'app-workflow-jobs-status',
   standalone: true,
-  imports: [CommonModule, TablerIconComponent, Button],
+  imports: [TablerIconComponent, Button, WorkflowJobListComponent],
   providers: [
-    DatePipe,
     provideTablerIcons({
-      IconClock,
-      IconProgress,
-      IconCircleMinus,
-      IconCircleCheck,
-      IconCircleX,
       IconBrandGithub,
-      IconExternalLink,
-      IconChevronDown,
-      IconChevronRight,
     }),
   ],
   templateUrl: './workflow-jobs-status.component.html',
 })
 export class WorkflowJobsStatusComponent {
   permissions = inject(PermissionService);
-  latestDeployment = input.required<EnvironmentDeployment | undefined>();
 
-  workflowRunId = input.required<number>();
+  /**
+   * The latest deployment to monitor. When undefined, the component renders nothing.
+   * The workflowRunId is derived from the deployment's workflowRunHtmlUrl.
+   */
+  latestDeployment = input<EnvironmentDeployment | undefined>();
 
-  private datePipe = inject(DatePipe);
+  workflowRunId = computed(() => {
+    const url = this.latestDeployment()?.workflowRunHtmlUrl;
+    const match = url?.match(/\/runs\/(\d+)$/);
+    return match ? parseInt(match[1], 10) : undefined;
+  });
 
   private extraRefetchStarted = signal(false);
   private extraRefetchCompleted = signal(false);
 
-  expandedJobs = signal<Record<string, boolean>>({});
+  deploymentInProgress = computed(() => {
+    return ['IN_PROGRESS', 'WAITING', 'REQUESTED', 'PENDING', 'QUEUED'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
+  });
 
-  toggleJobExpansion(jobId: number) {
-    this.expandedJobs.update(state => ({
-      ...state,
-      [jobId]: !state[jobId],
-    }));
-  }
+  deploymentSuccessful = computed(() => {
+    return ['SUCCESS'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
+  });
 
-  isJobExpanded(jobId: number): boolean {
-    return !!this.expandedJobs()[jobId];
-  }
+  deploymentUnsuccessful = computed(() => {
+    return ['ERROR', 'FAILURE'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
+  });
 
   // Control when to poll for job status - during active deployment or limited extra fetches
   shouldPoll = computed(() => {
@@ -82,42 +69,17 @@ export class WorkflowJobsStatusComponent {
   });
 
   workflowJobsQuery = injectQuery(() => ({
-    ...getWorkflowJobStatusOptions({ path: { runId: this.workflowRunId() } }),
-    queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.workflowRunId() } }),
+    ...getWorkflowJobStatusOptions({ path: { runId: this.workflowRunId() ?? 0 } }),
+    queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.workflowRunId() ?? 0 } }),
     enabled: this.shouldPoll(),
-    refetchInterval: this.extraRefetchStarted() ? 10000 : 5000, // Slower interval for extra fetches
+    refetchInterval: () => (this.extraRefetchStarted() ? 10000 : 5000),
     staleTime: 0,
   }));
 
-  // Extract jobs data for the template - now properly typed
   jobs = computed<WorkflowJobDto[]>(() => {
     const response = this.workflowJobsQuery.data();
     if (!response || !response.jobs) return [];
     return response.jobs;
-  });
-
-  // Check if all jobs are completed
-  allJobsCompleted = computed(() => {
-    const jobs = this.jobs();
-    if (!jobs.length) return false;
-    return jobs.every(job => job.status === 'completed');
-  });
-
-  deploymentInProgress = computed(() => {
-    return ['IN_PROGRESS', 'WAITING', 'REQUESTED', 'PENDING', 'QUEUED'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
-  });
-
-  deploymentSuccessful = computed(() => {
-    return ['SUCCESS'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
-  });
-
-  deploymentUnsuccessful = computed(() => {
-    return ['ERROR', 'FAILURE'].includes(this.latestDeployment()?.state || '') && this.latestDeployment()?.workflowRunHtmlUrl;
-  });
-
-  // Track if any jobs failed
-  hasFailedJobs = computed(() => {
-    return this.jobs().some(job => job.conclusion === 'failure');
   });
 
   constructor() {
@@ -140,88 +102,6 @@ export class WorkflowJobsStatusComponent {
         }, 60 * 1000); // Stop after 1 minute
       }
     });
-  }
-  // Get CSS class for job status
-  getStatusClass(status: string | null | undefined, conclusion: string | null | undefined): string {
-    if (conclusion === 'success') return 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30';
-    if (conclusion === 'failure') return 'text-red-600 bg-red-100 dark:text-red-400 dark:bg-red-900/30';
-    if (conclusion === 'skipped') return 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-900';
-    if (conclusion === 'cancelled') return 'text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30';
-
-    if (status === 'in_progress') return 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30';
-    if (status === 'queued' || status === 'waiting') return 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-900';
-
-    return 'text-gray-600 dark:text-gray-400';
-  }
-
-  getStatusIndicatorClass(status: string | null | undefined, conclusion: string | null | undefined): string {
-    if (conclusion === 'success') return 'bg-green-500 dark:bg-green-400';
-    if (conclusion === 'failure') return 'bg-red-500 dark:bg-red-400';
-    if (conclusion === 'skipped') return 'bg-gray-400 dark:bg-gray-500';
-    if (conclusion === 'cancelled') return 'bg-orange-500 dark:bg-orange-400';
-
-    if (status === 'in_progress') return 'bg-blue-500 dark:bg-blue-400';
-    if (status === 'queued' || status === 'waiting') return 'bg-gray-300 dark:bg-gray-600';
-
-    return 'bg-gray-300 dark:bg-gray-600';
-  }
-
-  // Get icon for job status
-  getStatusIcon(status: string | null | undefined, conclusion: string | null | undefined): string {
-    if (conclusion === 'success') return 'circle-check';
-    if (conclusion === 'failure') return 'circle-x';
-    if (conclusion === 'skipped' || conclusion === 'cancelled') return 'circle-minus';
-
-    if (status === 'in_progress') return 'progress';
-    if (status === 'queued' || status === 'waiting') return 'clock';
-
-    return 'help';
-  }
-
-  getIconColorClass(status: string | null | undefined, conclusion: string | null | undefined): string {
-    if (conclusion === 'success') return 'text-green-600 dark:text-green-400';
-    if (conclusion === 'failure') return 'text-red-600 dark:text-red-400';
-    if (conclusion === 'skipped') return 'text-gray-600 dark:text-gray-400';
-    if (conclusion === 'cancelled') return 'text-orange-600 dark:text-orange-400';
-
-    if (status === 'in_progress') return 'text-blue-600 dark:text-blue-400 animate-spin';
-    if (status === 'queued' || status === 'waiting') return 'text-gray-600 dark:text-gray-400';
-
-    return 'text-gray-600 dark:text-gray-400';
-  }
-
-  // Get status text for display
-  getStatusText(status: string | null | undefined, conclusion: string | null | undefined): string {
-    return conclusion || status || 'Unknown';
-  }
-
-  // Format timestamp to readable format
-  formatTime(timestamp: string | null | undefined): string {
-    if (!timestamp) return '';
-    return this.datePipe.transform(timestamp, 'HH:mm:ss') || '';
-  }
-
-  // Calculate duration between start and end time
-  getDuration(startTime: string | undefined, endTime: string | undefined): string {
-    if (!startTime) return '';
-
-    const start = new Date(startTime).getTime();
-    const end = endTime ? new Date(endTime).getTime() : Date.now();
-
-    const durationMs = end - start;
-    const seconds = Math.floor(durationMs / 1000);
-
-    if (seconds < 60) {
-      return `${seconds}s`;
-    } else if (seconds < 3600) {
-      const minutes = Math.floor(seconds / 60);
-      const remainingSeconds = seconds % 60;
-      return `${minutes}m ${remainingSeconds}s`;
-    } else {
-      const hours = Math.floor(seconds / 3600);
-      const minutes = Math.floor((seconds % 3600) / 60);
-      return `${hours}h ${minutes}m`;
-    }
   }
 
   openLink(url: string | undefined) {

--- a/client/src/app/components/pipeline/pipeline.component.ts
+++ b/client/src/app/components/pipeline/pipeline.component.ts
@@ -23,6 +23,9 @@ export type PipelineSelector = { repositoryId: number } & (
   | {
       pullRequestId: number;
     }
+  | {
+      workflowRunId: number;
+    }
 );
 
 export interface Pipeline {

--- a/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
+++ b/client/src/app/components/pipeline/test-results/pipeline-test-results.component.ts
@@ -18,6 +18,7 @@ import {
   getGitRepoSettingsOptions,
   getLatestTestResultsByBranchOptions,
   getLatestTestResultsByPullRequestIdOptions,
+  getTestResultsByWorkflowRunIdOptions,
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { TestCaseDto, TestSuiteDto, TestTypeResults } from '@app/core/modules/openapi';
 import { DialogModule } from 'primeng/dialog';
@@ -257,6 +258,12 @@ export class PipelineTestResultsComponent {
     return 'pullRequestId' in selector ? selector.pullRequestId : null;
   });
 
+  workflowRunId = computed(() => {
+    const selector = this.selector();
+    if (!selector) return null;
+    return 'workflowRunId' in selector ? selector.workflowRunId : null;
+  });
+
   branchQuery = injectQuery(() => ({
     ...getLatestTestResultsByBranchOptions({
       query: {
@@ -285,8 +292,23 @@ export class PipelineTestResultsComponent {
     // refetchInterval: 15000,
   }));
 
+  workflowRunQuery = injectQuery(() => ({
+    ...getTestResultsByWorkflowRunIdOptions({
+      path: { workflowRunId: this.workflowRunId() || 0 },
+      query: {
+        page: this.testSuiteFirst() / this.testSuiteRows(),
+        size: this.testSuiteRows(),
+        search: this.searchValue(),
+        onlyFailed: this.showOnlyFailed(),
+      },
+    }),
+    enabled: this.workflowRunId() !== null,
+  }));
+
   resultsQuery = computed(() => {
-    return this.branchName() ? this.branchQuery : this.pullRequestQuery;
+    if (this.branchName()) return this.branchQuery;
+    if (this.pullRequestId()) return this.pullRequestQuery;
+    return this.workflowRunQuery;
   });
 
   op = viewChild.required<Popover>('op');

--- a/client/src/app/components/workflow-job-list/workflow-job-list.component.html
+++ b/client/src/app/components/workflow-job-list/workflow-job-list.component.html
@@ -1,0 +1,123 @@
+@if (isPending() && !jobs().length) {
+  <div class="flex flex-col gap-2">
+    <p-skeleton width="100%" height="3rem" />
+    <p-skeleton width="100%" height="3rem" />
+    <p-skeleton width="100%" height="3rem" />
+  </div>
+} @else if (isError()) {
+  <div class="p-4 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300">
+    <span>Failed to load jobs. The workflow run might have been deleted or there was an error fetching the data.</span>
+  </div>
+} @else if (!isPending() && jobs().length === 0) {
+  <div class="p-4 rounded-lg bg-surface-100 dark:bg-surface-800 text-muted-color">No jobs found for this workflow run.</div>
+} @else {
+  <div class="grid">
+    @for (job of jobs(); track job.id) {
+      <div
+        class="workflow-job mb-4 border border-gray-200 dark:border-gray-700 rounded-lg p-3 bg-gray-50 dark:bg-gray-800"
+        [ngClass]="{
+          'border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-900/30': job.conclusion === 'success',
+          'border-red-300 bg-red-50 dark:border-red-800 dark:bg-red-900/30': job.conclusion === 'failure',
+        }"
+      >
+        <div class="job-header flex justify-between items-center mb-2 cursor-pointer" (click)="toggleJobExpansion(job.id!)">
+          <div class="flex items-center gap-2">
+            <i-tabler [name]="isJobExpanded(job.id!) ? 'chevron-down' : 'chevron-right'" class="!size-5 text-gray-500"></i-tabler>
+            <i-tabler [name]="getStatusIcon(job.status, job.conclusion)" [ngClass]="getIconColorClass(job.status, job.conclusion)" class="!size-5"></i-tabler>
+            <span class="font-semibold">{{ job.name }}</span>
+            <span class="status-badge px-2 py-1 rounded-full text-xs font-medium" [ngClass]="getStatusClass(job.status, job.conclusion)">
+              {{ getStatusText(job.status, job.conclusion) }}
+            </span>
+          </div>
+          <div class="text-sm text-gray-500 flex items-center gap-2">
+            @if (job.startedAt) {
+              <span>Started: {{ formatTime(job.startedAt) }}</span>
+              @if (job.completedAt) {
+                <span>• Completed: {{ formatTime(job.completedAt) }}</span>
+                <span class="px-2 py-0.5 bg-gray-100 rounded-full">
+                  {{ getDuration(job.startedAt, job.completedAt) }}
+                </span>
+              } @else {
+                <span class="px-2 py-0.5 bg-blue-50 text-blue-600 rounded-full"> Running </span>
+              }
+            }
+            @if (!!job.htmlUrl) {
+              <p-button [link]="true" label="View Logs on Github" size="small" (click)="$event.stopPropagation(); openLink(job.htmlUrl)">
+                <i-tabler name="external-link" class="!size-4"></i-tabler>
+              </p-button>
+            }
+          </div>
+        </div>
+
+        @if (isJobExpanded(job.id!)) {
+          <div class="job-details mt-3">
+            <!-- Runner Information -->
+            @if (job.runnerId) {
+              <div class="runner-info text-sm mb-2 flex flex-wrap items-center gap-2">
+                <span class="text-gray-600">Runner:</span>
+                <span class="font-medium">{{ job.runnerName || 'Unknown' }}</span>
+                @if (job.labels && job.labels.length > 0) {
+                  <div class="runner-labels flex flex-wrap gap-1 ml-2">
+                    @for (label of job.labels; track label) {
+                      <span class="px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-700">
+                        {{ label }}
+                      </span>
+                    }
+                  </div>
+                }
+              </div>
+            }
+
+            <!-- Waiting for Runner Message -->
+            @if (job.status === 'queued' && !job.runnerId) {
+              <div class="waiting-for-runner text-sm mb-2">
+                <span class="text-yellow-600 flex items-center">
+                  <i-tabler name="clock" class="mr-1"></i-tabler>
+                  Waiting for available runner...
+                </span>
+              </div>
+            }
+
+            <!-- Waiting for Review Message -->
+            @if (job.status === 'waiting') {
+              <div class="waiting-for-runner text-sm mb-2">
+                <span class="text-yellow-600 flex items-center">
+                  <i-tabler name="clock" class="mr-1"></i-tabler>
+                  Waiting for approval...
+                </span>
+              </div>
+            }
+
+            <!-- Skipped Message -->
+            @if (job.conclusion === 'skipped') {
+              <div class="waiting-for-runner text-sm mb-2 ml-2">
+                <span class="text-gray-600 dark:text-gray-400 flex items-center"> This job was skipped. </span>
+              </div>
+            }
+
+            @if (job.steps?.length) {
+              <div class="job-steps pl-4 border-l-2 border-gray-200 mt-3">
+                @for (step of job.steps; track step.number) {
+                  <div class="step py-1 flex items-center gap-2">
+                    <span class="status-indicator size-2 rounded-full" [ngClass]="getStatusIndicatorClass(step.status, step.conclusion)"></span>
+                    <span class="step-name text-sm flex-grow">{{ step.name }}</span>
+                    <div class="flex items-center gap-2">
+                      @if (step.startedAt && step.completedAt) {
+                        <span class="text-xs text-gray-500">
+                          {{ getDuration(step.startedAt, step.completedAt) }}
+                        </span>
+                      }
+                      <span class="status-badge px-2 py-0.5 rounded-full text-xs" [ngClass]="getStatusClass(step.status, step.conclusion)">
+                        {{ getStatusText(step.status, step.conclusion) }}
+                      </span>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+  </div>
+}

--- a/client/src/app/components/workflow-job-list/workflow-job-list.component.ts
+++ b/client/src/app/components/workflow-job-list/workflow-job-list.component.ts
@@ -1,0 +1,124 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import { Component, inject, input, signal } from '@angular/core';
+import { WorkflowJobDto } from '@app/core/modules/openapi';
+import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
+import {
+  IconBrandGithub,
+  IconCircleCheck,
+  IconCircleMinus,
+  IconCircleX,
+  IconClock,
+  IconExternalLink,
+  IconProgress,
+  IconChevronDown,
+  IconChevronRight,
+} from 'angular-tabler-icons/icons';
+import { Button } from 'primeng/button';
+import { SkeletonModule } from 'primeng/skeleton';
+
+@Component({
+  selector: 'app-workflow-job-list',
+  standalone: true,
+  imports: [CommonModule, TablerIconComponent, Button, SkeletonModule],
+  providers: [
+    DatePipe,
+    provideTablerIcons({
+      IconClock,
+      IconProgress,
+      IconCircleMinus,
+      IconCircleCheck,
+      IconCircleX,
+      IconBrandGithub,
+      IconExternalLink,
+      IconChevronDown,
+      IconChevronRight,
+    }),
+  ],
+  templateUrl: './workflow-job-list.component.html',
+})
+export class WorkflowJobListComponent {
+  jobs = input.required<WorkflowJobDto[]>();
+  isPending = input(false);
+  isError = input(false);
+
+  private datePipe = inject(DatePipe);
+
+  expandedJobs = signal<Record<string, boolean>>({});
+
+  toggleJobExpansion(jobId: number) {
+    this.expandedJobs.update(state => ({
+      ...state,
+      [jobId]: !state[jobId],
+    }));
+  }
+
+  isJobExpanded(jobId: number): boolean {
+    return !!this.expandedJobs()[jobId];
+  }
+
+  getStatusClass(status: string | null | undefined, conclusion: string | null | undefined): string {
+    if (conclusion === 'success') return 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30';
+    if (conclusion === 'failure') return 'text-red-600 bg-red-100 dark:text-red-400 dark:bg-red-900/30';
+    if (conclusion === 'skipped') return 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-900';
+    if (conclusion === 'cancelled') return 'text-orange-600 bg-orange-50 dark:text-orange-400 dark:bg-orange-900/30';
+    if (status === 'in_progress') return 'text-blue-600 bg-blue-50 dark:text-blue-400 dark:bg-blue-900/30';
+    if (status === 'queued' || status === 'waiting') return 'text-gray-600 bg-gray-100 dark:text-gray-400 dark:bg-gray-900';
+    return 'text-gray-600 dark:text-gray-400';
+  }
+
+  getStatusIndicatorClass(status: string | null | undefined, conclusion: string | null | undefined): string {
+    if (conclusion === 'success') return 'bg-green-500 dark:bg-green-400';
+    if (conclusion === 'failure') return 'bg-red-500 dark:bg-red-400';
+    if (conclusion === 'skipped') return 'bg-gray-400 dark:bg-gray-500';
+    if (conclusion === 'cancelled') return 'bg-orange-500 dark:bg-orange-400';
+    if (status === 'in_progress') return 'bg-blue-500 dark:bg-blue-400';
+    if (status === 'queued' || status === 'waiting') return 'bg-gray-300 dark:bg-gray-600';
+    return 'bg-gray-300 dark:bg-gray-600';
+  }
+
+  getStatusIcon(status: string | null | undefined, conclusion: string | null | undefined): string {
+    if (conclusion === 'success') return 'circle-check';
+    if (conclusion === 'failure') return 'circle-x';
+    if (conclusion === 'skipped' || conclusion === 'cancelled') return 'circle-minus';
+    if (status === 'in_progress') return 'progress';
+    if (status === 'queued' || status === 'waiting') return 'clock';
+    return 'help';
+  }
+
+  getIconColorClass(status: string | null | undefined, conclusion: string | null | undefined): string {
+    if (conclusion === 'success') return 'text-green-600 dark:text-green-400';
+    if (conclusion === 'failure') return 'text-red-600 dark:text-red-400';
+    if (conclusion === 'skipped') return 'text-gray-600 dark:text-gray-400';
+    if (conclusion === 'cancelled') return 'text-orange-600 dark:text-orange-400';
+    if (status === 'in_progress') return 'text-blue-600 dark:text-blue-400 animate-spin';
+    if (status === 'queued' || status === 'waiting') return 'text-gray-600 dark:text-gray-400';
+    return 'text-gray-600 dark:text-gray-400';
+  }
+
+  getStatusText(status: string | null | undefined, conclusion: string | null | undefined): string {
+    return conclusion || status || 'Unknown';
+  }
+
+  formatTime(timestamp: string | null | undefined): string {
+    if (!timestamp) return '';
+    return this.datePipe.transform(timestamp, 'HH:mm:ss') || '';
+  }
+
+  getDuration(startTime: string | undefined, endTime: string | undefined): string {
+    if (!startTime) return '';
+    const start = new Date(startTime).getTime();
+    const end = endTime ? new Date(endTime).getTime() : Date.now();
+    const seconds = Math.floor((end - start) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) {
+      return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    }
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  }
+
+  openLink(url: string | undefined) {
+    if (url) {
+      window.open(url, '_blank');
+    }
+  }
+}

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.html
@@ -21,9 +21,9 @@
         <app-table-filter-paginated [paginationService]="typedPaginationService" [table]="table" />
       </th>
       <th class="hidden md:table-cell">Status</th>
-      <th class="hidden lg:table-cell">Tests</th>
+      <th class="hidden lg:table-cell">Test Processing</th>
       <th class="hidden lg:table-cell">Started</th>
-      <th class="hidden lg:table-cell">Updated</th>
+      <th class="hidden lg:table-cell">Duration</th>
     </tr>
   </ng-template>
 
@@ -38,7 +38,7 @@
         </td>
       </tr>
     } @else {
-      <tr>
+      <tr (click)="navigateToRun(run)" class="cursor-pointer">
         <td class="px-2 py-2">
           <div class="flex flex-col gap-2.5">
             <div class="flex flex-wrap items-center gap-2">
@@ -78,11 +78,11 @@
         </td>
         <td class="hidden lg:table-cell w-40">
           @if (run.runStartedAt) {
-            <span class="text-sm">{{ run.runStartedAt | timeAgo }}</span>
+            <span class="text-sm" [pTooltip]="formatExactDate(run.runStartedAt)" tooltipPosition="top">{{ run.runStartedAt | timeAgo }}</span>
           }
         </td>
         <td class="hidden lg:table-cell w-40">
-          <span class="text-sm">{{ run.updatedAt | timeAgo }}</span>
+          <span class="text-sm">{{ getDuration(run) }}</span>
         </td>
       </tr>
     }

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.spec.ts
@@ -68,6 +68,7 @@ describe('WorkflowRunsTableComponent', () => {
 
     fixture = TestBed.createComponent(WorkflowRunsTableComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('repositoryId', 1);
 
     setMockQuery(component, { data: undefined, isPending: false, isError: false });
 

--- a/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
+++ b/client/src/app/components/workflow-runs-table/workflow-runs-table.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, inject, ViewChild } from '@angular/core';
+import { Component, computed, inject, input, numberAttribute, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 import { Table, TableModule, TablePageEvent } from 'primeng/table';
 import { TagModule } from 'primeng/tag';
 import { TooltipModule } from 'primeng/tooltip';
@@ -55,6 +56,9 @@ export class WorkflowRunsTableComponent {
 
   messageService = inject(MessageService);
   paginationService = inject(PaginatedTableService);
+  private router = inject(Router);
+
+  repositoryId = input.required({ transform: numberAttribute });
 
   queryOptions = computed(() => {
     const paginationState = this.paginationService.paginationState();
@@ -119,6 +123,12 @@ export class WorkflowRunsTableComponent {
   openRunExternal(event: Event, run: WorkflowRunDto) {
     window.open(run.htmlUrl, '_blank');
     event.stopPropagation();
+  }
+
+  navigateToRun(run: WorkflowRunDto) {
+    this.router.navigate(['/repo', this.repositoryId(), 'ci-cd', 'runs', run.id], {
+      state: { workflowRun: run },
+    });
   }
 
   getWorkflowStatusIcon(run: WorkflowRunDto): string {
@@ -189,5 +199,27 @@ export class WorkflowRunsTableComponent {
       return 'text-blue-500 animate-spin';
     }
     return 'text-surface-500';
+  }
+
+  formatExactDate(dateStr: string | null | undefined): string | undefined {
+    if (!dateStr) return undefined;
+    return new Date(dateStr).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }
+
+  getDuration(run: WorkflowRunDto): string {
+    if (!run.runStartedAt) return '—';
+    const start = new Date(run.runStartedAt).getTime();
+    const end = run.updatedAt ? new Date(run.updatedAt).getTime() : Date.now();
+    const seconds = Math.floor((end - start) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
   }
 }

--- a/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
+++ b/client/src/app/core/modules/openapi/@tanstack/angular-query-experimental.gen.ts
@@ -5,6 +5,7 @@ import { type InfiniteData, infiniteQueryOptions, type MutationOptions, queryOpt
 import { client } from '../client.gen';
 import {
   cancelDeployment,
+  cancelWorkflowRun,
   createReleaseCandidate,
   createTestType,
   createWorkflowGroup,
@@ -52,10 +53,12 @@ import {
   getPullRequests,
   getReleaseInfoByName,
   getRepositoryById,
+  getTestResultsByWorkflowRunId,
   getUserPermissions,
   getUserSettings,
   getWorkflowById,
   getWorkflowJobStatus,
+  getWorkflowRunById,
   getWorkflowRuns,
   getWorkflowsByRepositoryId,
   getWorkflowsByState,
@@ -63,6 +66,8 @@ import {
   lockEnvironment,
   type Options,
   publishReleaseDraft,
+  reRunFailedJobs,
+  reRunWorkflow,
   rotateSecret,
   setBranchPinnedByRepositoryIdAndNameAndUserId,
   setPrPinnedByNumber,
@@ -84,6 +89,8 @@ import type {
   CancelDeploymentData,
   CancelDeploymentError,
   CancelDeploymentResponse,
+  CancelWorkflowRunData,
+  CancelWorkflowRunError,
   CreateReleaseCandidateData,
   CreateReleaseCandidateError,
   CreateReleaseCandidateResponse,
@@ -159,10 +166,14 @@ import type {
   GetReleaseInfoByNameError,
   GetReleaseInfoByNameResponse,
   GetRepositoryByIdData,
+  GetTestResultsByWorkflowRunIdData,
+  GetTestResultsByWorkflowRunIdError,
+  GetTestResultsByWorkflowRunIdResponse,
   GetUserPermissionsData,
   GetUserSettingsData,
   GetWorkflowByIdData,
   GetWorkflowJobStatusData,
+  GetWorkflowRunByIdData,
   GetWorkflowRunsData,
   GetWorkflowRunsError,
   GetWorkflowRunsResponse,
@@ -174,6 +185,10 @@ import type {
   LockEnvironmentResponse,
   PublishReleaseDraftData,
   PublishReleaseDraftError,
+  ReRunFailedJobsData,
+  ReRunFailedJobsError,
+  ReRunWorkflowData,
+  ReRunWorkflowError,
   RotateSecretData,
   RotateSecretError,
   RotateSecretResponse,
@@ -443,6 +458,48 @@ export const extendEnvironmentLockMutation = (
   const mutationOptions: MutationOptions<ExtendEnvironmentLockResponse, ExtendEnvironmentLockError, Options<ExtendEnvironmentLockData>> = {
     mutationFn: async fnOptions => {
       const { data } = await extendEnvironmentLock({
+        ...options,
+        ...fnOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const reRunWorkflowMutation = (options?: Partial<Options<ReRunWorkflowData>>): MutationOptions<unknown, ReRunWorkflowError, Options<ReRunWorkflowData>> => {
+  const mutationOptions: MutationOptions<unknown, ReRunWorkflowError, Options<ReRunWorkflowData>> = {
+    mutationFn: async fnOptions => {
+      const { data } = await reRunWorkflow({
+        ...options,
+        ...fnOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const reRunFailedJobsMutation = (options?: Partial<Options<ReRunFailedJobsData>>): MutationOptions<unknown, ReRunFailedJobsError, Options<ReRunFailedJobsData>> => {
+  const mutationOptions: MutationOptions<unknown, ReRunFailedJobsError, Options<ReRunFailedJobsData>> = {
+    mutationFn: async fnOptions => {
+      const { data } = await reRunFailedJobs({
+        ...options,
+        ...fnOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const cancelWorkflowRunMutation = (options?: Partial<Options<CancelWorkflowRunData>>): MutationOptions<unknown, CancelWorkflowRunError, Options<CancelWorkflowRunData>> => {
+  const mutationOptions: MutationOptions<unknown, CancelWorkflowRunError, Options<CancelWorkflowRunData>> = {
+    mutationFn: async fnOptions => {
+      const { data } = await cancelWorkflowRun({
         ...options,
         ...fnOptions,
         throwOnError: true,
@@ -971,6 +1028,23 @@ export const getWorkflowRunsInfiniteOptions = (options?: Options<GetWorkflowRuns
   );
 };
 
+export const getWorkflowRunByIdQueryKey = (options: Options<GetWorkflowRunByIdData>) => createQueryKey('getWorkflowRunById', options);
+
+export const getWorkflowRunByIdOptions = (options: Options<GetWorkflowRunByIdData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getWorkflowRunById({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getWorkflowRunByIdQueryKey(options),
+  });
+};
+
 export const getWorkflowsByRepositoryIdQueryKey = (options: Options<GetWorkflowsByRepositoryIdData>) => createQueryKey('getWorkflowsByRepositoryId', options);
 
 export const getWorkflowsByRepositoryIdOptions = (options: Options<GetWorkflowsByRepositoryIdData>) => {
@@ -1039,6 +1113,60 @@ export const getUserPermissionsOptions = (options?: Options<GetUserPermissionsDa
     },
     queryKey: getUserPermissionsQueryKey(options),
   });
+};
+
+export const getTestResultsByWorkflowRunIdQueryKey = (options: Options<GetTestResultsByWorkflowRunIdData>) => createQueryKey('getTestResultsByWorkflowRunId', options);
+
+export const getTestResultsByWorkflowRunIdOptions = (options: Options<GetTestResultsByWorkflowRunIdData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getTestResultsByWorkflowRunId({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getTestResultsByWorkflowRunIdQueryKey(options),
+  });
+};
+
+export const getTestResultsByWorkflowRunIdInfiniteQueryKey = (options: Options<GetTestResultsByWorkflowRunIdData>): QueryKey<Options<GetTestResultsByWorkflowRunIdData>> =>
+  createQueryKey('getTestResultsByWorkflowRunId', options, true);
+
+export const getTestResultsByWorkflowRunIdInfiniteOptions = (options: Options<GetTestResultsByWorkflowRunIdData>) => {
+  return infiniteQueryOptions<
+    GetTestResultsByWorkflowRunIdResponse,
+    GetTestResultsByWorkflowRunIdError,
+    InfiniteData<GetTestResultsByWorkflowRunIdResponse>,
+    QueryKey<Options<GetTestResultsByWorkflowRunIdData>>,
+    number | Pick<QueryKey<Options<GetTestResultsByWorkflowRunIdData>>[0], 'body' | 'headers' | 'path' | 'query'>
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<QueryKey<Options<GetTestResultsByWorkflowRunIdData>>[0], 'body' | 'headers' | 'path' | 'query'> =
+          typeof pageParam === 'object'
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await getTestResultsByWorkflowRunId({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: getTestResultsByWorkflowRunIdInfiniteQueryKey(options),
+    }
+  );
 };
 
 export const getLatestTestResultsByPullRequestIdQueryKey = (options: Options<GetLatestTestResultsByPullRequestIdData>) =>

--- a/client/src/app/core/modules/openapi/sdk.gen.ts
+++ b/client/src/app/core/modules/openapi/sdk.gen.ts
@@ -6,6 +6,9 @@ import type {
   CancelDeploymentData,
   CancelDeploymentErrors,
   CancelDeploymentResponses,
+  CancelWorkflowRunData,
+  CancelWorkflowRunErrors,
+  CancelWorkflowRunResponses,
   CreateReleaseCandidateData,
   CreateReleaseCandidateErrors,
   CreateReleaseCandidateResponses,
@@ -147,6 +150,9 @@ import type {
   GetRepositoryByIdData,
   GetRepositoryByIdErrors,
   GetRepositoryByIdResponses,
+  GetTestResultsByWorkflowRunIdData,
+  GetTestResultsByWorkflowRunIdErrors,
+  GetTestResultsByWorkflowRunIdResponses,
   GetUserPermissionsData,
   GetUserPermissionsErrors,
   GetUserPermissionsResponses,
@@ -159,6 +165,9 @@ import type {
   GetWorkflowJobStatusData,
   GetWorkflowJobStatusErrors,
   GetWorkflowJobStatusResponses,
+  GetWorkflowRunByIdData,
+  GetWorkflowRunByIdErrors,
+  GetWorkflowRunByIdResponses,
   GetWorkflowRunsData,
   GetWorkflowRunsErrors,
   GetWorkflowRunsResponses,
@@ -177,6 +186,12 @@ import type {
   PublishReleaseDraftData,
   PublishReleaseDraftErrors,
   PublishReleaseDraftResponses,
+  ReRunFailedJobsData,
+  ReRunFailedJobsErrors,
+  ReRunFailedJobsResponses,
+  ReRunWorkflowData,
+  ReRunWorkflowErrors,
+  ReRunWorkflowResponses,
   RotateSecretData,
   RotateSecretErrors,
   RotateSecretResponses,
@@ -356,6 +371,27 @@ export const lockEnvironment = <ThrowOnError extends boolean = false>(options: O
 export const extendEnvironmentLock = <ThrowOnError extends boolean = false>(options: Options<ExtendEnvironmentLockData, ThrowOnError>) => {
   return (options.client ?? client).put<ExtendEnvironmentLockResponses, ExtendEnvironmentLockErrors, ThrowOnError>({
     url: '/api/environments/{id}/extend-lock',
+    ...options,
+  });
+};
+
+export const reRunWorkflow = <ThrowOnError extends boolean = false>(options: Options<ReRunWorkflowData, ThrowOnError>) => {
+  return (options.client ?? client).post<ReRunWorkflowResponses, ReRunWorkflowErrors, ThrowOnError>({
+    url: '/api/workflows/runs/{runId}/rerun',
+    ...options,
+  });
+};
+
+export const reRunFailedJobs = <ThrowOnError extends boolean = false>(options: Options<ReRunFailedJobsData, ThrowOnError>) => {
+  return (options.client ?? client).post<ReRunFailedJobsResponses, ReRunFailedJobsErrors, ThrowOnError>({
+    url: '/api/workflows/runs/{runId}/rerun-failed-jobs',
+    ...options,
+  });
+};
+
+export const cancelWorkflowRun = <ThrowOnError extends boolean = false>(options: Options<CancelWorkflowRunData, ThrowOnError>) => {
+  return (options.client ?? client).post<CancelWorkflowRunResponses, CancelWorkflowRunErrors, ThrowOnError>({
+    url: '/api/workflows/runs/{runId}/cancel',
     ...options,
   });
 };
@@ -614,6 +650,13 @@ export const getWorkflowRuns = <ThrowOnError extends boolean = false>(options?: 
   });
 };
 
+export const getWorkflowRunById = <ThrowOnError extends boolean = false>(options: Options<GetWorkflowRunByIdData, ThrowOnError>) => {
+  return (options.client ?? client).get<GetWorkflowRunByIdResponses, GetWorkflowRunByIdErrors, ThrowOnError>({
+    url: '/api/workflows/runs/{runId}',
+    ...options,
+  });
+};
+
 export const getWorkflowsByRepositoryId = <ThrowOnError extends boolean = false>(options: Options<GetWorkflowsByRepositoryIdData, ThrowOnError>) => {
   return (options.client ?? client).get<GetWorkflowsByRepositoryIdResponses, GetWorkflowsByRepositoryIdErrors, ThrowOnError>({
     url: '/api/workflows/repository/{repositoryId}',
@@ -642,6 +685,13 @@ export const getLatestWorkflowRunsByBranchAndHeadCommit = <ThrowOnError extends 
 export const getUserPermissions = <ThrowOnError extends boolean = false>(options?: Options<GetUserPermissionsData, ThrowOnError>) => {
   return (options?.client ?? client).get<GetUserPermissionsResponses, GetUserPermissionsErrors, ThrowOnError>({
     url: '/api/user-permissions',
+    ...options,
+  });
+};
+
+export const getTestResultsByWorkflowRunId = <ThrowOnError extends boolean = false>(options: Options<GetTestResultsByWorkflowRunIdData, ThrowOnError>) => {
+  return (options.client ?? client).get<GetTestResultsByWorkflowRunIdResponses, GetTestResultsByWorkflowRunIdErrors, ThrowOnError>({
+    url: '/api/tests/run/{workflowRunId}',
     ...options,
   });
 };

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -924,6 +924,81 @@ export type ExtendEnvironmentLockResponses = {
 
 export type ExtendEnvironmentLockResponse = ExtendEnvironmentLockResponses[keyof ExtendEnvironmentLockResponses];
 
+export type ReRunWorkflowData = {
+  body?: never;
+  path: {
+    runId: number;
+  };
+  query?: never;
+  url: '/api/workflows/runs/{runId}/rerun';
+};
+
+export type ReRunWorkflowErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type ReRunWorkflowError = ReRunWorkflowErrors[keyof ReRunWorkflowErrors];
+
+export type ReRunWorkflowResponses = {
+  /**
+   * OK
+   */
+  200: unknown;
+};
+
+export type ReRunFailedJobsData = {
+  body?: never;
+  path: {
+    runId: number;
+  };
+  query?: never;
+  url: '/api/workflows/runs/{runId}/rerun-failed-jobs';
+};
+
+export type ReRunFailedJobsErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type ReRunFailedJobsError = ReRunFailedJobsErrors[keyof ReRunFailedJobsErrors];
+
+export type ReRunFailedJobsResponses = {
+  /**
+   * OK
+   */
+  200: unknown;
+};
+
+export type CancelWorkflowRunData = {
+  body?: never;
+  path: {
+    runId: number;
+  };
+  query?: never;
+  url: '/api/workflows/runs/{runId}/cancel';
+};
+
+export type CancelWorkflowRunErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type CancelWorkflowRunError = CancelWorkflowRunErrors[keyof CancelWorkflowRunErrors];
+
+export type CancelWorkflowRunResponses = {
+  /**
+   * OK
+   */
+  200: unknown;
+};
+
 export type SyncWorkflowsByRepositoryIdData = {
   body?: never;
   path: {
@@ -1636,6 +1711,33 @@ export type GetWorkflowRunsResponses = {
 
 export type GetWorkflowRunsResponse = GetWorkflowRunsResponses[keyof GetWorkflowRunsResponses];
 
+export type GetWorkflowRunByIdData = {
+  body?: never;
+  path: {
+    runId: number;
+  };
+  query?: never;
+  url: '/api/workflows/runs/{runId}';
+};
+
+export type GetWorkflowRunByIdErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type GetWorkflowRunByIdError = GetWorkflowRunByIdErrors[keyof GetWorkflowRunByIdErrors];
+
+export type GetWorkflowRunByIdResponses = {
+  /**
+   * OK
+   */
+  200: WorkflowRunDto;
+};
+
+export type GetWorkflowRunByIdResponse = GetWorkflowRunByIdResponses[keyof GetWorkflowRunByIdResponses];
+
 export type GetWorkflowsByRepositoryIdData = {
   body?: never;
   path: {
@@ -1743,6 +1845,38 @@ export type GetUserPermissionsResponses = {
 };
 
 export type GetUserPermissionsResponse = GetUserPermissionsResponses[keyof GetUserPermissionsResponses];
+
+export type GetTestResultsByWorkflowRunIdData = {
+  body?: never;
+  path: {
+    workflowRunId: number;
+  };
+  query?: {
+    page?: number;
+    size?: number;
+    search?: string;
+    onlyFailed?: boolean;
+  };
+  url: '/api/tests/run/{workflowRunId}';
+};
+
+export type GetTestResultsByWorkflowRunIdErrors = {
+  /**
+   * Conflict
+   */
+  409: ApiError;
+};
+
+export type GetTestResultsByWorkflowRunIdError = GetTestResultsByWorkflowRunIdErrors[keyof GetTestResultsByWorkflowRunIdErrors];
+
+export type GetTestResultsByWorkflowRunIdResponses = {
+  /**
+   * OK
+   */
+  200: TestResultsDto;
+};
+
+export type GetTestResultsByWorkflowRunIdResponse = GetTestResultsByWorkflowRunIdResponses[keyof GetTestResultsByWorkflowRunIdResponses];
 
 export type GetLatestTestResultsByPullRequestIdData = {
   body?: never;

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.html
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.html
@@ -1,0 +1,91 @@
+<p-toast />
+<div class="mt-4 mb-5 flex flex-col gap-4">
+  <a [routerLink]="['/repo', repositoryId(), 'ci-cd', 'runs']" class="flex items-center gap-2 text-muted-color hover:underline cursor-pointer w-fit">
+    <i-tabler name="arrow-left" class="!size-5" />
+    <span class="text-sm">Back to Workflow Runs</span>
+  </a>
+
+  @if (runQuery.isPending()) {
+    <div class="flex flex-col gap-3">
+      <p-skeleton height="2rem" width="16rem" />
+      <p-skeleton height="1.25rem" width="12rem" />
+      <p-skeleton height="1rem" width="10rem" />
+    </div>
+  } @else if (runQuery.isError()) {
+    <div class="flex flex-col gap-2 p-4 rounded-lg bg-surface-100 dark:bg-surface-800">
+      <p class="text-muted-color">Could not load workflow run #{{ runId() }}.</p>
+      <a [routerLink]="['/repo', repositoryId(), 'ci-cd', 'runs']" class="text-primary hover:underline">Back to Workflow Runs</a>
+    </div>
+  } @else if (run(); as runData) {
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-wrap items-start justify-between gap-4">
+        <div class="flex flex-col gap-2">
+          <h2 class="text-2xl font-bold">{{ runData.displayTitle || runData.name }}</h2>
+          <div class="flex flex-wrap items-center gap-2">
+            <div class="flex items-center gap-2">
+              <i-tabler [name]="getWorkflowStatusIcon(runData)" [class]="getWorkflowStatusClass(runData)" class="!size-5" [pTooltip]="runData.conclusion || runData.status" />
+              <span class="text-sm font-medium">{{ runData.conclusion || runData.status }}</span>
+            </div>
+            <p-tag [value]="runData.label === 'TEST' ? 'Test' : 'General'" [severity]="runData.label === 'TEST' ? 'info' : 'secondary'" rounded class="text-xs" />
+          </div>
+          @if (runData.headBranch || runData.headSha) {
+            <div class="flex flex-wrap items-center gap-2 text-sm text-muted-color">
+              @if (runData.headBranch) {
+                <span>Branch: {{ runData.headBranch }}</span>
+              }
+              @if (runData.headSha) {
+                <span class="font-mono">({{ runData.headSha.slice(0, 7) }})</span>
+              }
+            </div>
+          }
+          @if (runData.testProcessingStatus) {
+            <div class="flex items-center gap-2 text-sm text-muted-color">
+              <span>Test Processing:</span>
+              <span class="font-medium text-foreground">{{ runData.testProcessingStatus }}</span>
+            </div>
+          }
+          <div class="flex flex-wrap items-center gap-4 text-sm text-muted-color">
+            @if (runData.runStartedAt) {
+              <span [pTooltip]="formatExactDate(runData.runStartedAt)" tooltipPosition="top">Started {{ runData.runStartedAt | timeAgo }}</span>
+            }
+            <span>Duration: {{ getDuration(runData) }}</span>
+          </div>
+        </div>
+        <div class="flex flex-wrap items-center gap-2">
+          @if (permissions.hasWritePermission()) {
+            @if (isRunActive()) {
+              <p-button (click)="onCancel()" label="Cancel" severity="danger" [disabled]="cancelMutation.isPending()" pTooltip="Cancel this workflow run">
+                <i-tabler name="x" class="!size-4" />
+              </p-button>
+            }
+            @if (isRunCompleted()) {
+              @if (canReRunFailed()) {
+                <p-button (click)="onReRunFailed()" label="Re-run Failed" severity="secondary" [disabled]="reRunFailedMutation.isPending()" pTooltip="Re-run only the failed jobs">
+                  <i-tabler name="refresh" class="!size-4" />
+                </p-button>
+              }
+              <p-button (click)="onReRun()" label="Re-run All" severity="secondary" [disabled]="reRunMutation.isPending()" pTooltip="Re-run all jobs in this workflow">
+                <i-tabler name="player-play" class="!size-4" />
+              </p-button>
+            }
+          }
+          <p-button (click)="openRunExternal()" label="Open on GitHub">
+            <i-tabler name="brand-github" class="!size-4" />
+          </p-button>
+        </div>
+      </div>
+    </div>
+  }
+</div>
+
+<div class="flex flex-col gap-6">
+  @if (permissions.hasWritePermission()) {
+    <div>
+      <p-divider />
+      <h3 class="text-xl mb-3">Jobs</h3>
+      <app-workflow-job-list [jobs]="jobs()" [isPending]="workflowJobsQuery.isPending()" [isError]="workflowJobsQuery.isError()" />
+    </div>
+  }
+
+  <app-pipeline-test-results [selector]="pipelineSelector()" />
+</div>

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.spec.ts
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter } from '@angular/router';
+import { provideQueryClient, QueryClient } from '@tanstack/angular-query-experimental';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { WorkflowRunDetailsComponent } from './workflow-run-details.component';
+import { PermissionService } from '@app/core/services/permission.service';
+import type { WorkflowRunDto, WorkflowJobDto } from '@app/core/modules/openapi';
+
+function createRun(overrides: Partial<WorkflowRunDto> = {}): WorkflowRunDto {
+  return {
+    id: 1,
+    name: 'CI',
+    displayTitle: 'CI',
+    status: 'COMPLETED',
+    workflowId: 10,
+    htmlUrl: 'https://github.com/org/repo/actions/runs/1',
+    label: 'TEST',
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:01:00Z',
+    ...overrides,
+  };
+}
+
+describe('WorkflowRunDetailsComponent', () => {
+  let component: WorkflowRunDetailsComponent;
+  let fixture: ComponentFixture<WorkflowRunDetailsComponent>;
+
+  const permissionServiceMock = {
+    hasWritePermission: () => true,
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WorkflowRunDetailsComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideQueryClient(new QueryClient()),
+        provideNoopAnimations(),
+        { provide: PermissionService, useValue: permissionServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WorkflowRunDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('repositoryId', 1);
+    fixture.componentRef.setInput('runId', 1);
+
+    const run = createRun({ id: 1 });
+    const jobs: WorkflowJobDto[] = [
+      {
+        id: 11,
+        name: 'build',
+        status: 'completed',
+        conclusion: 'success',
+      },
+    ];
+
+    Object.defineProperty(component, 'runQuery', {
+      configurable: true,
+      value: {
+        data: () => run,
+        isPending: () => false,
+        isError: () => false,
+      },
+    });
+
+    Object.defineProperty(component, 'workflowJobsQuery', {
+      configurable: true,
+      value: {
+        data: () => ({ jobs }),
+        isPending: () => false,
+        isError: () => false,
+      },
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders workflow job list section', () => {
+    const hostElement: HTMLElement = fixture.nativeElement;
+    const jobList = hostElement.querySelector('app-workflow-job-list');
+    expect(jobList).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
@@ -1,0 +1,222 @@
+import { Component, computed, inject, input, numberAttribute } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { WorkflowJobDto, WorkflowRunDto } from '@app/core/modules/openapi';
+import {
+  cancelWorkflowRunMutation,
+  getWorkflowJobStatusOptions,
+  getWorkflowJobStatusQueryKey,
+  getWorkflowRunByIdOptions,
+  reRunWorkflowMutation,
+  reRunFailedJobsMutation,
+} from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { PermissionService } from '@app/core/services/permission.service';
+import { WorkflowJobListComponent } from '@app/components/workflow-job-list/workflow-job-list.component';
+import { PipelineTestResultsComponent } from '@app/components/pipeline/test-results/pipeline-test-results.component';
+import { PipelineSelector } from '@app/components/pipeline/pipeline.component';
+import { injectMutation, injectQuery } from '@tanstack/angular-query-experimental';
+import { MessageService } from 'primeng/api';
+import { TagModule } from 'primeng/tag';
+import { ButtonModule } from 'primeng/button';
+import { DividerModule } from 'primeng/divider';
+import { ToastModule } from 'primeng/toast';
+import { SkeletonModule } from 'primeng/skeleton';
+import { TimeAgoPipe } from '@app/pipes/time-ago.pipe';
+import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
+import {
+  IconArrowLeft,
+  IconBrandGithub,
+  IconCircleCheck,
+  IconCircleX,
+  IconClockHour4,
+  IconProgress,
+  IconAlertTriangle,
+  IconPlayerPlay,
+  IconRefresh,
+  IconX,
+} from 'angular-tabler-icons/icons';
+import { TooltipModule } from 'primeng/tooltip';
+
+@Component({
+  selector: 'app-workflow-run-details',
+  standalone: true,
+  imports: [
+    RouterLink,
+    TagModule,
+    ButtonModule,
+    DividerModule,
+    ToastModule,
+    SkeletonModule,
+    TimeAgoPipe,
+    TablerIconComponent,
+    TooltipModule,
+    WorkflowJobListComponent,
+    PipelineTestResultsComponent,
+  ],
+  providers: [
+    MessageService,
+    provideTablerIcons({
+      IconArrowLeft,
+      IconBrandGithub,
+      IconCircleCheck,
+      IconCircleX,
+      IconClockHour4,
+      IconProgress,
+      IconAlertTriangle,
+      IconPlayerPlay,
+      IconRefresh,
+      IconX,
+    }),
+  ],
+  templateUrl: './workflow-run-details.component.html',
+})
+export class WorkflowRunDetailsComponent {
+  repositoryId = input.required({ transform: numberAttribute });
+  runId = input.required({ transform: numberAttribute });
+
+  protected permissions = inject(PermissionService);
+  private messageService = inject(MessageService);
+
+  runQuery = injectQuery(() => ({
+    ...getWorkflowRunByIdOptions({ path: { runId: this.runId() } }),
+    refetchInterval: query => {
+      const data = query.state?.data;
+      const activeStatuses = ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'];
+      return data && activeStatuses.includes(data.status) ? 5000 : 0;
+    },
+    staleTime: 0,
+  }));
+
+  run = computed(() => this.runQuery.data() ?? null);
+
+  pipelineSelector = computed<PipelineSelector | null>(() => {
+    const r = this.run();
+    if (!r || r.label !== 'TEST') return null;
+    return { repositoryId: this.repositoryId(), workflowRunId: this.runId() };
+  });
+
+  workflowJobsQuery = injectQuery(() => ({
+    ...getWorkflowJobStatusOptions({ path: { runId: this.runId() } }),
+    queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.runId() } }),
+    enabled: this.permissions.hasWritePermission(),
+    refetchInterval: query => {
+      const data = query.state?.data as { jobs?: WorkflowJobDto[] } | undefined;
+      const inProgress = (data?.jobs ?? []).some(j => j.status === 'in_progress' || j.status === 'queued' || j.status === 'waiting');
+      return inProgress ? 5000 : 0;
+    },
+    staleTime: 0,
+  }));
+
+  jobs = computed<WorkflowJobDto[]>(() => {
+    const response = this.workflowJobsQuery.data();
+    if (!response || !response.jobs) return [];
+    return response.jobs;
+  });
+
+  reRunMutation = injectMutation(() => ({
+    ...reRunWorkflowMutation(),
+    onSuccess: () => {
+      this.messageService.add({ severity: 'success', summary: 'Re-run triggered', detail: 'All jobs have been queued for re-run.' });
+    },
+    onError: () => {
+      this.messageService.add({ severity: 'error', summary: 'Re-run failed', detail: 'Could not trigger re-run. Please try again.' });
+    },
+  }));
+
+  reRunFailedMutation = injectMutation(() => ({
+    ...reRunFailedJobsMutation(),
+    onSuccess: () => {
+      this.messageService.add({ severity: 'success', summary: 'Re-run triggered', detail: 'Failed jobs have been queued for re-run.' });
+    },
+    onError: () => {
+      this.messageService.add({ severity: 'error', summary: 'Re-run failed', detail: 'Could not trigger re-run of failed jobs. Please try again.' });
+    },
+  }));
+
+  cancelMutation = injectMutation(() => ({
+    ...cancelWorkflowRunMutation(),
+    onSuccess: () => {
+      this.messageService.add({ severity: 'success', summary: 'Cancellation requested', detail: 'The workflow run has been requested to cancel.' });
+    },
+    onError: () => {
+      this.messageService.add({ severity: 'error', summary: 'Cancellation failed', detail: 'Could not cancel the workflow run. Please try again.' });
+    },
+  }));
+
+  canReRunFailed = computed(() => {
+    const r = this.run();
+    return ['FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT'].includes(r?.conclusion ?? '');
+  });
+
+  isRunCompleted = computed(() => {
+    const r = this.run();
+    return r?.conclusion != null;
+  });
+
+  isRunActive = computed(() => {
+    const r = this.run();
+    return ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'].includes(r?.status ?? '');
+  });
+
+  onReRun(): void {
+    this.reRunMutation.mutate({ path: { runId: this.runId() } });
+  }
+
+  onReRunFailed(): void {
+    this.reRunFailedMutation.mutate({ path: { runId: this.runId() } });
+  }
+
+  onCancel(): void {
+    this.cancelMutation.mutate({ path: { runId: this.runId() } });
+  }
+
+  formatExactDate(dateStr: string | null | undefined): string | undefined {
+    if (!dateStr) return undefined;
+    return new Date(dateStr).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }
+
+  getDuration(run: WorkflowRunDto | null): string {
+    if (!run?.runStartedAt) return '—';
+    const start = new Date(run.runStartedAt).getTime();
+    const end = run.updatedAt ? new Date(run.updatedAt).getTime() : Date.now();
+    const seconds = Math.floor((end - start) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+    return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+  }
+
+  openRunExternal(): void {
+    const r = this.run();
+    if (r?.htmlUrl) {
+      window.open(r.htmlUrl, '_blank');
+    }
+  }
+
+  getWorkflowStatusIcon(run: WorkflowRunDto | null): string {
+    if (!run) return 'help';
+    if (run.conclusion === 'SUCCESS') return 'circle-check';
+    if (['FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT'].includes(run.conclusion ?? '')) return 'circle-x';
+    if (run.conclusion === 'CANCELLED') return 'circle-x';
+    if (run.status === 'IN_PROGRESS') return 'progress';
+    if (['QUEUED', 'WAITING', 'PENDING', 'REQUESTED'].includes(run.status)) return 'clock-hour-4';
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') return 'alert-triangle';
+    return 'circle-x';
+  }
+
+  getWorkflowStatusClass(run: WorkflowRunDto | null): string {
+    if (!run) return 'text-surface-500';
+    if (run.conclusion === 'SUCCESS') return 'text-green-500';
+    if (['FAILURE', 'STARTUP_FAILURE', 'TIMED_OUT'].includes(run.conclusion ?? '')) return 'text-red-500';
+    if (run.conclusion === 'CANCELLED') return 'text-surface-500';
+    if (run.status === 'IN_PROGRESS') return 'text-blue-500 animate-spin';
+    if (['QUEUED', 'WAITING', 'PENDING', 'REQUESTED'].includes(run.status)) return 'text-amber-500';
+    if (run.status === 'ACTION_REQUIRED' || run.conclusion === 'ACTION_REQUIRED') return 'text-orange-500';
+    return 'text-surface-500';
+  }
+}

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, numberAttribute } from '@angular/core';
+import { Component, computed, inject, input, numberAttribute, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { WorkflowJobDto, WorkflowRunDto } from '@app/core/modules/openapi';
 import {
@@ -6,6 +6,7 @@ import {
   getWorkflowJobStatusOptions,
   getWorkflowJobStatusQueryKey,
   getWorkflowRunByIdOptions,
+  getWorkflowRunByIdQueryKey,
   reRunWorkflowMutation,
   reRunFailedJobsMutation,
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
@@ -13,7 +14,7 @@ import { PermissionService } from '@app/core/services/permission.service';
 import { WorkflowJobListComponent } from '@app/components/workflow-job-list/workflow-job-list.component';
 import { PipelineTestResultsComponent } from '@app/components/pipeline/test-results/pipeline-test-results.component';
 import { PipelineSelector } from '@app/components/pipeline/pipeline.component';
-import { injectMutation, injectQuery } from '@tanstack/angular-query-experimental';
+import { injectMutation, injectQuery, QueryClient } from '@tanstack/angular-query-experimental';
 import { MessageService } from 'primeng/api';
 import { TagModule } from 'primeng/tag';
 import { ButtonModule } from 'primeng/button';
@@ -75,16 +76,28 @@ export class WorkflowRunDetailsComponent {
 
   protected permissions = inject(PermissionService);
   private messageService = inject(MessageService);
+  private queryClient = inject(QueryClient);
 
-  runQuery = injectQuery(() => ({
-    ...getWorkflowRunByIdOptions({ path: { runId: this.runId() } }),
-    refetchInterval: query => {
-      const data = query.state?.data;
-      const activeStatuses = ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'];
-      return data && activeStatuses.includes(data.status) ? 5000 : 0;
-    },
-    staleTime: 0,
-  }));
+  // Duration to continue polling after a user action (cancel/rerun) to ensure UI updates promptly.
+  private readonly FORCED_POLL_DURATION_MS = 2 * 60 * 1000;
+
+  // Timestamp set when a user action (cancel/rerun) is triggered.
+  private actionTriggeredAt = signal<number | null>(null);
+
+  runQuery = injectQuery(() => {
+    const actionAt = this.actionTriggeredAt();
+    return {
+      ...getWorkflowRunByIdOptions({ path: { runId: this.runId() } }),
+      refetchInterval: (query: { state?: { data?: WorkflowRunDto } }) => {
+        const data = query.state?.data;
+        const activeStatuses = ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'];
+        if (data && activeStatuses.includes(data.status)) return 5000;
+        if (actionAt !== null && Date.now() - actionAt < this.FORCED_POLL_DURATION_MS) return 5000;
+        return 0;
+      },
+      staleTime: 0,
+    };
+  });
 
   run = computed(() => this.runQuery.data() ?? null);
 
@@ -94,17 +107,22 @@ export class WorkflowRunDetailsComponent {
     return { repositoryId: this.repositoryId(), workflowRunId: this.runId() };
   });
 
-  workflowJobsQuery = injectQuery(() => ({
-    ...getWorkflowJobStatusOptions({ path: { runId: this.runId() } }),
-    queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.runId() } }),
-    enabled: this.permissions.hasWritePermission(),
-    refetchInterval: query => {
-      const data = query.state?.data as { jobs?: WorkflowJobDto[] } | undefined;
-      const inProgress = (data?.jobs ?? []).some(j => j.status === 'in_progress' || j.status === 'queued' || j.status === 'waiting');
-      return inProgress ? 5000 : 0;
-    },
-    staleTime: 0,
-  }));
+  workflowJobsQuery = injectQuery(() => {
+    const actionAt = this.actionTriggeredAt();
+    return {
+      ...getWorkflowJobStatusOptions({ path: { runId: this.runId() } }),
+      queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.runId() } }),
+      enabled: this.permissions.hasWritePermission(),
+      refetchInterval: (query: { state?: { data?: { jobs?: WorkflowJobDto[] } } }) => {
+        const data = query.state?.data;
+        const inProgress = (data?.jobs ?? []).some(j => j.status === 'in_progress' || j.status === 'queued' || j.status === 'waiting');
+        if (inProgress) return 5000;
+        if (actionAt !== null && Date.now() - actionAt < this.FORCED_POLL_DURATION_MS) return 5000;
+        return 0;
+      },
+      staleTime: 0,
+    };
+  });
 
   jobs = computed<WorkflowJobDto[]>(() => {
     const response = this.workflowJobsQuery.data();
@@ -116,6 +134,7 @@ export class WorkflowRunDetailsComponent {
     ...reRunWorkflowMutation(),
     onSuccess: () => {
       this.messageService.add({ severity: 'success', summary: 'Re-run triggered', detail: 'All jobs have been queued for re-run.' });
+      this.invalidateRunQueries();
     },
     onError: () => {
       this.messageService.add({ severity: 'error', summary: 'Re-run failed', detail: 'Could not trigger re-run. Please try again.' });
@@ -126,6 +145,7 @@ export class WorkflowRunDetailsComponent {
     ...reRunFailedJobsMutation(),
     onSuccess: () => {
       this.messageService.add({ severity: 'success', summary: 'Re-run triggered', detail: 'Failed jobs have been queued for re-run.' });
+      this.invalidateRunQueries();
     },
     onError: () => {
       this.messageService.add({ severity: 'error', summary: 'Re-run failed', detail: 'Could not trigger re-run of failed jobs. Please try again.' });
@@ -136,11 +156,20 @@ export class WorkflowRunDetailsComponent {
     ...cancelWorkflowRunMutation(),
     onSuccess: () => {
       this.messageService.add({ severity: 'success', summary: 'Cancellation requested', detail: 'The workflow run has been requested to cancel.' });
+      this.invalidateRunQueries();
     },
     onError: () => {
       this.messageService.add({ severity: 'error', summary: 'Cancellation failed', detail: 'Could not cancel the workflow run. Please try again.' });
     },
   }));
+
+  private invalidateRunQueries(): void {
+    const runId = this.runId();
+    // Set the timestamp to trigger more frequent polling for a short duration to ensure UI updates promptly after user actions.
+    this.actionTriggeredAt.set(Date.now());
+    this.queryClient.invalidateQueries({ queryKey: getWorkflowRunByIdQueryKey({ path: { runId } }) });
+    this.queryClient.invalidateQueries({ queryKey: getWorkflowJobStatusQueryKey({ path: { runId } }) });
+  }
 
   canReRunFailed = computed(() => {
     const r = this.run();

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.html
@@ -1,1 +1,1 @@
-<app-workflow-runs-table />
+<app-workflow-runs-table [repositoryId]="repositoryId()" />

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.spec.ts
@@ -16,6 +16,7 @@ describe('Integration Test Workflow Run List Page', () => {
 
     fixture = TestBed.createComponent(WorkflowRunListComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('repositoryId', 1);
 
     await fixture.whenStable();
   });

--- a/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
+++ b/client/src/app/pages/workflow-run-list/workflow-run-list.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, input, numberAttribute } from '@angular/core';
 import { WorkflowRunsTableComponent } from '@app/components/workflow-runs-table/workflow-runs-table.component';
 
 @Component({
@@ -7,4 +7,6 @@ import { WorkflowRunsTableComponent } from '@app/components/workflow-runs-table/
   imports: [WorkflowRunsTableComponent],
   templateUrl: './workflow-run-list.component.html',
 })
-export class WorkflowRunListComponent {}
+export class WorkflowRunListComponent {
+  repositoryId = input.required({ transform: numberAttribute });
+}

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -348,6 +348,69 @@ paths:
             application/json:
               schema:
                 type: object
+  /api/workflows/runs/{runId}/rerun:
+    post:
+      tags:
+      - workflow-run-controller
+      operationId: reRunWorkflow
+      parameters:
+      - name: runId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+  /api/workflows/runs/{runId}/rerun-failed-jobs:
+    post:
+      tags:
+      - workflow-run-controller
+      operationId: reRunFailedJobs
+      parameters:
+      - name: runId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+  /api/workflows/runs/{runId}/cancel:
+    post:
+      tags:
+      - workflow-run-controller
+      operationId: cancelWorkflowRun
+      parameters:
+      - name: runId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
   /api/workflows/repository/{repositoryId}/sync:
     post:
       tags:
@@ -1024,6 +1087,31 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PaginatedWorkflowRunsResponse"
+  /api/workflows/runs/{runId}:
+    get:
+      tags:
+      - workflow-run-controller
+      operationId: getWorkflowRunById
+      parameters:
+      - name: runId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowRunDto"
   /api/workflows/repository/{repositoryId}:
     get:
       tags:
@@ -1122,6 +1210,56 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GitHubRepositoryRoleDto"
+  /api/tests/run/{workflowRunId}:
+    get:
+      tags:
+      - test-result-controller
+      operationId: getTestResultsByWorkflowRunId
+      parameters:
+      - name: workflowRunId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 10
+      - name: search
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: onlyFailed
+        in: query
+        required: false
+        schema:
+          type: boolean
+          default: false
+      responses:
+        "409":
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestResultsDto"
   /api/tests/pr/{pullRequestId}:
     get:
       tags:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -728,21 +728,7 @@ public class GitHubService {
 
     try (Response response = okHttpClient.newCall(request).execute()) {
       if (!response.isSuccessful()) {
-        String errorBody = "No error details";
-        ResponseBody responseBody = response.body();
-        if (responseBody != null) {
-          try {
-            errorBody = responseBody.string();
-          } catch (IOException e) {
-            log.warn("Failed to read error response body", e);
-          }
-        }
-
-        log.error(
-            "GitHub API call failed to fetch workflow jobs with response code: {} and body: {}",
-            response.code(),
-            errorBody);
-        throw new IOException("GitHub API call failed with response code: " + response.code());
+        handleErrorResponse(response, "fetch workflow jobs for run " + runId);
       }
 
       ResponseBody responseBody = response.body();
@@ -764,9 +750,60 @@ public class GitHubService {
    * @throws IOException if an I/O error occurs during the API call
    */
   public void cancelWorkflowRun(String repoNameWithOwner, long runId) throws IOException {
+    executeWorkflowRunAction(
+        repoNameWithOwner,
+        runId,
+        "cancel",
+        "Successfully sent cancellation request for workflow run ID: {}"
+    );
+  }
+
+  /**
+   * Re-runs all jobs in a GitHub workflow run.
+   *
+   * @param repoNameWithOwner Repository in format "owner/repo"
+   * @param runId Workflow run ID to re-run
+   * @throws IOException if an I/O error occurs during the API call
+   */
+  public void reRunWorkflow(String repoNameWithOwner, long runId) throws IOException {
+    executeWorkflowRunAction(
+        repoNameWithOwner,
+        runId,
+        "rerun",
+        "Successfully sent re-run request for workflow run ID: {}");
+  }
+
+  /**
+   * Re-runs only the failed jobs in a GitHub workflow run.
+   *
+   * @param repoNameWithOwner Repository in format "owner/repo"
+   * @param runId Workflow run ID whose failed jobs to re-run
+   * @throws IOException if an I/O error occurs during the API call
+   */
+  public void reRunFailedJobs(String repoNameWithOwner, long runId) throws IOException {
+    executeWorkflowRunAction(
+        repoNameWithOwner,
+        runId,
+        "rerun-failed-jobs",
+        "Successfully sent re-run failed jobs request for workflow run ID: {}");
+  }
+
+  /**
+   * Sends an empty POST to a GitHub Actions workflow run sub-resource (e.g. cancel, rerun).
+   *
+   * @param repoNameWithOwner Repository in format "owner/repo"
+   * @param runId Workflow run ID
+   * @param pathSuffix URL suffix appended after the run ID (e.g. "cancel", "rerun")
+   * @param successMessage Log message on success; must contain one {} placeholder for the run ID
+   * @throws IOException if the API call fails
+   */
+  private void executeWorkflowRunAction(
+      String repoNameWithOwner, long runId, String pathSuffix, String successMessage)
+      throws IOException {
     String url =
         String.format(
-            "https://api.github.com/repos/%s/actions/runs/%d/cancel", repoNameWithOwner, runId);
+            "https://api.github.com/repos/%s/actions/runs/%d/%s",
+            repoNameWithOwner, runId, pathSuffix);
 
     Request request =
         getRequestBuilder()
@@ -776,23 +813,9 @@ public class GitHubService {
 
     try (Response response = okHttpClient.newCall(request).execute()) {
       if (!response.isSuccessful()) {
-        String errorBody = "No error details";
-        ResponseBody responseBody = response.body();
-        if (responseBody != null) {
-          try {
-            errorBody = responseBody.string();
-          } catch (IOException e) {
-            log.warn("Failed to read error response body", e);
-          }
-        }
-
-        log.error(
-            "GitHub API call failed to cancel workflow run with response code: {} and body: {}",
-            response.code(),
-            errorBody);
-        throw new IOException("GitHub API call failed with response code: " + response.code());
+        handleErrorResponse(response, pathSuffix + " for run " + runId);
       }
-      log.info("Successfully sent cancellation request for workflow run ID: {}", runId);
+      log.info(successMessage, runId);
     }
   }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultController.java
@@ -62,6 +62,25 @@ public class TestResultController {
   }
 
   /**
+   * Get the test results for a specific workflow run.
+   *
+   * @param workflowRunId the workflow run ID
+   * @return the grouped test results
+   */
+  @GetMapping("/run/{workflowRunId}")
+  public ResponseEntity<TestResultsDto> getTestResultsByWorkflowRunId(
+      @PathVariable Long workflowRunId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) String search,
+      @RequestParam(defaultValue = "false") boolean onlyFailed) {
+    return ResponseEntity.ok(
+        testResultService.getTestResultsForWorkflowRun(
+            workflowRunId,
+            new TestResultService.TestSearchCriteria(page, size, search, onlyFailed)));
+  }
+
+  /**
    * Look up historical flakiness scores for a list of test cases.
    * Authenticated via repository shared secret.
    * Designed for CI pipelines (e.g. GitHub Actions)

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -10,6 +10,7 @@ import de.tum.cit.aet.helios.tests.TestResultsDto.TestTypeResults;
 import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -209,6 +210,52 @@ public class TestResultService {
     var context =
         new TestRunContext(
             latestRuns,
+            previousRuns,
+            defaultContext.defaultBranchName(),
+            defaultContext.defaultWorkflowRunByTestType());
+
+    return processTestResults(context, criteria);
+  }
+
+  /**
+   * Get the test results for a specific workflow run.
+   *
+   * @param workflowRunId the workflow run ID
+   * @param criteria search and pagination criteria
+   * @return the grouped test results
+   */
+  public TestResultsDto getTestResultsForWorkflowRun(
+      Long workflowRunId, TestSearchCriteria criteria) {
+    final Long repositoryId = RepositoryContext.getRepositoryId();
+    var run =
+        workflowRunRepository
+            .findByIdAndRepositoryRepositoryId(workflowRunId, repositoryId)
+            .orElseThrow(() -> new EntityNotFoundException(
+                "Workflow run with id %d not found".formatted(workflowRunId)));
+
+    var defaultContext = getDefaultBranchContext(run.getRepository());
+
+    List<WorkflowRun> previousRuns = List.of();
+    if (run.getHeadBranch() != null && run.getHeadSha() != null) {
+      previousRuns =
+          workflowRunRepository
+              .findNthLatestCommitShaBehindHeadByBranchAndRepoId(
+                  run.getHeadBranch(),
+                  run.getRepository().getRepositoryId(),
+                  0,
+                  run.getHeadSha())
+              .map(
+                  prevSha ->
+                      workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
+                          run.getHeadBranch(),
+                          prevSha,
+                          run.getRepository().getRepositoryId()))
+              .orElse(List.of());
+    }
+
+    var context =
+        new TestRunContext(
+            List.of(run),
             previousRuns,
             defaultContext.defaultBranchName(),
             defaultContext.defaultWorkflowRunByTestType());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -11,6 +11,7 @@ import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -237,20 +238,37 @@ public class TestResultService {
 
     List<WorkflowRun> previousRuns = List.of();
     if (run.getHeadBranch() != null && run.getHeadSha() != null) {
-      previousRuns =
-          workflowRunRepository
-              .findNthLatestCommitShaBehindHeadByBranchAndRepoId(
-                  run.getHeadBranch(),
-                  run.getRepository().getRepositoryId(),
-                  0,
-                  run.getHeadSha())
-              .map(
-                  prevSha ->
-                      workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
-                          run.getHeadBranch(),
-                          prevSha,
-                          run.getRepository().getRepositoryId()))
-              .orElse(List.of());
+      var pullRequests = run.getPullRequests();
+      if (pullRequests != null && !pullRequests.isEmpty()) {
+        // A run can technically be associated with multiple PRs.
+        // We pick the lowest PR ID (oldest PR) for a deterministic baseline; in
+        // practice the sync service almost always resolves to exactly one PR per run.
+        // TODO consider better handling of multiple PRs
+        var prId = pullRequests.stream()
+            .min(Comparator.comparingLong(pr -> pr.getId()))
+            .orElseThrow()
+            .getId();
+        previousRuns =
+            workflowRunRepository
+                .findNthLatestCommitShaBehindHeadByPullRequestId(prId, 0, run.getHeadSha())
+                .map(prevSha -> workflowRunRepository.findByPullRequestsIdAndHeadSha(prId, prevSha))
+                .orElse(List.of());
+      } else {
+        previousRuns =
+            workflowRunRepository
+                .findNthLatestCommitShaBehindHeadByBranchAndRepoId(
+                    run.getHeadBranch(),
+                    run.getRepository().getRepositoryId(),
+                    0,
+                    run.getHeadSha())
+                .map(
+                    prevSha ->
+                        workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
+                            run.getHeadBranch(),
+                            prevSha,
+                            run.getRepository().getRepositoryId()))
+                .orElse(List.of());
+      }
     }
 
     var context =

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunController.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunController.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.workflow;
 
+import de.tum.cit.aet.helios.config.security.annotations.EnforceAtLeastWritePermission;
 import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunFilterType;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,5 +54,31 @@ public class WorkflowRunController {
       @RequestParam String branch) {
     var workflowRuns = workflowRunService.getLatestWorkflowRunsByBranchAndHeadCommitSha(branch);
     return ResponseEntity.ok(workflowRuns);
+  }
+
+  @GetMapping("/runs/{runId}")
+  public ResponseEntity<WorkflowRunDto> getWorkflowRunById(@PathVariable Long runId) {
+    return ResponseEntity.ok(workflowRunService.getWorkflowRunById(runId));
+  }
+
+  @EnforceAtLeastWritePermission
+  @PostMapping("/runs/{runId}/cancel")
+  public ResponseEntity<Void> cancelWorkflowRun(@PathVariable Long runId) {
+    workflowRunService.cancelWorkflowRun(runId);
+    return ResponseEntity.ok().build();
+  }
+
+  @EnforceAtLeastWritePermission
+  @PostMapping("/runs/{runId}/rerun")
+  public ResponseEntity<Void> reRunWorkflow(@PathVariable Long runId) {
+    workflowRunService.reRunWorkflow(runId);
+    return ResponseEntity.ok().build();
+  }
+
+  @EnforceAtLeastWritePermission
+  @PostMapping("/runs/{runId}/rerun-failed-jobs")
+  public ResponseEntity<Void> reRunFailedJobs(@PathVariable Long runId) {
+    workflowRunService.reRunFailedJobs(runId);
+    return ResponseEntity.ok().build();
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -16,6 +16,8 @@ public interface WorkflowRunRepository
     extends JpaRepository<WorkflowRun, Long>, JpaSpecificationExecutor<WorkflowRun> {
   Optional<WorkflowRun> findById(long id);
 
+  Optional<WorkflowRun> findByIdAndRepositoryRepositoryId(long id, Long repositoryId);
+
   @Query(
       "SELECT DISTINCT wr FROM WorkflowRun wr "
           + "JOIN wr.pullRequests pr "

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
@@ -2,13 +2,18 @@ package de.tum.cit.aet.helios.workflow;
 
 import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.criteria.Predicate;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,8 @@ public class WorkflowRunService {
   private final WorkflowRunRepository workflowRunRepository;
   private final PullRequestRepository pullRequestRepository;
   private final BranchRepository branchRepository;
+  private final GitHubService gitHubService;
+  private final GitRepoRepository gitRepoRepository;
 
   public List<WorkflowRun> getAllWorkflowRuns() {
     return workflowRunRepository.findAll();
@@ -197,7 +204,62 @@ public class WorkflowRunService {
     return Sort.by(direction, property).and(defaultSort);
   }
 
-  public void deleteWorkflowRun(Long workflowRunId) {
-    workflowRunRepository.deleteById(workflowRunId);
+  public WorkflowRunDto getWorkflowRunById(Long runId) {
+    Long repositoryId = RepositoryContext.getRepositoryId();
+    return getWorkflowRunForCurrentRepository(runId, repositoryId, false)
+        .map(WorkflowRunDto::fromWorkflowRun)
+        .orElseThrow(() -> new EntityNotFoundException(
+            "Workflow run with id %d not found".formatted(runId)));
+  }
+
+  public void cancelWorkflowRun(Long runId) {
+    executeWorkflowRunAction(runId, gitHubService::cancelWorkflowRun, "cancel");
+  }
+
+  public void reRunWorkflow(Long runId) {
+    executeWorkflowRunAction(runId, gitHubService::reRunWorkflow, "re-run");
+  }
+
+  public void reRunFailedJobs(Long runId) {
+    executeWorkflowRunAction(runId, gitHubService::reRunFailedJobs, "re-run failed jobs for");
+  }
+
+  @FunctionalInterface
+  private interface WorkflowRunAction {
+    void execute(String repoNameWithOwner, long runId) throws IOException;
+  }
+
+  private void executeWorkflowRunAction(Long runId, WorkflowRunAction action, String actionName) {
+    try {
+      Long repositoryId = RepositoryContext.getRepositoryId();
+      var repository =
+          gitRepoRepository
+              .findById(repositoryId)
+              .orElseThrow(() -> new EntityNotFoundException(
+                  "Repository with id %d not found".formatted(repositoryId)));
+
+      getWorkflowRunForCurrentRepository(runId, repositoryId, true)
+          .orElseThrow(() -> new EntityNotFoundException(
+              "Workflow run with id %d not found".formatted(runId)));
+
+      action.execute(repository.getNameWithOwner(), runId);
+    } catch (IOException e) {
+      log.error("Failed to {} workflow run {}: {}", actionName, runId, e.getMessage());
+      throw new RuntimeException(
+          "Failed to %s workflow run with id %d".formatted(actionName, runId), e);
+    }
+  }
+
+  private Optional<WorkflowRun> getWorkflowRunForCurrentRepository(
+      Long runId, Long repositoryId, boolean actionRequest) {
+    return workflowRunRepository.findByIdAndRepositoryRepositoryId(runId, repositoryId).or(() -> {
+      if (actionRequest && workflowRunRepository.findById(runId).isPresent()) {
+        log.warn(
+            "Blocked workflow run action for run {} in repository {} due to repository mismatch",
+            runId,
+            repositoryId);
+      }
+      return Optional.empty();
+    });
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
@@ -5,6 +5,7 @@ import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.helios.tests.TestSuiteRepository;
 import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
 import jakarta.persistence.EntityNotFoundException;
@@ -25,6 +26,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 @Log4j2
 @RequiredArgsConstructor
@@ -37,6 +39,7 @@ public class WorkflowRunService {
   private final BranchRepository branchRepository;
   private final GitHubService gitHubService;
   private final GitRepoRepository gitRepoRepository;
+  private final TestSuiteRepository testSuiteRepository;
 
   public List<WorkflowRun> getAllWorkflowRuns() {
     return workflowRunRepository.findAll();
@@ -213,15 +216,15 @@ public class WorkflowRunService {
   }
 
   public void cancelWorkflowRun(Long runId) {
-    executeWorkflowRunAction(runId, gitHubService::cancelWorkflowRun, "cancel");
+    executeWorkflowRunAction(runId, gitHubService::cancelWorkflowRun, "cancel", false);
   }
 
   public void reRunWorkflow(Long runId) {
-    executeWorkflowRunAction(runId, gitHubService::reRunWorkflow, "re-run");
+    executeWorkflowRunAction(runId, gitHubService::reRunWorkflow, "re-run", true);
   }
 
   public void reRunFailedJobs(Long runId) {
-    executeWorkflowRunAction(runId, gitHubService::reRunFailedJobs, "re-run failed jobs for");
+    executeWorkflowRunAction(runId, gitHubService::reRunFailedJobs, "re-run failed jobs for", true);
   }
 
   @FunctionalInterface
@@ -229,7 +232,8 @@ public class WorkflowRunService {
     void execute(String repoNameWithOwner, long runId) throws IOException;
   }
 
-  private void executeWorkflowRunAction(Long runId, WorkflowRunAction action, String actionName) {
+  private void executeWorkflowRunAction(
+      Long runId, WorkflowRunAction action, String actionName, boolean resetTestState) {
     try {
       Long repositoryId = RepositoryContext.getRepositoryId();
       var repository =
@@ -238,11 +242,15 @@ public class WorkflowRunService {
               .orElseThrow(() -> new EntityNotFoundException(
                   "Repository with id %d not found".formatted(repositoryId)));
 
-      getWorkflowRunForCurrentRepository(runId, repositoryId, true)
+      var workflowRun = getWorkflowRunForCurrentRepository(runId, repositoryId, true)
           .orElseThrow(() -> new EntityNotFoundException(
               "Workflow run with id %d not found".formatted(runId)));
 
       action.execute(repository.getNameWithOwner(), runId);
+
+      if (resetTestState) {
+        resetTestStateForRerun(workflowRun);
+      }
     } catch (IOException e) {
       log.error("Failed to {} workflow run {}: {}", actionName, runId, e.getMessage());
       throw new RuntimeException(
@@ -261,5 +269,21 @@ public class WorkflowRunService {
       }
       return Optional.empty();
     });
+  }
+
+  private void resetTestStateForRerun(WorkflowRun workflowRun) {
+    var workflow = workflowRun.getWorkflow();
+    if (workflow == null || CollectionUtils.isEmpty(workflow.getTestTypes())) {
+      return;
+    }
+
+    var existingTestSuites = testSuiteRepository.findByWorkflowRunId(workflowRun.getId());
+    if (!existingTestSuites.isEmpty()) {
+      testSuiteRepository.deleteAll(existingTestSuites);
+    }
+
+    workflowRun.setTestSuites(null);
+    workflowRun.setTestProcessingStatus(null);
+    workflowRunRepository.save(workflowRun);
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
@@ -1148,6 +1148,7 @@ class GitHubServiceTest {
             () -> {
               gitHubService.cancelWorkflowRun(repoNameWithOwner, runId);
             });
-    assertTrue(exception.getMessage().contains("GitHub API call failed with response code: 500"));
+    assertTrue(exception.getMessage()
+        .contains("GitHub API cancel for run " + runId + " failed with response code: 500"));
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
@@ -2,17 +2,26 @@ package de.tum.cit.aet.helios.workflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.helios.branch.BranchRepository;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Conclusion;
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Status;
 import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
+import jakarta.persistence.EntityNotFoundException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +46,8 @@ public class WorkflowRunServiceTest {
   @Mock private WorkflowRunRepository workflowRunRepository;
   @Mock private PullRequestRepository pullRequestRepository;
   @Mock private BranchRepository branchRepository;
+  @Mock private GitHubService gitHubService;
+  @Mock private GitRepoRepository gitRepoRepository;
 
   @BeforeEach
   public void setUp() {
@@ -145,6 +156,130 @@ public class WorkflowRunServiceTest {
     // secondary default sort is still appended
     assertNotNull(pageable.getSort().getOrderFor("runStartedAt"));
     assertNotNull(pageable.getSort().getOrderFor("createdAt"));
+  }
+
+  @Test
+  public void getWorkflowRunById_usesRepositoryScopedLookup() {
+    WorkflowRun run = createWorkflowRun(
+        100L, "Build", "Build workflow", Status.SUCCESS, Conclusion.SUCCESS);
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(eq(100L), eq(1L)))
+        .thenReturn(Optional.of(run));
+
+    WorkflowRunDto result = workflowRunService.getWorkflowRunById(100L);
+
+    assertEquals(100L, result.id());
+    verify(workflowRunRepository).findByIdAndRepositoryRepositoryId(100L, 1L);
+  }
+
+  @Test
+  public void getWorkflowRunById_whenRunNotInRepository_throwsNotFound() {
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(eq(100L), eq(1L)))
+        .thenReturn(Optional.empty());
+
+    assertThrows(EntityNotFoundException.class, () -> workflowRunService.getWorkflowRunById(100L));
+    verify(workflowRunRepository).findByIdAndRepositoryRepositoryId(100L, 1L);
+  }
+
+  @Test
+  public void cancelWorkflowRun_success_callsGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(1L, 1L))
+        .thenReturn(Optional.of(run));
+
+    workflowRunService.cancelWorkflowRun(1L);
+
+    verify(gitHubService).cancelWorkflowRun("owner/repo", 1L);
+  }
+
+  @Test
+  public void cancelWorkflowRun_whenRunNotInRepository_doesNotCallGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(eq(200L), eq(1L)))
+        .thenReturn(Optional.empty());
+    lenient().when(workflowRunRepository.findById(200L))
+        .thenReturn(Optional.of(new WorkflowRun()));
+
+    assertThrows(EntityNotFoundException.class, () -> workflowRunService.cancelWorkflowRun(200L));
+
+    verify(gitHubService, never()).cancelWorkflowRun(any(), anyLong());
+  }
+
+  @Test
+  public void reRunWorkflowRun_success_callsGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(201L, 1L))
+        .thenReturn(Optional.of(run));
+
+    workflowRunService.reRunWorkflow(201L);
+
+    verify(gitHubService).reRunWorkflow("owner/repo", 201L);
+  }
+
+  @Test
+  public void reRunWorkflow_whenRunNotInRepository_doesNotCallGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(eq(201L), eq(1L)))
+        .thenReturn(Optional.empty());
+    lenient().when(workflowRunRepository.findById(200L))
+        .thenReturn(Optional.of(new WorkflowRun()));
+
+    assertThrows(EntityNotFoundException.class, () -> workflowRunService.reRunWorkflow(201L));
+
+    verify(gitHubService, never()).reRunWorkflow(any(), anyLong());
+  }
+
+  @Test
+  public void reRunFailedJobs_success_callsGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(202L, 1L))
+        .thenReturn(Optional.of(run));
+
+    workflowRunService.reRunFailedJobs(202L);
+
+    verify(gitHubService).reRunFailedJobs("owner/repo", 202L);
+  }
+
+  @Test
+  public void reRunFailedJobs_whenRunNotInRepository_doesNotCallGithub() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(eq(202L), eq(1L)))
+        .thenReturn(Optional.empty());
+    lenient().when(workflowRunRepository.findById(200L))
+        .thenReturn(Optional.of(new WorkflowRun()));
+
+    assertThrows(EntityNotFoundException.class, () -> workflowRunService.reRunFailedJobs(202L));
+
+    verify(gitHubService, never()).reRunFailedJobs(any(), anyLong());
   }
 
   private WorkflowRun createWorkflowRun(

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/WorkflowRunServiceTest.java
@@ -2,10 +2,13 @@ package de.tum.cit.aet.helios.workflow;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -17,18 +20,24 @@ import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
+import de.tum.cit.aet.helios.tests.TestSuite;
+import de.tum.cit.aet.helios.tests.TestSuiteRepository;
+import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Conclusion;
 import de.tum.cit.aet.helios.workflow.WorkflowRun.Status;
 import de.tum.cit.aet.helios.workflow.pagination.PaginatedWorkflowRunsResponse;
 import de.tum.cit.aet.helios.workflow.pagination.WorkflowRunPageRequest;
 import jakarta.persistence.EntityNotFoundException;
+import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,6 +57,7 @@ public class WorkflowRunServiceTest {
   @Mock private BranchRepository branchRepository;
   @Mock private GitHubService gitHubService;
   @Mock private GitRepoRepository gitRepoRepository;
+  @Mock private TestSuiteRepository testSuiteRepository;
 
   @BeforeEach
   public void setUp() {
@@ -221,14 +231,51 @@ public class WorkflowRunServiceTest {
     repository.setNameWithOwner("owner/repo");
 
     WorkflowRun run = new WorkflowRun();
+    run.setId(201L);
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>(List.of(new TestType())));
+    run.setWorkflow(workflow);
 
     when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
     when(workflowRunRepository.findByIdAndRepositoryRepositoryId(201L, 1L))
         .thenReturn(Optional.of(run));
+    when(testSuiteRepository.findByWorkflowRunId(201L)).thenReturn(List.of());
 
     workflowRunService.reRunWorkflow(201L);
 
     verify(gitHubService).reRunWorkflow("owner/repo", 201L);
+    verify(workflowRunRepository).save(run);
+  }
+
+  @Test
+  public void reRunWorkflow_whenTestWorkflowAndExistingSuites_resetsStateAfterGithubCall()
+      throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+    run.setId(205L);
+    run.setTestProcessingStatus(WorkflowRun.TestProcessingStatus.PROCESSED);
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>(List.of(new TestType())));
+    run.setWorkflow(workflow);
+
+    TestSuite existingSuite = new TestSuite();
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(205L, 1L))
+        .thenReturn(Optional.of(run));
+    when(testSuiteRepository.findByWorkflowRunId(205L)).thenReturn(List.of(existingSuite));
+
+    workflowRunService.reRunWorkflow(205L);
+
+    InOrder inOrder = inOrder(gitHubService, testSuiteRepository);
+    inOrder.verify(gitHubService).reRunWorkflow("owner/repo", 205L);
+    inOrder.verify(testSuiteRepository).findByWorkflowRunId(205L);
+    verify(testSuiteRepository).deleteAll(List.of(existingSuite));
+    verify(workflowRunRepository).save(run);
+    assertNull(run.getTestProcessingStatus());
   }
 
   @Test
@@ -255,14 +302,85 @@ public class WorkflowRunServiceTest {
     repository.setNameWithOwner("owner/repo");
 
     WorkflowRun run = new WorkflowRun();
+    run.setId(202L);
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>(List.of(new TestType())));
+    run.setWorkflow(workflow);
 
     when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
     when(workflowRunRepository.findByIdAndRepositoryRepositoryId(202L, 1L))
         .thenReturn(Optional.of(run));
+    when(testSuiteRepository.findByWorkflowRunId(202L)).thenReturn(List.of());
 
     workflowRunService.reRunFailedJobs(202L);
 
     verify(gitHubService).reRunFailedJobs("owner/repo", 202L);
+    verify(workflowRunRepository).save(run);
+  }
+
+  @Test
+  public void reRunWorkflow_whenWorkflowHasNoTestTypes_doesNotResetTestState() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>());
+    run.setWorkflow(workflow);
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(203L, 1L))
+        .thenReturn(Optional.of(run));
+
+    workflowRunService.reRunWorkflow(203L);
+
+    verify(gitHubService).reRunWorkflow("owner/repo", 203L);
+    verify(testSuiteRepository, never()).findByWorkflowRunId(anyLong());
+  }
+
+  @Test
+  public void reRunWorkflow_whenGithubRerunFails_doesNotResetTestState() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>(List.of(new TestType())));
+    run.setWorkflow(workflow);
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(204L, 1L))
+        .thenReturn(Optional.of(run));
+    doThrow(new IOException("Dummy error")).when(gitHubService).reRunWorkflow("owner/repo", 204L);
+
+    assertThrows(RuntimeException.class, () -> workflowRunService.reRunWorkflow(204L));
+
+    verify(testSuiteRepository, never()).findByWorkflowRunId(anyLong());
+    verify(workflowRunRepository, never()).save(run);
+  }
+
+  @Test
+  public void reRunFailedJobs_whenGithubRerunFails_doesNotResetTestState() throws Exception {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(1L);
+    repository.setNameWithOwner("owner/repo");
+
+    WorkflowRun run = new WorkflowRun();
+    Workflow workflow = new Workflow();
+    workflow.setTestTypes(new HashSet<>(List.of(new TestType())));
+    run.setWorkflow(workflow);
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(repository));
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(206L, 1L))
+        .thenReturn(Optional.of(run));
+    doThrow(new IOException("Dummy error")).when(gitHubService).reRunFailedJobs("owner/repo", 206L);
+
+    assertThrows(RuntimeException.class, () -> workflowRunService.reRunFailedJobs(206L));
+
+    verify(testSuiteRepository, never()).findByWorkflowRunId(anyLong());
+    verify(workflowRunRepository, never()).save(run);
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Previously Workflow Runs tab has implemented and placed in CI/CD menu. Now, Workflow Run Detail page is added to see Jobs, Tests (if exists). Additionally, Helios was not supporting re-run a workflow and re-run failed jobs features before. Also, cancellation a deployment was possible but we didn't have cancel workflow functionality. Now, these three options are also added to Workflow Run Detail page. This PR is related to these issue: #913  #918

### Description
<!-- Describe your changes in detail -->
This PR introduces end-to-end workflow run details support and action handling across backend and frontend.

- Added backend API endpoints for:
  - fetching workflow run details by run ID,
  - canceling a workflow run,
  - re-running all jobs in a workflow run,
  - re-running failed jobs only,
  - fetching test results by workflow run ID.
- Extended GitHub integration service to execute workflow run actions (cancel, rerun, rerun-failed-jobs) with shared error handling.
- Added a dedicated Workflow Run Details page and route.
- Enhanced workflow runs table UX:
  - row click navigation to run details,
  - clearer columns (test processing, duration),
  - improved date/time display.
- Refactored workflow jobs rendering:
  - extracted reusable workflow-job-list component,
  - reused it in environments and run-details views.
- Extended pipeline test results selection to support workflowRunId.
- Improved run-details polling after action triggers, so delayed GitHub synchronization can still be reflected in the UI without manual refresh.


### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub account with normal developer access (no admin/owner permissions required).
- A repository connected in Helios with existing workflow runs.
- At least one completed workflow run (preferably one failed run to test “Re-run failed”)

#### Flow:
1. Log in to Helios as a Developer with write access
2. Open a repository and navigate to CI/CD > Workflow Runs.
3. Open a failed workflow run  details page that includes test cases.
4. On the details page, verify baseline data:
- run title/status/branch/SHA/timestamps are visible,
- jobs list is rendered,
- test results section loads for test-labeled runs.
5. Trigger actions:
- click Re-run All on a completed run,
- click Re-run Failed on a failed run,
- click Cancel on an active run.
6. Confirm behavior after each action:
- success toast appears,
- page updates status/jobs without hard refresh,
- delayed GitHub sync is eventually reflected (allow up to ~2 minutes).
9. Logout or login with readonly access.
10. Verify that Jobs component and re-run/cancel buttons are not visible.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1451" height="817" alt="Screenshot 2026-03-20 at 13 34 19" src="https://github.com/user-attachments/assets/b614aef9-0983-4867-93d0-7f2f6979df0f" />
<img width="1494" height="815" alt="Screenshot 2026-03-20 at 13 34 03" src="https://github.com/user-attachments/assets/d26f2fee-361e-4157-8a69-a7e4c0307607" />
<img width="1458" height="812" alt="Screenshot 2026-03-20 at 13 35 09" src="https://github.com/user-attachments/assets/68b849df-2614-49f1-a4d1-2eb1b33cba15" />
<img width="1500" height="828" alt="Screenshot 2026-03-20 at 13 43 47" src="https://github.com/user-attachments/assets/797e1a6f-edce-4e68-a1db-9ad397a64d4e" />

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.