### PR TITLE
refactor: replace JAXB with StAX for XML parsing in JunitParser

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/JunitParser.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/parsers/JunitParser.java
@@ -1,12 +1,5 @@
 package de.tum.cit.aet.helios.tests.parsers;
 
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.Unmarshaller;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlValue;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -14,22 +7,19 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
-import lombok.extern.log4j.Log4j2;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 import org.springframework.stereotype.Component;
 
 @Component
-@Log4j2
 public class JunitParser implements TestResultParser {
-  private static final JAXBContext JAXB_CONTEXT = createJaxbContext();
-
-  private static JAXBContext createJaxbContext() {
-    try {
-      return JAXBContext.newInstance(TestSuite.class, TestSuites.class);
-    } catch (JAXBException e) {
-      throw new IllegalStateException("Failed to initialize JUnit JAXB context", e);
-    }
-  }
+  private static final int MAX_FAILURE_MESSAGE_CHARS = 8_192;
+  private static final int MAX_FAILURE_TYPE_CHARS = 255;
+  private static final int MAX_STACK_TRACE_CHARS = 65_536;
+  private static final int MAX_SYSTEM_OUT_CHARS = 65_536;
+  private static final String TRUNCATION_SUFFIX = "\n...[truncated]";
 
   private static LocalDateTime parseDateTime(String dateTime) {
     try {
@@ -49,152 +39,296 @@ public class JunitParser implements TestResultParser {
    * @return A list of parsed test suites
    * @throws TestResultParseException if there is an error parsing the XML content
    */
+  @Override
   public List<TestResultParser.TestSuite> parse(InputStream inputStream)
       throws TestResultParseException {
+    XMLStreamReader reader = null;
     try {
-      Unmarshaller unmarshaller = JAXB_CONTEXT.createUnmarshaller();
-      Object unmarshalled = unmarshaller.unmarshal(inputStream);
-
-      if (unmarshalled instanceof TestSuites) {
-        TestSuites testSuites = (TestSuites) unmarshalled;
-        List<TestResultParser.TestSuite> result = new ArrayList<>();
-        for (TestSuite suite : testSuites.testsuites) {
-          result.add(convertJunitTestSuite(suite));
+      reader = createXmlStreamReader(inputStream);
+      while (reader.hasNext()) {
+        if (reader.next() != XMLStreamConstants.START_ELEMENT) {
+          continue;
         }
-        return result;
-      } else if (unmarshalled instanceof TestSuite) {
-        return Collections.singletonList(convertJunitTestSuite((TestSuite) unmarshalled));
-      } else {
-        throw new TestResultParseException("Unexpected root element type");
+
+        if ("testsuites".equals(reader.getLocalName())) {
+          return parseTestSuites(reader);
+        }
+        if ("testsuite".equals(reader.getLocalName())) {
+          return Collections.singletonList(parseTestSuite(reader));
+        }
+
+        throw new TestResultParseException(
+            "Unexpected root element type: " + reader.getLocalName());
       }
-    } catch (JAXBException e) {
+
+      throw new TestResultParseException("Missing root element");
+    } catch (XMLStreamException e) {
       throw new TestResultParseException("Failed to parse JUnit XML", e);
+    } finally {
+      closeReader(reader);
     }
   }
 
-  private TestResultParser.TestSuite convertJunitTestSuite(TestSuite suite) {
-    boolean hasSuiteFailures = suite.failures > 0 || suite.errors > 0;
-    return new TestResultParser.TestSuite(
-        suite.name,
-        parseDateTime(suite.timestamp),
-        suite.tests,
-        suite.failures,
-        suite.errors,
-        suite.skipped,
-        suite.time,
-        hasSuiteFailures ? concatenateSystemOut(suite.systemOut) : null,
-        suite.testcases.stream().map(this::parseTestCase).toList());
-  }
-
+  @Override
   public boolean supports(String fileName) {
     return (fileName.startsWith("TEST-") && fileName.endsWith(".xml"))
         || fileName.equals("results.xml")
         || fileName.equals("junit.xml");
   }
 
-  private TestResultParser.TestCase parseTestCase(TestCase tc) {
-    boolean failed = tc.failure != null;
-    boolean errored = tc.error != null;
+  private XMLStreamReader createXmlStreamReader(InputStream inputStream)
+      throws XMLStreamException {
+    XMLInputFactory factory = XMLInputFactory.newFactory();
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    return factory.createXMLStreamReader(inputStream);
+  }
+
+  private List<TestResultParser.TestSuite> parseTestSuites(XMLStreamReader reader)
+      throws XMLStreamException {
+    List<TestResultParser.TestSuite> suites = new ArrayList<>();
+    while (reader.hasNext()) {
+      int eventType = reader.next();
+      if (eventType == XMLStreamConstants.START_ELEMENT
+          && "testsuite".equals(reader.getLocalName())) {
+        suites.add(parseTestSuite(reader));
+      } else if (eventType == XMLStreamConstants.END_ELEMENT
+          && "testsuites".equals(reader.getLocalName())) {
+        return suites;
+      }
+    }
+    return suites;
+  }
+
+  private TestResultParser.TestSuite parseTestSuite(XMLStreamReader reader)
+      throws XMLStreamException {
+    String name = reader.getAttributeValue(null, "name");
+    int tests = parseIntAttribute(reader, "tests");
+    int failures = parseIntAttribute(reader, "failures");
+    int errors = parseIntAttribute(reader, "errors");
+    int skipped = parseIntAttribute(reader, "skipped");
+    double time = parseDoubleAttribute(reader, "time");
+    String timestamp = reader.getAttributeValue(null, "timestamp");
+    boolean keepSuiteSystemOut = failures > 0 || errors > 0;
+    TextAccumulator suiteSystemOut =
+        keepSuiteSystemOut ? new TextAccumulator(MAX_SYSTEM_OUT_CHARS) : null;
+    List<TestResultParser.TestCase> testCases = new ArrayList<>();
+
+    while (reader.hasNext()) {
+      int eventType = reader.next();
+      if (eventType == XMLStreamConstants.START_ELEMENT) {
+        switch (reader.getLocalName()) {
+          case "testcase" -> testCases.add(parseTestCase(reader));
+          case "system-out" -> {
+            if (suiteSystemOut != null) {
+              suiteSystemOut.appendElementText(reader, "\n");
+            } else {
+              skipElement(reader);
+            }
+          }
+          default -> skipElement(reader);
+        }
+      } else if (eventType == XMLStreamConstants.END_ELEMENT
+          && "testsuite".equals(reader.getLocalName())) {
+        return new TestResultParser.TestSuite(
+            name,
+            parseDateTime(timestamp),
+            tests,
+            failures,
+            errors,
+            skipped,
+            time,
+            suiteSystemOut == null ? null : suiteSystemOut.build(),
+            testCases);
+      }
+    }
+
+    throw new XMLStreamException("Unexpected end of document while parsing testsuite");
+  }
+
+  private TestResultParser.TestCase parseTestCase(XMLStreamReader reader)
+      throws XMLStreamException {
+    String name = reader.getAttributeValue(null, "name");
+    String className = reader.getAttributeValue(null, "classname");
+    double time = parseDoubleAttribute(reader, "time");
+    boolean failed = false;
+    boolean errored = false;
+    boolean skipped = false;
     String errorType = null;
     String message = null;
     String stackTrace = null;
+    TextAccumulator systemOut = new TextAccumulator(MAX_SYSTEM_OUT_CHARS);
 
-    if (failed) {
-      errorType = tc.failure.type;
-      message = tc.failure.message;
-      stackTrace = tc.failure.content;
-    } else if (errored) {
-      errorType = tc.error.type;
-      message = tc.error.message;
-      stackTrace = tc.error.content;
+    while (reader.hasNext()) {
+      int eventType = reader.next();
+      if (eventType == XMLStreamConstants.START_ELEMENT) {
+        switch (reader.getLocalName()) {
+          case "failure" -> {
+            FailureDetails details = parseFailureDetails(reader);
+            if (!failed) {
+              errorType = details.type();
+              message = details.message();
+              stackTrace = details.content();
+            }
+            failed = true;
+          }
+          case "error" -> {
+            FailureDetails details = parseFailureDetails(reader);
+            if (!failed && !errored) {
+              errorType = details.type();
+              message = details.message();
+              stackTrace = details.content();
+            }
+            errored = true;
+          }
+          case "skipped" -> {
+            skipped = true;
+            skipElement(reader);
+          }
+          case "system-out" -> systemOut.appendElementText(reader, "\n");
+          default -> skipElement(reader);
+        }
+      } else if (eventType == XMLStreamConstants.END_ELEMENT
+          && "testcase".equals(reader.getLocalName())) {
+        return new TestResultParser.TestCase(
+            name,
+            className,
+            time,
+            failed,
+            errored,
+            skipped,
+            errorType,
+            message,
+            stackTrace,
+            failed || errored ? systemOut.build() : null);
+      }
     }
 
-    return new TestResultParser.TestCase(
-        tc.name,
-        tc.className,
-        tc.time,
-        failed,
-        errored,
-        tc.skipped != null,
-        errorType,
-        message,
-        stackTrace,
-        failed || errored ? concatenateSystemOut(tc.systemOut) : null);
+    throw new XMLStreamException("Unexpected end of document while parsing testcase");
   }
 
-  @XmlRootElement(name = "testsuites")
-  public static class TestSuites {
-    @XmlElement(name = "testsuite")
-    public List<TestSuite> testsuites = new ArrayList<>();
+  private FailureDetails parseFailureDetails(XMLStreamReader reader) throws XMLStreamException {
+    String message =
+        truncateAttribute(
+            reader.getAttributeValue(null, "message"), MAX_FAILURE_MESSAGE_CHARS);
+    String type =
+        truncateAttribute(reader.getAttributeValue(null, "type"), MAX_FAILURE_TYPE_CHARS);
+    TextAccumulator content = new TextAccumulator(MAX_STACK_TRACE_CHARS);
+    content.appendElementText(reader, "");
+    return new FailureDetails(type, message, content.build());
   }
 
-  @XmlRootElement(name = "testsuite")
-  public static class TestSuite {
-    @XmlAttribute public String name;
-    @XmlAttribute public int tests;
-    @XmlAttribute public int failures;
-    @XmlAttribute public int errors;
-    @XmlAttribute public int skipped;
-    @XmlAttribute public double time;
-    @XmlAttribute public String timestamp;
-
-    @XmlElement(name = "testcase")
-    public List<TestCase> testcases = new ArrayList<>();
-
-    @XmlElement(name = "system-out")
-    public List<SystemOut> systemOut = new ArrayList<>();
+  private int parseIntAttribute(XMLStreamReader reader, String attributeName) {
+    String value = reader.getAttributeValue(null, attributeName);
+    return value == null || value.isBlank() ? 0 : Integer.parseInt(value);
   }
 
-  public static class SystemOut {
-    @XmlValue public String content;
+  private double parseDoubleAttribute(XMLStreamReader reader, String attributeName) {
+    String value = reader.getAttributeValue(null, attributeName);
+    return value == null || value.isBlank() ? 0.0 : Double.parseDouble(value);
   }
 
-  private String concatenateSystemOut(List<SystemOut> systemOuts) {
-    if (systemOuts == null || systemOuts.isEmpty()) {
-      return null;
+  private String truncateAttribute(String value, int maxChars) {
+    if (value == null || value.length() <= maxChars) {
+      return value;
     }
-    return systemOuts.stream()
-        .map(s -> s.content)
-        .filter(s -> s != null && !s.isEmpty())
-        .collect(Collectors.joining("\n"));
+    return value.substring(0, maxChars);
   }
 
-  public static class TestCase {
-    @XmlAttribute public String name;
-
-    @XmlAttribute(name = "classname")
-    public String className;
-
-    @XmlAttribute public double time;
-
-    @XmlElement(name = "failure")
-    public TestCaseFailure failure;
-
-    @XmlElement(name = "error")
-    public TestCaseError error;
-
-    @XmlElement(name = "skipped")
-    public TestCaseSkipped skipped;
-
-    @XmlElement(name = "system-out")
-    public List<SystemOut> systemOut = new ArrayList<>();
+  private static void skipElement(XMLStreamReader reader) throws XMLStreamException {
+    int depth = 1;
+    while (reader.hasNext() && depth > 0) {
+      int eventType = reader.next();
+      if (eventType == XMLStreamConstants.START_ELEMENT) {
+        depth++;
+      } else if (eventType == XMLStreamConstants.END_ELEMENT) {
+        depth--;
+      }
+    }
   }
 
-  public static class TestCaseFailure {
-    @XmlAttribute public String message;
+  private void closeReader(XMLStreamReader reader) {
+    if (reader == null) {
+      return;
+    }
 
-    @XmlAttribute public String type;
-
-    @XmlValue public String content;
+    try {
+      reader.close();
+    } catch (XMLStreamException ignored) {
+      // Ignore close failures for parser cleanup.
+    }
   }
 
-  public static class TestCaseError {
-    @XmlAttribute public String message;
+  private record FailureDetails(String type, String message, String content) {}
 
-    @XmlAttribute public String type;
+  private static final class TextAccumulator {
+    private final int maxChars;
+    private final int maxContentChars;
+    private final StringBuilder builder = new StringBuilder();
+    private boolean truncated;
 
-    @XmlValue public String content;
+    private TextAccumulator(int maxChars) {
+      this.maxChars = maxChars;
+      this.maxContentChars = Math.max(0, maxChars - TRUNCATION_SUFFIX.length());
+    }
+
+    private void appendElementText(XMLStreamReader reader, String separator)
+        throws XMLStreamException {
+      boolean appendSeparator = hasContent();
+      boolean sawTextInElement = false;
+
+      while (reader.hasNext()) {
+        int eventType = reader.next();
+        if (eventType == XMLStreamConstants.CHARACTERS
+            || eventType == XMLStreamConstants.CDATA
+            || eventType == XMLStreamConstants.SPACE) {
+          String text = reader.getText();
+          if (text == null || text.isEmpty()) {
+            continue;
+          }
+          if (!sawTextInElement && appendSeparator) {
+            append(separator);
+          }
+          append(text);
+          sawTextInElement = true;
+        } else if (eventType == XMLStreamConstants.START_ELEMENT) {
+          skipElement(reader);
+        } else if (eventType == XMLStreamConstants.END_ELEMENT) {
+          return;
+        }
+      }
+    }
+
+    private void append(String text) {
+      if (text == null || text.isEmpty()) {
+        return;
+      }
+
+      int remaining = maxContentChars - builder.length();
+      if (remaining > 0) {
+        builder.append(text, 0, Math.min(remaining, text.length()));
+      }
+      if (text.length() > remaining) {
+        truncated = true;
+      }
+    }
+
+    private boolean hasContent() {
+      return !builder.isEmpty() || truncated;
+    }
+
+    private String build() {
+      if (!hasContent()) {
+        return null;
+      }
+      String value = builder.toString();
+      if (!truncated) {
+        return value;
+      }
+      if (value.length() >= maxChars) {
+        return value.substring(0, maxChars);
+      }
+      return value + TRUNCATION_SUFFIX;
+    }
   }
-
-  public static class TestCaseSkipped {}
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/parsers/JunitParserTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/parsers/JunitParserTest.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.helios.tests.parsers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -53,5 +54,60 @@ class JunitParserTest {
     assertEquals(1, suites.size());
     assertEquals("suite output", suites.getFirst().systemOut());
     assertEquals("failed output", suites.getFirst().testCases().getFirst().systemOut());
+  }
+
+  @Test
+  void parse_shouldHandleTestsuitesRoot() throws TestResultParseException {
+    String xml =
+        """
+        <testsuites>
+          <testsuite name="suite-a" tests="1" failures="0" errors="0"
+              skipped="0" time="1.0" timestamp="2026-03-27T11:34:31Z">
+            <testcase name="passed-a" classname="pkg.TestA" time="0.1" />
+          </testsuite>
+          <testsuite name="suite-b" tests="1" failures="0" errors="0"
+              skipped="0" time="2.0" timestamp="2026-03-27T11:35:31Z">
+            <testcase name="passed-b" classname="pkg.TestB" time="0.2" />
+          </testsuite>
+        </testsuites>
+        """;
+
+    List<TestResultParser.TestSuite> suites =
+        junitParser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(2, suites.size());
+    assertEquals("suite-a", suites.get(0).name());
+    assertEquals("suite-b", suites.get(1).name());
+  }
+
+  @Test
+  void parse_shouldTruncateOversizedFailurePayloads() throws TestResultParseException {
+    String longMessage = "m".repeat(10_000);
+    String longStackTrace = "s".repeat(70_000);
+    String longSystemOut = "o".repeat(70_000);
+    String xml =
+        """
+        <testsuite name="suite" tests="1" failures="1" errors="0"
+            skipped="0" time="1.0" timestamp="2026-03-27T11:34:31Z">
+          <testcase name="failed" classname="pkg.Test" time="0.1">
+            <failure message="%s" type="AssertionError">%s</failure>
+            <system-out>%s</system-out>
+          </testcase>
+          <system-out>%s</system-out>
+        </testsuite>
+        """
+            .formatted(longMessage, longStackTrace, longSystemOut, longSystemOut);
+
+    List<TestResultParser.TestSuite> suites =
+        junitParser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+
+    TestResultParser.TestCase testCase = suites.getFirst().testCases().getFirst();
+    assertEquals(8_192, testCase.message().length());
+    assertEquals(65_536, testCase.stackTrace().length());
+    assertTrue(testCase.stackTrace().endsWith("[truncated]"));
+    assertEquals(65_536, testCase.systemOut().length());
+    assertTrue(testCase.systemOut().endsWith("[truncated]"));
+    assertEquals(65_536, suites.getFirst().systemOut().length());
+    assertTrue(suites.getFirst().systemOut().endsWith("[truncated]"));
   }
 }


### PR DESCRIPTION
### Motivation

The current `JunitParser` relies on JAXB unmarshalling, which eagerly materializes the XML structure and is less suitable for large JUnit result files. This refactor moves the parser to a streaming approach so it can handle larger payloads more safely, support both `testsuite` and `testsuites` roots directly, and avoid storing oversized failure or log output without bounds.

### Description

- Replace JAXB-based JUnit XML parsing with a StAX-based streaming parser in `JunitParser`
- Disable DTDs and external entities when creating the XML reader
- Add bounded truncation for large failure messages, stack traces, and `system-out` payloads
- Keep suite and testcase `system-out` output only when failures or errors are present
- Extend parser tests to cover `testsuites` roots and truncation of oversized XML payloads

### Testing Instructions
#### Prerequisites:
- JDK 21 is installed
- From the repository root, switch to this branch and run commands from `server/`

#### Flow:
1. Run `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :application-server:test --tests de.tum.cit.aet.helios.tests.parsers.JunitParserTest`
2. Review `JunitParser` and verify that XML parsing now uses `XMLStreamReader` instead of JAXB, with DTD and external entity support disabled
3. Inspect `JunitParserTest` and verify coverage for:
   1. parsing `<testsuites>` documents with multiple suites
   2. truncating oversized failure messages, stack traces, and `system-out` content
4. Confirm that parser behavior still preserves failing suite/testcase output while avoiding unbounded payload retention

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [ ] I documented the Java code using JavaDoc style.
