### PR TITLE
chore: add JVM heap dump and GC logging configuration in compose file

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -132,12 +132,15 @@ services:
       - HELIOS_PROD_SECRET_KEY=${HELIOS_PROD_SECRET_KEY}
       - HELIOS_STAGING_SECRET_KEY=${HELIOS_STAGING_SECRET_KEY}
       - HELIOS_DEVELOPERS_GITHUB_USERNAMES=${HELIOS_DEVELOPERS_GITHUB_USERNAMES}
+      - JAVA_TOOL_OPTIONS=-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -Xlog:gc*:file=/logs/gc.log:time,uptime,level,tags
     depends_on:
       - postgres
       - nats-server
       - webhook-listener
     volumes:
       - ./heliosapp.converted_key_pkcs8.pem:/app/heliosapp.converted_key_pkcs8.pem
+      - ./dumps:/dumps
+      - ./logs:/logs
     networks:
       - helios-network
 


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Enable heap dump generation on OutOfMemoryError and GC logging to improve observability and debugging of memory-related issues in the application.

### Description
<!-- Describe your changes in detail -->
- Added JVM options via JAVA_TOOL_OPTIONS in the Docker Compose configuration.
- Configured heap dumps to be written to /dumps.
- Configured GC logs to be written to /logs/gc.log.
- Added volume mounts to persist heap dumps and logs on the host machine.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- Docker and Docker Compose installed
- Access to the running environment
#### Flow:
1. Start the application using Docker Compose.
2. Trigger high memory usage (e.g., load test or artificially induce memory pressure).
3. Verify that:
3.1. A heap dump (.hprof) is created in the ./dumps directory.
3.2. GC logs are written to ./logs/gc.log.
4. Optionally inspect the heap dump using a heap analysis tool (e.g., Eclipse MAT).

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.