### PR TITLE
fix: show deployed branch in environment activities

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/ActivityHistoryDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/ActivityHistoryDto.java
@@ -40,14 +40,27 @@ public record ActivityHistoryDto(
   }
 
   public static ActivityHistoryDto fromDeployment(Deployment deployment) {
+    return fromDeployment(deployment, null);
+  }
+
+  public static ActivityHistoryDto fromDeployment(
+      Deployment deployment, HeliosDeployment heliosDeployment) {
+    // For Helios-triggered deployments, use the branch name and SHA from the HeliosDeployment if
+    // available, as the GitHub Deployment's ref and sha may not reflect the actual deployed code.
+    String ref = heliosDeployment != null && heliosDeployment.getBranchName() != null
+        ? heliosDeployment.getBranchName()
+        : deployment.getRef();
+    String sha = heliosDeployment != null && heliosDeployment.getSha() != null
+        ? heliosDeployment.getSha()
+        : deployment.getSha();
     return new ActivityHistoryDto(
         "DEPLOYMENT",
         deployment.getId(),
         RepositoryInfoDto.fromRepository(deployment.getRepository()),
         deployment.getEnvironment().getName(),
         deployment.getState(),
-        deployment.getSha(),
-        deployment.getRef(),
+        sha,
+        ref,
         UserInfoDto.fromUser(deployment.getCreator()),
         null,
         deployment.getCreatedAt(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -147,7 +148,9 @@ public class DeploymentService {
     heliosDeployment.setEnvironment(environment);
     heliosDeployment.setUser(authService.getUserId());
     heliosDeployment.setStatus(HeliosDeployment.Status.WAITING);
-    heliosDeployment.setBranchName(this.getDeploymentWorkflowBranch(environment, deployRequest));
+    heliosDeployment.setBranchName(deployRequest.branchName());
+    heliosDeployment.setWorkflowBranch(
+        this.getDeploymentWorkflowBranch(environment, deployRequest));
     heliosDeployment.setSha(deployRequest.commitSha());
     heliosDeployment.setCreator(authService.getUserFromGithubId());
     heliosDeployment.setPullRequest(optionalPullRequest.orElse(null));
@@ -290,10 +293,14 @@ public class DeploymentService {
    *     </ul>
    */
   public List<ActivityHistoryDto> getActivityHistoryByEnvironmentId(Long environmentId) {
-    // 1) Real deployments
+    // 1) Real deployments — enriched with the linked HeliosDeployment so the actual deployed
+    // branch is displayed instead of the workflow dispatch ref stored on the GitHub Deployment.
+    List<Deployment> deployments =
+        deploymentRepository.findByEnvironmentIdOrderByCreatedAtDesc(environmentId);
+    Map<Long, HeliosDeployment> heliosByDeploymentId = buildHeliosByDeploymentIdMap(deployments);
     List<ActivityHistoryDto> deploymentDtos =
-        deploymentRepository.findByEnvironmentIdOrderByCreatedAtDesc(environmentId).stream()
-            .map(ActivityHistoryDto::fromDeployment)
+        deployments.stream()
+            .map(d -> ActivityHistoryDto.fromDeployment(d, heliosByDeploymentId.get(d.getId())))
             .toList();
 
     // 3) Lock history (lock/unlock)
@@ -354,9 +361,12 @@ public class DeploymentService {
 
     List<ActivityHistoryDto> combined = new ArrayList<>();
 
+    List<Deployment> deployments =
+        deploymentRepository.findByPullRequest_IdOrderByCreatedAtDesc(pullRequestId);
+    Map<Long, HeliosDeployment> heliosByDeploymentId = buildHeliosByDeploymentIdMap(deployments);
     List<ActivityHistoryDto> deploymentDtos =
-        deploymentRepository.findByPullRequest_IdOrderByCreatedAtDesc(pullRequestId).stream()
-            .map(ActivityHistoryDto::fromDeployment)
+        deployments.stream()
+            .map(d -> ActivityHistoryDto.fromDeployment(d, heliosByDeploymentId.get(d.getId())))
             .toList();
     combined.addAll(deploymentDtos);
 
@@ -386,11 +396,13 @@ public class DeploymentService {
       Long repositoryId, String branchName) {
     List<ActivityHistoryDto> combined = new ArrayList<>();
 
+    List<Deployment> deployments =
+        deploymentRepository.findByRepositoryRepositoryIdAndRefOrderByCreatedAtDesc(
+            repositoryId, branchName);
+    Map<Long, HeliosDeployment> heliosByDeploymentId = buildHeliosByDeploymentIdMap(deployments);
     List<ActivityHistoryDto> deploymentDtos =
-        deploymentRepository
-            .findByRepositoryRepositoryIdAndRefOrderByCreatedAtDesc(repositoryId, branchName)
-            .stream()
-            .map(ActivityHistoryDto::fromDeployment)
+        deployments.stream()
+            .map(d -> ActivityHistoryDto.fromDeployment(d, heliosByDeploymentId.get(d.getId())))
             .toList();
     combined.addAll(deploymentDtos);
 
@@ -404,6 +416,41 @@ public class DeploymentService {
     combined.addAll(heliosDeploymentDtos);
 
     return ActivityHistoryDto.sortActivityHistoryDtosByTimestampDesc(combined);
+  }
+
+  /**
+   * Builds a map from GitHub deployment ID to the linked HeliosDeployment for a batch of
+   * deployments. Used to enrich ActivityHistoryDto entries so the actual deployed branch (stored on
+   * HeliosDeployment) is shown instead of the workflow dispatch ref recorded by GitHub.
+   */
+  private Map<Long, HeliosDeployment> buildHeliosByDeploymentIdMap(
+      List<Deployment> deployments) {
+    List<Long> ids =
+        deployments.stream()
+            .map(Deployment::getId)
+            .filter(Objects::nonNull)
+            .toList();
+    if (ids.isEmpty()) {
+      return Map.of();
+    }
+    return heliosDeploymentRepository.findByDeploymentIdIn(ids).stream()
+        .filter(hd -> hd.getDeploymentId() != null)
+        .collect(Collectors.toMap(
+            HeliosDeployment::getDeploymentId,
+            hd -> hd,
+            (a, b) -> {
+              HeliosDeployment kept = a.getCreatedAt().isAfter(b.getCreatedAt()) ? a : b;
+              HeliosDeployment discarded = kept == a ? b : a;
+              log.warn(
+                  "Duplicate HeliosDeployment entries for deploymentId {}: "
+                      + "keeping HeliosDeployment id={} (createdAt={}), "
+                      + "discarding HeliosDeployment id={} (createdAt={})",
+                  kept.getDeploymentId(),
+                  kept.getId(), kept.getCreatedAt(),
+                  discarded.getId(), discarded.getCreatedAt());
+              return kept;
+            }
+        ));
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -359,26 +359,18 @@ public class DeploymentService {
       throw new EntityNotFoundException("Pull request not found with id: " + pullRequestId);
     }
 
-    List<ActivityHistoryDto> combined = new ArrayList<>();
-
-    List<Deployment> deployments =
-        deploymentRepository.findByPullRequest_IdOrderByCreatedAtDesc(pullRequestId);
-    Map<Long, HeliosDeployment> heliosByDeploymentId = buildHeliosByDeploymentIdMap(deployments);
-    List<ActivityHistoryDto> deploymentDtos =
-        deployments.stream()
-            .map(d -> ActivityHistoryDto.fromDeployment(d, heliosByDeploymentId.get(d.getId())))
-            .toList();
-    combined.addAll(deploymentDtos);
-
-    List<ActivityHistoryDto> heliosDeploymentDtos =
-        heliosDeploymentRepository.findByPullRequest_IdAndDeploymentIdIsNullOrderByCreatedAtDesc(
+    // TODO: Consider including Github Deployments without linked HeliosDeployment as well,
+    // For now, it is not included because the Deployment.ref stores the workflow dispatch ref
+    // (e.g. "main") instead of the actual deployed branch. So, this could lead to confusion in the
+    // UI if we show deployments with a ref that doesn't match the PR branch.
+    List<ActivityHistoryDto> heliosDeploymentDtos = new ArrayList<>(
+        heliosDeploymentRepository.findByPullRequest_IdOrderByCreatedAtDesc(
                 pullRequestId)
             .stream()
             .map(ActivityHistoryDto::fromHeliosDeployment)
-            .toList();
-    combined.addAll(heliosDeploymentDtos);
-
-    return ActivityHistoryDto.sortActivityHistoryDtosByTimestampDesc(combined);
+            .toList()
+    );
+    return ActivityHistoryDto.sortActivityHistoryDtosByTimestampDesc(heliosDeploymentDtos);
   }
 
   /**
@@ -394,28 +386,19 @@ public class DeploymentService {
    */
   public List<ActivityHistoryDto> getActivityHistoryByRepositoryIdAndBranchName(
       Long repositoryId, String branchName) {
-    List<ActivityHistoryDto> combined = new ArrayList<>();
 
-    List<Deployment> deployments =
-        deploymentRepository.findByRepositoryRepositoryIdAndRefOrderByCreatedAtDesc(
-            repositoryId, branchName);
-    Map<Long, HeliosDeployment> heliosByDeploymentId = buildHeliosByDeploymentIdMap(deployments);
-    List<ActivityHistoryDto> deploymentDtos =
-        deployments.stream()
-            .map(d -> ActivityHistoryDto.fromDeployment(d, heliosByDeploymentId.get(d.getId())))
-            .toList();
-    combined.addAll(deploymentDtos);
-
-    List<ActivityHistoryDto> heliosDeploymentDtos =
-        heliosDeploymentRepository
-            .findByRepositoryIdAndBranchNameAndDeploymentIdIsNullOrderByCreatedAtDesc(
+    // TODO: Consider including Github Deployments without linked HeliosDeployment as well,
+    // For now, it is not included because the Deployment.ref stores the workflow dispatch ref
+    // (e.g. "main") instead of the actual deployed branch. So, this could lead to confusion in the
+    // UI if we show deployments with a ref that doesn't match the branch.
+    List<ActivityHistoryDto> heliosDeploymentDtos = new ArrayList<>(
+        heliosDeploymentRepository.findByRepositoryIdAndBranchNameOrderByCreatedAtDesc(
                 repositoryId, branchName)
             .stream()
             .map(ActivityHistoryDto::fromHeliosDeployment)
-            .toList();
-    combined.addAll(heliosDeploymentDtos);
-
-    return ActivityHistoryDto.sortActivityHistoryDtosByTimestampDesc(combined);
+            .toList()
+    );
+    return ActivityHistoryDto.sortActivityHistoryDtosByTimestampDesc(heliosDeploymentDtos);
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -171,6 +171,11 @@ public class LatestDeploymentUnion {
 
   public String getSha() {
     if (isRealDeployment()) {
+      // For Helios-triggered deployments the HeliosDeployment holds the actual commit SHA,
+      // whereas the GitHub Deployment SHA is the HEAD of the workflow dispatch ref.
+      if (heliosDeployment != null && heliosDeployment.getSha() != null) {
+        return heliosDeployment.getSha();
+      }
       return realDeployment.getSha();
     } else if (isHeliosDeployment()) {
       return heliosDeployment.getSha();
@@ -181,6 +186,11 @@ public class LatestDeploymentUnion {
 
   public String getRef() {
     if (isRealDeployment()) {
+      // For Helios-triggered deployments the HeliosDeployment holds the actual deployed branch,
+      // whereas the GitHub Deployment ref is the workflow dispatch ref (e.g. "main").
+      if (heliosDeployment != null && heliosDeployment.getBranchName() != null) {
+        return heliosDeployment.getBranchName();
+      }
       return realDeployment.getRef();
     } else if (isHeliosDeployment()) {
       return heliosDeployment.getBranchName();
@@ -231,6 +241,9 @@ public class LatestDeploymentUnion {
 
   public String getPullRequestName() {
     if (isRealDeployment()) {
+      if (heliosDeployment != null && heliosDeployment.getPullRequest() != null) {
+        return heliosDeployment.getPullRequest().getTitle();
+      }
       return realDeployment.getPullRequest() != null
           ? realDeployment.getPullRequest().getTitle()
           : null;
@@ -245,6 +258,9 @@ public class LatestDeploymentUnion {
 
   public Integer getPullRequestNumber() {
     if (isRealDeployment()) {
+      if (heliosDeployment != null && heliosDeployment.getPullRequest() != null) {
+        return heliosDeployment.getPullRequest().getNumber();
+      }
       return realDeployment.getPullRequest() != null
           ? realDeployment.getPullRequest().getNumber()
           : null;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
@@ -34,6 +34,7 @@ public class GitHubDeploymentSyncService {
    *     DeploymentSource
    * @param gitRepository the associated GitRepository entity
    * @param environment the associated environment entity
+   * @param user the creator of the deployment
    */
   @Transactional
   public void processDeployment(
@@ -89,15 +90,35 @@ public class GitHubDeploymentSyncService {
     }
 
     if (maybeHeliosDeployment.isEmpty()) {
+      // Primary fallback: match by workflowBranch (the dispatch ref stored on new records).
       maybeHeliosDeployment =
           heliosDeploymentRepository
-              .findTopByEnvironmentAndBranchNameOrderByCreatedAtDesc(
+              .findTopByEnvironmentAndWorkflowBranchOrderByCreatedAtDesc(
                   environment, deployment.getRef())
               .filter(
                   hd ->
                       hd.getWorkflowRunId() == null
                           || (deployment.getWorkflowRunId() != null
                               && hd.getWorkflowRunId().equals(deployment.getWorkflowRunId())));
+    }
+
+    if (maybeHeliosDeployment.isEmpty()) {
+      // Secondary fallback: match by branchName for records created before the workflowBranch
+      // field was introduced (where branchName still held the dispatch ref).
+      // Note that this fallback is still needed for old workflow runs created before the
+      // workflowBranch field was introduced, because those records were created with
+      // branchName = dispatch ref, and workflowBranch = null. So we need to check branchName here,
+      // but only for records where workflowBranch is still null (i.e. old records).
+      maybeHeliosDeployment =
+          heliosDeploymentRepository
+              .findTopByEnvironmentAndBranchNameOrderByCreatedAtDesc(
+                  environment, deployment.getRef())
+              .filter(
+                  hd ->
+                      hd.getWorkflowBranch() == null
+                          && (hd.getWorkflowRunId() == null
+                          || (deployment.getWorkflowRunId() != null
+                              && hd.getWorkflowRunId().equals(deployment.getWorkflowRunId()))));
     }
 
     maybeHeliosDeployment.ifPresent(heliosDeployment -> {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
@@ -56,6 +56,9 @@ public class HeliosDeployment {
   @Column(name = "branch_name")
   private String branchName;
 
+  @Column(name = "workflow_branch")
+  private String workflowBranch;
+
   @Column(name = "build_tag")
   private String buildTag;
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
@@ -32,6 +32,9 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
   List<HeliosDeployment> findByPullRequest_IdAndDeploymentIdIsNullOrderByCreatedAtDesc(
       Long pullRequestId);
 
+  @SuppressWarnings({"checkstyle:MethodName"})
+  List<HeliosDeployment> findByPullRequest_IdOrderByCreatedAtDesc(Long pullRequestId);
+
   @Query(
       "SELECT hd FROM HeliosDeployment hd "
           + "JOIN hd.environment e "
@@ -50,6 +53,16 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
           + "AND hd.deploymentId IS NULL "
           + "ORDER BY hd.createdAt DESC")
   List<HeliosDeployment> findByRepositoryIdAndBranchNameAndDeploymentIdIsNullOrderByCreatedAtDesc(
+      @Param("repositoryId") Long repositoryId, @Param("branchName") String branchName);
+
+  @Query(
+      "SELECT hd FROM HeliosDeployment hd "
+          + "JOIN hd.environment e "
+          + "JOIN e.repository r "
+          + "WHERE r.id = :repositoryId "
+          + "AND hd.branchName = :branchName "
+          + "ORDER BY hd.createdAt DESC")
+  List<HeliosDeployment> findByRepositoryIdAndBranchNameOrderByCreatedAtDesc(
       @Param("repositoryId") Long repositoryId, @Param("branchName") String branchName);
 
   Optional<HeliosDeployment> findByDeploymentId(Long deploymentId);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
@@ -17,8 +17,14 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
   Optional<HeliosDeployment> findTopByBranchNameAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
       String branchName, OffsetDateTime eventTime);
 
+  Optional<HeliosDeployment> findTopByWorkflowBranchAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+      String workflowBranch, OffsetDateTime eventTime);
+
   Optional<HeliosDeployment> findTopByEnvironmentAndBranchNameOrderByCreatedAtDesc(
       Environment environment, String branchName);
+
+  Optional<HeliosDeployment> findTopByEnvironmentAndWorkflowBranchOrderByCreatedAtDesc(
+      Environment environment, String workflowBranch);
 
   List<HeliosDeployment> findByEnvironmentAndDeploymentIdIsNull(Environment environment);
 
@@ -47,6 +53,8 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
       @Param("repositoryId") Long repositoryId, @Param("branchName") String branchName);
 
   Optional<HeliosDeployment> findByDeploymentId(Long deploymentId);
+
+  List<HeliosDeployment> findByDeploymentIdIn(java.util.Collection<Long> deploymentIds);
 
   Optional<HeliosDeployment> findByWorkflowRunId(Long workflowRunId);
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -160,7 +160,7 @@ public class GitHubWorkflowRunSyncService {
 
     // Process the workflow run for HeliosDeployment
     try {
-      processRunForHeliosDeployment(ghWorkflowRun);
+      processRunForHeliosDeployment(ghWorkflowRun, result);
     } catch (IOException e) {
       log.error(
           "Failed to process workflow run {} for HeliosDeployment: {}",
@@ -201,7 +201,8 @@ public class GitHubWorkflowRunSyncService {
         && (message.contains("Bad credentials") || message.contains("\"status\": \"401\""));
   }
 
-  private void processRunForHeliosDeployment(GHWorkflowRun workflowRun) throws IOException {
+  private void processRunForHeliosDeployment(
+      GHWorkflowRun workflowRun, WorkflowRun workflowRunEntity) throws IOException {
     // Get the deployment workflow set by the managers
     List<Workflow> deploymentWorkflows =
         workflowService.getDeploymentWorkflowsForAllEnv(workflowRun.getRepository().getId());
@@ -235,6 +236,25 @@ public class GitHubWorkflowRunSyncService {
         heliosDeploymentRepository.findByWorkflowRunId(workflowRun.getId());
 
     if (heliosDeploymentOpt.isEmpty()) {
+      // Primary fallback: match by workflowBranch (the dispatch ref stored on new records).
+      heliosDeploymentOpt =
+          heliosDeploymentRepository
+              .findTopByWorkflowBranchAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+                  workflowRun.getHeadBranch(),
+                  DateUtil.convertToOffsetDateTime(workflowRun.getRunStartedAt()))
+              .filter(
+                  hd ->
+                      hd.getWorkflowRunId() == null
+                          || hd.getWorkflowRunId().equals(workflowRun.getId()));
+    }
+
+    if (heliosDeploymentOpt.isEmpty()) {
+      // Secondary fallback: match by branchName for records created before the workflowBranch
+      // field was introduced (where branchName still held the dispatch ref).
+      // Note that this fallback is still needed for old workflow runs created before the
+      // workflowBranch field was introduced, because those records were created with
+      // branchName = dispatch ref, and workflowBranch = null. So we need to check branchName here,
+      // but only for records where workflowBranch is still null (i.e. old records).
       heliosDeploymentOpt =
           heliosDeploymentRepository
               .findTopByBranchNameAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
@@ -242,8 +262,9 @@ public class GitHubWorkflowRunSyncService {
                   DateUtil.convertToOffsetDateTime(workflowRun.getRunStartedAt()))
               .filter(
                   hd ->
-                      hd.getWorkflowRunId() == null
-                          || hd.getWorkflowRunId().equals(workflowRun.getId()));
+                      hd.getWorkflowBranch() == null
+                          && (hd.getWorkflowRunId() == null
+                              || hd.getWorkflowRunId().equals(workflowRun.getId())));
     }
 
     heliosDeploymentOpt.ifPresent(
@@ -310,6 +331,28 @@ public class GitHubWorkflowRunSyncService {
                       heliosDeployment.getId(),
                       mappedStatus);
                   heliosDeploymentRepository.save(heliosDeployment);
+                }
+
+                // Correct WorkflowRun.headBranch/headSha/pullRequests when a deployment workflow
+                // branch caused a mismatch (i.e. the workflow was dispatched from a different branch
+                // than the one being deployed). Only applied for Helios-triggered deployments where
+                // the actual deployed branch is known via the HeliosDeployment record.
+                if (heliosDeployment.getBranchName() != null
+                    && !heliosDeployment.getBranchName().equals(workflowRun.getHeadBranch())) {
+                  workflowRunEntity.setHeadBranch(heliosDeployment.getBranchName());
+                  if (heliosDeployment.getSha() != null) {
+                    workflowRunEntity.setHeadSha(heliosDeployment.getSha());
+                  }
+                  if (heliosDeployment.getPullRequest() != null) {
+                    workflowRunEntity.setPullRequests(
+                        new HashSet<>(
+                            Collections.singletonList(heliosDeployment.getPullRequest())));
+                  }
+                  log.info(
+                      "Corrected WorkflowRun {} headBranch from '{}' to '{}' via HeliosDeployment",
+                      workflowRun.getId(),
+                      workflowRun.getHeadBranch(),
+                      heliosDeployment.getBranchName());
                 }
               } catch (IOException e) {
                 e.printStackTrace();

--- a/server/application-server/src/main/resources/db/migration/V43__add_workflow_branch_to_helios_deployment.sql
+++ b/server/application-server/src/main/resources/db/migration/V43__add_workflow_branch_to_helios_deployment.sql
@@ -1,0 +1,1 @@
+ALTER TABLE helios_deployment ADD COLUMN workflow_branch VARCHAR(255);


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When an environment uses a deployment workflow branch (e.g. main), GitHub runs the workflow from that branch, so GitHub Actions reports workflow_run as being for that dispatch branch and commit (head_branch / head_sha).
In fact, deployed version can be another branch (e.g. a feature branch) with a different SHA and open PR. As a result, in Helios, if deployment workflow branch is set in Environment Settings, the branch name shown in the UI does not reflect the actual branch that was deployed. Additionally, in this case, Test Results are always linked to the deployment workflow branch even though actual deployed branch is different. This PR fixes https://github.com/ls1intum/Helios/issues/934 .  

### Description
<!-- Describe your changes in detail -->

The solution is provided for the deployments triggered via Helios. It does not handle the deployments triggered directly via GitHub. This is because GitHub API does not provide `workflow_run inputs`. See: https://github.com/orgs/community/discussions/73223 So, for the deployments triggered directly via GitHub, Helios will still display the workflow dispatch ref instead of actual deployed branch name and SHA.

For the deployments triggered via Helios, the following solution is proposed:

The persisted WorkflowRun is corrected with what Helios already knows from the linked `HeliosDeployment` (actual deployed branch, SHA, and PR when available):

- `GitHubWorkflowRunSyncService.processRunForHeliosDeployment` now receives the `WorkflowRun` entity being saved.
After resolving the matching `HeliosDeployment`, if its stored deployed branch name differs from GitHub’s run head_branch, we update the WorkflowRun to use:
  - branch_name → WorkflowRun.headBranch
  - sha → WorkflowRun.headSha (when set on the deployment)
linked PR → WorkflowRun.pullRequests (when set on the deployment)
- I intentionally reuse the existing WorkflowRun fields (no extra “dual branch/SHA” columns). Instead, `workflow_branch` column is added to `HeliosDeployment`. The workflow-dispatch branch remains available on `HeliosDeployment (workflow_branch)`, so we do not lose which ref the workflow was triggered from.


### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- A repo with a deployment workflow and Helios configured
- An environment with Deployment workflow branch set (e.g. to main)
- A non-default branch to deploy (e.g. feature/...) with an open PR

#### Flow:
1. Log in to Helios as a Developer
2. Open the Repository > Environment and confirm Deployment Workflow Branch is not the branch you will deploy (e.g. workflow from main, deploy feature/x).
3. Start a deployment from Helios targeting feature/x.
4. Wait until the GitHub Actions run finishes.
5. In Helios, open the components that previously showed main and the wrong SHA:
5.1. Test Results component in PR details and Branches details.
5.2. Last deployed branch/PR Labels in Environment component
5.3. Activity History of Environment (It should display both Helios-deployments and GitHub-deployments)
5.4. Deployment History of the branch/PR (It should display only Helios-deployments because for now we don't have necessary information for GitHub-only deployments.)
8. Confirm the run is associated with feature/x, the deployed commit SHA, and the expected PR if one exists.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.