### PR TITLE
fix: optimize flakiness update process with chunked queries and batch writes to prevent oom exception

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -11,6 +11,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TestCaseFlakinessRepository
     extends JpaRepository<TestCaseFlakiness, Long>, JpaSpecificationExecutor<TestCaseFlakiness> {
+  interface FlakinessKeyRow {
+    Long getId();
+
+    String getTestName();
+
+    String getClassName();
+
+    String getTestSuiteName();
+  }
 
   /**
    * Total number of flaky tests for a repository, regardless of flakiness score.
@@ -37,6 +46,15 @@ public interface TestCaseFlakinessRepository
    */
   List<TestCaseFlakiness> findByTestSuiteNameInAndRepositoryRepositoryId(
       Collection<String> suiteNames, Long repositoryId);
+
+  @Query(
+      "SELECT f.id AS id, f.testName AS testName, f.className AS className,"
+          + " f.testSuiteName AS testSuiteName"
+          + " FROM TestCaseFlakiness f"
+          + " WHERE f.testSuiteName IN :suiteNames"
+          + " AND f.repository.repositoryId = :repositoryId")
+  List<FlakinessKeyRow> findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
+      @Param("suiteNames") Collection<String> suiteNames, @Param("repositoryId") Long repositoryId);
 
   /**
    * Finds flakiness records matching a test name and class name for a repository, ordered by

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsRepository.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -12,6 +14,17 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStatistics, Long> {
+  interface FailureRateRow {
+    String getTestName();
+
+    String getClassName();
+
+    String getTestSuiteName();
+
+    int getTotalRuns();
+
+    int getFailedRuns();
+  }
 
   /**
    * Find statistics for a specific test case on a specific branch.
@@ -64,4 +77,16 @@ public interface TestCaseStatisticsRepository extends JpaRepository<TestCaseStat
    */
   List<TestCaseStatistics> findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
       Collection<String> testSuiteNames, String branchName, Long repositoryId);
