### PR TITLE
fix: implement upsert functionality for flakiness records to optimize database interactions

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseFlakinessRepository.java
@@ -1,9 +1,11 @@
 package de.tum.cit.aet.helios.tests;
 
+import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -11,15 +13,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface TestCaseFlakinessRepository
     extends JpaRepository<TestCaseFlakiness, Long>, JpaSpecificationExecutor<TestCaseFlakiness> {
-  interface FlakinessKeyRow {
-    Long getId();
-
-    String getTestName();
-
-    String getClassName();
-
-    String getTestSuiteName();
-  }
 
   /**
    * Total number of flaky tests for a repository, regardless of flakiness score.
@@ -47,14 +40,37 @@ public interface TestCaseFlakinessRepository
   List<TestCaseFlakiness> findByTestSuiteNameInAndRepositoryRepositoryId(
       Collection<String> suiteNames, Long repositoryId);
 
+  /**
+   * Inserts or updates a flakiness row for a single test case. Uses PostgreSQL
+   * {@code ON CONFLICT DO UPDATE} so concurrent calls for the same test are safe — the second
+   * writer simply overwrites with the latest computed score rather than failing.
+   */
+  @Modifying
   @Query(
-      "SELECT f.id AS id, f.testName AS testName, f.className AS className,"
-          + " f.testSuiteName AS testSuiteName"
-          + " FROM TestCaseFlakiness f"
-          + " WHERE f.testSuiteName IN :suiteNames"
-          + " AND f.repository.repositoryId = :repositoryId")
-  List<FlakinessKeyRow> findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
-      @Param("suiteNames") Collection<String> suiteNames, @Param("repositoryId") Long repositoryId);
+      value =
+          """
+          INSERT INTO test_case_flakiness
+              (repository_id, test_name, class_name, test_suite_name,
+               flakiness_score, default_branch_failure_rate, combined_failure_rate, last_updated)
+          VALUES (:repositoryId, :testName, :className, :suiteName,
+                  :flakinessScore, :defaultRate, :combinedRate, :lastUpdated)
+          ON CONFLICT ON CONSTRAINT uk_test_case_flakiness
+          DO UPDATE SET
+              flakiness_score             = EXCLUDED.flakiness_score,
+              default_branch_failure_rate = EXCLUDED.default_branch_failure_rate,
+              combined_failure_rate       = EXCLUDED.combined_failure_rate,
+              last_updated                = EXCLUDED.last_updated
+          """,
+      nativeQuery = true)
+  void upsertFlakiness(
+      @Param("repositoryId") Long repositoryId,
+      @Param("testName") String testName,
+      @Param("className") String className,
+      @Param("suiteName") String suiteName,
+      @Param("flakinessScore") double flakinessScore,
+      @Param("defaultRate") double defaultRate,
+      @Param("combinedRate") double combinedRate,
+      @Param("lastUpdated") OffsetDateTime lastUpdated);
 
   /**
    * Finds flakiness records matching a test name and class name for a repository, ordered by

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -2,7 +2,6 @@ package de.tum.cit.aet.helios.tests;
 
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
-import jakarta.persistence.EntityManager;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
@@ -34,11 +33,9 @@ public class TestCaseStatisticsService {
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
   private static final double MAX_FLAKY_RATE = 0.5; // 50%
   private static final int SUITE_NAME_QUERY_CHUNK_SIZE = 250;
-  private static final int FLAKINESS_SAVE_BATCH_SIZE = 1_000;
 
   private final TestCaseStatisticsRepository statisticsRepository;
   private final TestCaseFlakinessRepository flakinessRepository;
-  private final EntityManager entityManager;
 
   /**
    * Composite key uniquely identifying one test case within a suite.
@@ -133,11 +130,12 @@ public class TestCaseStatisticsService {
   }
 
   /**
-   * Recomputes and persists flakiness scores for all tests belonging to the given suites.
+   * Recomputes and persists flakiness scores for all test cases in the given suites.
    *
-   * <p>All statistics and existing flakiness records are fetched in two bulk queries and indexed
-   * into {@link Map}s before the test-case loop, making per-test lookups O(1). Scores are persisted
-   * even when equal to zero so consumers can distinguish "known non-flaky" from "no record yet".
+   * <p>Failure rates are pre-loaded in two bulk queries (default branch + combined) and indexed
+   * into {@link Map}s so each per-test score computation is O(1). Each score is written via a
+   * native {@code INSERT ... ON CONFLICT DO UPDATE} that bypasses the Hibernate first-level cache
+   * entirely, preventing session growth and handling concurrent calls safely.
    *
    * @param testSuites the suites processed in this run
    * @param defaultBranch the repository's default branch name
@@ -150,57 +148,32 @@ public class TestCaseStatisticsService {
     var suiteNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
 
     // Two bulk DB reads and index into Maps for O(1) per-test lookup
-    Map<StatsKey, Double> defaultRates = loadFailureRateIndex(
-        suiteNames, defaultBranch, repository.getRepositoryId());
-    Map<StatsKey, Double> combinedRates = loadFailureRateIndex(
-        suiteNames, "combined", repository.getRepositoryId());
+    Map<StatsKey, Double> defaultRates =
+        loadFailureRateIndex(suiteNames, defaultBranch, repository.getRepositoryId());
+    Map<StatsKey, Double> combinedRates =
+        loadFailureRateIndex(suiteNames, "combined", repository.getRepositoryId());
 
-    // Fetch only IDs + key fields to avoid loading full entities into the persistence context.
-    Map<StatsKey, Long> existingFlakinessIds = loadFlakinessIdIndex(
-        suiteNames, repository.getRepositoryId());
-
-    List<TestCaseFlakiness> batchToSave = new ArrayList<>(FLAKINESS_SAVE_BATCH_SIZE);
-    int savedRows = 0;
-    int batchNumber = 0;
+    OffsetDateTime now = OffsetDateTime.now();
+    int count = 0;
     for (TestSuite suite : testSuites) {
       for (TestCase testCase : suite.getTestCases()) {
-        var key = new StatsKey(testCase.getName(), testCase.getClassName(), suite.getName());
-        TestCaseFlakiness record = new TestCaseFlakiness();
-        Long existingId = existingFlakinessIds.get(key);
-        if (existingId != null) {
-          record.setId(existingId);
-        }
-        record.setTestName(key.testName());
-        record.setClassName(key.className());
-        record.setTestSuiteName(key.testSuiteName());
-        record.setRepository(repository);
-
         var info = computeFlakinessInfo(
             testCase.getName(), testCase.getClassName(), suite.getName(),
             defaultRates, combinedRates);
-        record.setFlakinessScore(info.flakinessScore());
-        record.setDefaultBranchFailureRate(info.defaultBranchFailureRate());
-        record.setCombinedFailureRate(info.combinedFailureRate());
-        record.setLastUpdated(OffsetDateTime.now());
-        batchToSave.add(record);
-
-        if (batchToSave.size() >= FLAKINESS_SAVE_BATCH_SIZE) {
-          batchNumber++;
-          saveFlakinessBatch(repository.getRepositoryId(), batchNumber, batchToSave);
-          savedRows += batchToSave.size();
-          batchToSave.clear();
-        }
+        flakinessRepository.upsertFlakiness(
+            repository.getRepositoryId(),
+            testCase.getName(),
+            testCase.getClassName(),
+            suite.getName(),
+            info.flakinessScore(),
+            info.defaultBranchFailureRate(),
+            info.combinedFailureRate(),
+            now);
+        count++;
       }
     }
-
-    if (!batchToSave.isEmpty()) {
-      batchNumber++;
-      saveFlakinessBatch(repository.getRepositoryId(), batchNumber, batchToSave);
-      savedRows += batchToSave.size();
-    }
-
-    log.info("Finished flakiness recomputation for repository {}: savedRows={}",
-        repository.getRepositoryId(), savedRows);
+    log.info("Finished flakiness upsert for repository {}: rows={}",
+        repository.getRepositoryId(), count);
   }
 
   /**
@@ -246,30 +219,6 @@ public class TestCaseStatisticsService {
         branchName,
         rates.size());
     return rates;
-  }
-
-  private Map<StatsKey, Long> loadFlakinessIdIndex(List<String> suiteNames, Long repositoryId) {
-    Map<StatsKey, Long> ids = new HashMap<>();
-    for (List<String> chunk : chunked(suiteNames, SUITE_NAME_QUERY_CHUNK_SIZE)) {
-      List<TestCaseFlakinessRepository.FlakinessKeyRow> rows =
-          flakinessRepository.findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
-              chunk, repositoryId);
-      for (TestCaseFlakinessRepository.FlakinessKeyRow row : rows) {
-        ids.put(new StatsKey(row.getTestName(), row.getClassName(), row.getTestSuiteName()),
-            row.getId());
-      }
-    }
-    log.info("Loaded flakiness keys for repository {}: rows={}", repositoryId, ids.size());
-    return ids;
-  }
-
-  private void saveFlakinessBatch(
-      Long repositoryId, int batchNumber, List<TestCaseFlakiness> batch) {
-    flakinessRepository.saveAll(batch);
-    flakinessRepository.flush();
-    entityManager.clear();
-    log.debug("Saved flakiness batch {} for repository {}: size={}",
-        batchNumber, repositoryId, batch.size());
   }
 
   private static <T> List<List<T>> chunked(List<T> items, int chunkSize) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -84,6 +84,7 @@ public class TestResultProcessor {
 
       // Update test statistics if the workflow run is on the default branch
       updateTestStatisticsIfDefaultBranch(testSuites, workflowRun);
+      updateFlakiness(testSuites, workflowRun);
     } catch (Exception e) {
       log.error("Failed to process test results for workflow run {}", workflowRun.getName(), e);
       workflowRun.setTestProcessingStatus(WorkflowRun.TestProcessingStatus.FAILED);
@@ -291,9 +292,6 @@ public class TestResultProcessor {
           "combined",
           repository.get()); // update statistics for all the branches combined
       log.debug("Successfully updated test statistics for all branches combined");
-
-      updateFlakinessScores(testSuites, defaultBranch, repository.get());
-      log.debug("Successfully recomputed flakiness scores for affected tests");
     } catch (Exception e) {
       log.error("Error while trying to update test statistics", e);
       // Don't fail the overall process if statistics update fails
@@ -322,24 +320,22 @@ public class TestResultProcessor {
 
   /**
    * Recomputes and persists flakiness scores for all tests belonging to the given suites.
-   * Called after both the default-branch and combined statistics have been updated for a run.
-   * Only fetches stats rows for the suite names present in the current run, keeping
-   * the query bounded.
+   * Called from {@link #processRun} after the statistics transaction has
+   * already committed, so that the flakiness update runs in its own fresh Hibernate session.
    *
-   * @param testSuites the suites processed in this run
-   * @param defaultBranchName the repository's default branch name
-   * @param repository the repository
+   * @param testSuites the test suites processed in this run
+   * @param workflowRun the workflow run
    */