+
+  @Query(
+      "SELECT s.testName AS testName, s.className AS className, s.testSuiteName AS testSuiteName,"
+          + " s.totalRuns AS totalRuns, s.failedRuns AS failedRuns"
+          + " FROM TestCaseStatistics s"
+          + " WHERE s.testSuiteName IN :testSuiteNames"
+          + " AND s.branchName = :branchName"
+          + " AND s.repository.repositoryId = :repositoryId")
+  List<FailureRateRow> findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+      @Param("testSuiteNames") Collection<String> testSuiteNames,
+      @Param("branchName") String branchName,
+      @Param("repositoryId") Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -2,11 +2,12 @@ package de.tum.cit.aet.helios.tests;
 
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
+import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,9 +33,13 @@ public class TestCaseStatisticsService {
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
   private static final double MAX_FLAKY_RATE = 0.5; // 50%
+  private static final int MAX_SUITE_NAMES_PER_RECOMPUTE = 10_000;
+  private static final int SUITE_NAME_QUERY_CHUNK_SIZE = 250;
+  private static final int FLAKINESS_SAVE_BATCH_SIZE = 1_000;
 
   private final TestCaseStatisticsRepository statisticsRepository;
   private final TestCaseFlakinessRepository flakinessRepository;
+  private final EntityManager entityManager;
 
   /**
    * Composite key uniquely identifying one test case within a suite.
@@ -146,45 +151,57 @@ public class TestCaseStatisticsService {
     var suiteNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
 
     // Two bulk DB reads and index into Maps for O(1) per-test lookup
-    Map<StatsKey, Double> defaultRates =
-        indexFailureRates(
-            statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-                suiteNames, defaultBranch, repository.getRepositoryId()));
+    Map<StatsKey, Double> defaultRates = loadFailureRateIndex(
+        suiteNames, defaultBranch, repository.getRepositoryId());
+    Map<StatsKey, Double> combinedRates = loadFailureRateIndex(
+        suiteNames, "combined", repository.getRepositoryId());
 
-    Map<StatsKey, Double> combinedRates =
-        indexFailureRates(
-            statisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-                suiteNames, "combined", repository.getRepositoryId()));
-
-    // One bulk read for existing flakiness records to avoid N+1 SELECTs in the loop
-    Map<StatsKey, TestCaseFlakiness> existingFlakinessRecords = loadFlakinessIndex(
+    // Fetch only IDs + key fields to avoid loading full entities into the persistence context.
+    Map<StatsKey, Long> existingFlakinessIds = loadFlakinessIdIndex(
         suiteNames, repository.getRepositoryId());
 
-    Map<StatsKey, TestCaseFlakiness> flakinessMapToSave = new LinkedHashMap<>();
+    List<TestCaseFlakiness> batchToSave = new ArrayList<>(FLAKINESS_SAVE_BATCH_SIZE);
+    int savedRows = 0;
+    int batchNumber = 0;
     for (TestSuite suite : testSuites) {
       for (TestCase testCase : suite.getTestCases()) {
         var key = new StatsKey(testCase.getName(), testCase.getClassName(), suite.getName());
+        TestCaseFlakiness record = new TestCaseFlakiness();
+        Long existingId = existingFlakinessIds.get(key);
+        if (existingId != null) {
+          record.setId(existingId);
+        }
+        record.setTestName(key.testName());
+        record.setClassName(key.className());
+        record.setTestSuiteName(key.testSuiteName());
+        record.setRepository(repository);
+
         var info = computeFlakinessInfo(
             testCase.getName(), testCase.getClassName(), suite.getName(),
             defaultRates, combinedRates);
-
-        TestCaseFlakiness record = existingFlakinessRecords.getOrDefault(key, null);
-        if (record == null) {
-          record = new TestCaseFlakiness();
-          record.setTestName(key.testName());
-          record.setClassName(key.className());
-          record.setTestSuiteName(key.testSuiteName());
-          record.setRepository(repository);
-        }
         record.setFlakinessScore(info.flakinessScore());
         record.setDefaultBranchFailureRate(info.defaultBranchFailureRate());
         record.setCombinedFailureRate(info.combinedFailureRate());
         record.setLastUpdated(OffsetDateTime.now());
-        flakinessMapToSave.put(key, record);
+        batchToSave.add(record);
+
+        if (batchToSave.size() >= FLAKINESS_SAVE_BATCH_SIZE) {
+          batchNumber++;
+          saveFlakinessBatch(repository.getRepositoryId(), batchNumber, batchToSave);
+          savedRows += batchToSave.size();
+          batchToSave.clear();
+        }
       }
     }
 
-    flakinessRepository.saveAll(flakinessMapToSave.values());
+    if (!batchToSave.isEmpty()) {
+      batchNumber++;
+      saveFlakinessBatch(repository.getRepositoryId(), batchNumber, batchToSave);
+      savedRows += batchToSave.size();
+    }
+
+    log.info("Finished flakiness recomputation for repository {}: savedRows={}",
+        repository.getRepositoryId(), savedRows);
   }
 
   /**
@@ -206,6 +223,65 @@ public class TestCaseStatisticsService {
                 f -> new StatsKey(f.getTestName(), f.getClassName(), f.getTestSuiteName()),
                 f -> f,
                 (a, b) -> a));
+  }
+
+  private Map<StatsKey, Double> loadFailureRateIndex(
+      List<String> suiteNames, String branchName, Long repositoryId) {
+    Map<StatsKey, Double> rates = new HashMap<>();
+    for (List<String> chunk : chunked(suiteNames, SUITE_NAME_QUERY_CHUNK_SIZE)) {
+      List<TestCaseStatisticsRepository.FailureRateRow> rows =
+          statisticsRepository
+              .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+                  chunk,
+                  branchName,
+                  repositoryId);
+      for (TestCaseStatisticsRepository.FailureRateRow row : rows) {
+        rates.put(
+            new StatsKey(row.getTestName(), row.getClassName(), row.getTestSuiteName()),
+            row.getTotalRuns() > 0 ? (double) row.getFailedRuns() / row.getTotalRuns() : 0.0);
+      }
+    }
+    log.info(
+        "Loaded failure rates for repository {} branch {}: rows={}",
+        repositoryId,
+        branchName,
+        rates.size());
+    return rates;
+  }
+
+  private Map<StatsKey, Long> loadFlakinessIdIndex(List<String> suiteNames, Long repositoryId) {
+    Map<StatsKey, Long> ids = new HashMap<>();
+    for (List<String> chunk : chunked(suiteNames, SUITE_NAME_QUERY_CHUNK_SIZE)) {
+      List<TestCaseFlakinessRepository.FlakinessKeyRow> rows =
+          flakinessRepository.findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
+              chunk, repositoryId);
+      for (TestCaseFlakinessRepository.FlakinessKeyRow row : rows) {
+        ids.put(new StatsKey(row.getTestName(), row.getClassName(), row.getTestSuiteName()),
+            row.getId());
+      }
+    }
+    log.info("Loaded flakiness keys for repository {}: rows={}", repositoryId, ids.size());
+    return ids;
+  }
+
+  private void saveFlakinessBatch(
+      Long repositoryId, int batchNumber, List<TestCaseFlakiness> batch) {
+    flakinessRepository.saveAll(batch);
+    flakinessRepository.flush();
+    entityManager.clear();
+    log.debug("Saved flakiness batch {} for repository {}: size={}",
+        batchNumber, repositoryId, batch.size());
+  }
+
+  private static <T> List<List<T>> chunked(List<T> items, int chunkSize) {
+    if (items.isEmpty()) {
+      return List.of();
+    }
+    List<List<T>> chunks = new ArrayList<>((items.size() + chunkSize - 1) / chunkSize);
+    for (int i = 0; i < items.size(); i += chunkSize) {
+      chunks.add(items.subList(i, Math.min(items.size(), i + chunkSize)));
+    }
+    return chunks;
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -33,7 +33,6 @@ public class TestCaseStatisticsService {
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
   private static final double MAX_FLAKY_RATE = 0.5; // 50%
-  private static final int MAX_SUITE_NAMES_PER_RECOMPUTE = 10_000;
   private static final int SUITE_NAME_QUERY_CHUNK_SIZE = 250;
   private static final int FLAKINESS_SAVE_BATCH_SIZE = 1_000;
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -3,18 +3,26 @@ package de.tum.cit.aet.helios.tests;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -28,6 +36,7 @@ class TestCaseStatisticsServiceTest {
 
   @Mock private TestCaseStatisticsRepository statisticsRepository;
   @Mock private TestCaseFlakinessRepository flakinessRepository;
+  @Mock private EntityManager entityManager;
 
   @InjectMocks private TestCaseStatisticsService service;
 
@@ -50,7 +59,8 @@ class TestCaseStatisticsServiceTest {
         flakinessList,
         Pageable.ofSize(5), 10);
 
-    when(flakinessRepository.findAll(any(Specification.class), any(Pageable.class)))
+    when(flakinessRepository
+        .findAll(ArgumentMatchers.<Specification<TestCaseFlakiness>>any(), any(Pageable.class)))
         .thenReturn(page);
 
     when(flakinessRepository.countByRepositoryRepositoryId(repository.getRepositoryId()))
@@ -184,6 +194,36 @@ class TestCaseStatisticsServiceTest {
     assertEquals(0.0, info.flakinessScore());
   }
 
+  @Test
+  void updateFlakinessForTestSuite_chunksQueriesAndBatchesWrites() {
+    List<TestSuite> testSuites = new ArrayList<>();
+    for (int i = 0; i < 260; i++) {
+      testSuites.add(createSuiteWithSingleTest("Suite-" + i, "test-" + i, "Class-" + i));
+    }
+
+    when(statisticsRepository
+        .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            anyCollection(), any(), any()))
+        .thenReturn(List.of());
+    when(flakinessRepository.findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
+        anyCollection(), any()))
+        .thenReturn(List.of());
+
+    service.updateFlakinessForTestSuite(testSuites, "main", repository);
+
+    verify(statisticsRepository, times(2))
+        .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            anyCollection(), eq("main"), any());
+    verify(statisticsRepository, times(2))
+        .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            anyCollection(), eq("combined"), any());
+    verify(flakinessRepository, times(2))
+        .findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(anyCollection(), any());
+    verify(flakinessRepository).saveAll(any());
+    verify(flakinessRepository).flush();
+    verify(entityManager).clear();
+  }
+
   private TestCaseFlakiness createFlakiness(
       String testName,
       String className,
@@ -215,5 +255,25 @@ class TestCaseStatisticsServiceTest {
     stat.setFailedRuns(failed);
     stat.setLastUpdated(OffsetDateTime.now());
     return stat;
+  }
+
+  private static TestSuite createSuiteWithSingleTest(
+      String suiteName, String testName, String className) {
+    TestCase testCase = new TestCase();
+    testCase.setName(testName);
+    testCase.setClassName(className);
+    testCase.setStatus(TestCase.TestStatus.PASSED);
+    testCase.setTime(0.1);
+
+    TestSuite suite = new TestSuite();
+    suite.setName(suiteName);
+    suite.setTimestamp(LocalDateTime.now());
+    suite.setTests(1);
+    suite.setFailures(0);
+    suite.setErrors(0);
+    suite.setSkipped(0);
+    suite.setTime(0.1);
+    suite.setTestCases(List.of(testCase));
+    return suite;
   }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Staging experienced repeated `java.lang.OutOfMemoryError: Java heap space` during test-result processing.
Heap-dump analysis showed memory concentrated in test-result-processor-1, with very large Hibernate/JDBC result materialization and persistence-context retention while recomputing flakiness (`TestCaseStatisticsService.updateFlakinessForTestSuite`).
This change is required to make flakiness recomputation memory-safe under high data volume and prevent service instability.

### Description
<!-- Describe your changes in detail -->
- Refactored flakiness recomputation data path to reduce heap pressure:
  - replaced heavy entity-based reads with lightweight projection queries for stats/flakiness keys.
  - added chunked suite-name querying to avoid very large IN processing at once.
- Added bounded batch persistence for flakiness writes:
  - save in batches.
  - call flush()/clear() per batch to prevent unbounded first-level persistence-context growth.
- Added/updated tests to cover chunked query behavior and batched save flow.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- ...
#### Flow:
1. Log in to Helios as a Developer
2. Start Helios and trigger test-result processing for workflows with many test suites/cases.
3. Observe application logs for flakiness recomputation:
3.1. verify chunked-load/batch-save logs appear.
3.2. verify no OutOfMemoryError occurs during recomputation.
4. Validate functional correctness:
4.1. flakiness scores are still persisted/updated.
4.2. API/UI views using flakiness data behave as before.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