-  public void updateFlakinessScores(
-      List<TestSuite> testSuites, String defaultBranchName, GitRepository repository) {
+  private void updateFlakiness(List<TestSuite> testSuites, WorkflowRun workflowRun) {
     try {
-      statisticsService.updateFlakinessForTestSuite(testSuites, defaultBranchName, repository);
-      log.debug("Successfully updated flakiness info for repository: {}",
-          repository.getRepositoryId());
+      GitRepository repository = gitRepoRepository
+          .findById(workflowRun.getRepository().getRepositoryId())
+          .orElseThrow();
+
+      statisticsService.updateFlakinessForTestSuite(
+          testSuites, repository.getDefaultBranch(), repository);
     } catch (Exception e) {
-      log.error("Failed to update flakiness info for repository: {}",
-          repository.getRepositoryId(), e);
-      // Don't fail the overall process if flakiness update fails
+      log.error("Failed to update flakiness scores for workflow run {}", workflowRun.getName(), e);
     }
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -12,7 +13,6 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
-import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -36,7 +36,6 @@ class TestCaseStatisticsServiceTest {
 
   @Mock private TestCaseStatisticsRepository statisticsRepository;
   @Mock private TestCaseFlakinessRepository flakinessRepository;
-  @Mock private EntityManager entityManager;
 
   @InjectMocks private TestCaseStatisticsService service;
 
@@ -205,9 +204,6 @@ class TestCaseStatisticsServiceTest {
         .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyCollection(), any(), any()))
         .thenReturn(List.of());
-    when(flakinessRepository.findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(
-        anyCollection(), any()))
-        .thenReturn(List.of());
 
     service.updateFlakinessForTestSuite(testSuites, "main", repository);
 
@@ -217,11 +213,27 @@ class TestCaseStatisticsServiceTest {
     verify(statisticsRepository, times(2))
         .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyCollection(), eq("combined"), any());
-    verify(flakinessRepository, times(2))
-        .findFlakinessKeyRowsByTestSuiteNameInAndRepositoryRepositoryId(anyCollection(), any());
-    verify(flakinessRepository).saveAll(any());
-    verify(flakinessRepository).flush();
-    verify(entityManager).clear();
+    verify(flakinessRepository, times(260)).upsertFlakiness(
+        any(), any(), any(), any(), anyDouble(), anyDouble(), anyDouble(), any());
+  }
+
+  @Test
+  void updateFlakinessForTestSuite_callsUpsertForEveryTestCaseOccurrence() {
+    // Two suites that share the same logical key — native ON CONFLICT handles duplicates in the DB
+    TestSuite suiteA = createSuiteWithSingleTest("SameSuite", "sameTest", "SameClass");
+    TestSuite suiteB = createSuiteWithSingleTest("SameSuite", "sameTest", "SameClass");
+    List<TestSuite> testSuites = List.of(suiteA, suiteB);
+
+    when(statisticsRepository
+        .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            anyCollection(), any(), any()))
+        .thenReturn(List.of());
+
+    service.updateFlakinessForTestSuite(testSuites, "main", repository);
+
+    // Called once per test-case occurrence; DB upsert safely overwrites on conflict
+    verify(flakinessRepository, times(2)).upsertFlakiness(
+        any(), any(), any(), any(), anyDouble(), anyDouble(), anyDouble(), any());
   }
 
   private TestCaseFlakiness createFlakiness(


### PR DESCRIPTION

<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The staging application server intermittently crashed with `java.lang.OutOfMemoryError: Java heap space` during test processing.
Heap analysis showed that statistics and flakiness updates were executed in the same long-lived transaction/session, causing very large Hibernate memory retention, and flakiness processing additionally created a large number of projection/proxy objects. Concurrent insert paths in flakiness writes also allowed race conditions.

### Description
<!-- Describe your changes in detail -->
- Moved flakiness recomputation out of `updateTestStatisticsIfDefaultBranch` and triggered it afterward from `processRun` via a dedicated helper, so it runs in a separate transaction/session from statistics updates.
- Reworked flakiness persistence to use repository-level native upsert (INSERT ... ON CONFLICT DO UPDATE) for each computed row.
- Removed the old flakiness preloading/dedup path based on FlakinessKeyRow and associated batch-save.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- Helios with at least one repo with multiple tests 

#### Flow:
1. Log in to Helios as a Developer
2. Start Helios and trigger test-result processing for workflows with many test suites/cases.
3. Observe application logs for flakiness recomputation:
3.1. verify chunked-load/batch-save logs appear.
3.2. verify no OutOfMemoryError occurs during recomputation.
4. Validate functional correctness:
4.1. flakiness scores are still persisted/updated.
4.2. API/UI views using flakiness data behave as before.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
