### PR TITLE
fix: fetch pull request IDs by workflow run ID to avoid lazy-loading LOB issues

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultService.java
@@ -239,16 +239,16 @@ public class TestResultService {
 
     List<WorkflowRun> previousRuns = List.of();
     if (run.getHeadBranch() != null && run.getHeadSha() != null) {
-      var pullRequests = run.getPullRequests();
-      if (pullRequests != null && !pullRequests.isEmpty()) {
+      var pullRequestIds = workflowRunRepository.findPullRequestIdsByWorkflowRunId(run.getId());
+      if (!pullRequestIds.isEmpty()) {
         // A run can technically be associated with multiple PRs.
         // We pick the lowest PR ID (oldest PR) for a deterministic baseline; in
         // practice the sync service almost always resolves to exactly one PR per run.
         // TODO consider better handling of multiple PRs
-        var prId = pullRequests.stream()
-            .min(Comparator.comparingLong(pr -> pr.getId()))
+        var prId = pullRequestIds.stream()
+            .min(Comparator.naturalOrder())
             .orElseThrow()
-            .getId();
+            .longValue();
         previousRuns =
             workflowRunRepository
                 .findNthLatestCommitShaBehindHeadByPullRequestId(prId, 0, run.getHeadSha())

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -120,6 +120,9 @@ public interface WorkflowRunRepository
 
   List<WorkflowRun> findByPullRequestsIdAndHeadSha(Long pullRequestsId, String headSha);
 
+  @Query("SELECT pr.id FROM WorkflowRun wr JOIN wr.pullRequests pr WHERE wr.id = :workflowRunId")
+  List<Long> findPullRequestIdsByWorkflowRunId(@Param("workflowRunId") Long workflowRunId);
+
   List<WorkflowRun> findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
       String branch, String headSha, Long repositoryId);
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultServiceTest.java
@@ -237,6 +237,62 @@ class TestResultServiceTest {
   }
 
   @Test
+  void getLatestTestResultsForWorkflowRun_shouldReturnResults() {
+    final TestResultService.TestSearchCriteria criteria =
+        new TestResultService.TestSearchCriteria(0, 10, "", false);
+
+    when(workflowRunRepository.findByIdAndRepositoryRepositoryId(1L, 1L))
+        .thenReturn(Optional.of(workflowRun));
+    when(branchRepository.findFirstByRepositoryRepositoryIdAndIsDefaultTrue(anyLong()))
+        .thenReturn(Optional.of(defaultBranch));
+    when(workflowRunRepository.findByHeadBranchAndHeadShaAndRepositoryRepositoryId(
+            eq("main"), eq("defaultSha"), anyLong()))
+        .thenReturn(List.of(workflowRun));
+    when(workflowRunRepository.findPullRequestIdsByWorkflowRunId(1L))
+        .thenReturn(List.of(42L));
+    when(workflowRunRepository.findNthLatestCommitShaBehindHeadByPullRequestId(
+        42L, 0, "featureSha"))
+        .thenReturn(Optional.empty());
+
+    TestSuiteSummaryDto summary = new TestSuiteSummaryDto(1L, 0L, 0L, 0L, 0.0, false);
+    when(testSuiteRepository.findByWorkflowRunIdAndTestTypeId(
+            anyLong(), anyLong(), any(), anyString(), anyBoolean(), any(PageRequest.class)))
+        .thenReturn(new PageImpl<>(List.of(testSuite)));
+    when(testSuiteRepository.findSummaryByWorkflowRunIdAndTestTypeId(anyLong(), anyLong(), any()))
+        .thenReturn(summary);
+    when(testCaseRepository.findFailedByTestSuiteWorkflowIdAndClassNamesAndTestTypeId(
+            any(), anyList(), anyLong()))
+        .thenReturn(Collections.emptyList());
+    when(testCaseStatisticsRepository.findByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+            anyList(), anyString(), anyLong()))
+        .thenReturn(Collections.emptyList());
+    when(testCaseStatisticsService.loadFlakinessIndex(anyList(), anyLong()))
+        .thenReturn(Collections.emptyMap());
+    lenient()
+        .when(testCaseStatisticsService.computeFlakinessInfo(
+            anyString(), anyString(), anyString(), anyMap(), anyMap()))
+        .thenReturn(new TestCaseStatisticsService.FlakinessInfo(0.0, 0.0, 0.0));
+
+    TestResultsDto result = testResultService.getTestResultsForWorkflowRun(1L, criteria);
+
+    assertNotNull(result);
+    assertFalse(result.testResults().isEmpty());
+    assertEquals(1, result.testResults().size());
+    TestResultsDto.TestTypeResults testTypeResults = result.testResults().getFirst();
+    assertEquals("Java", testTypeResults.testTypeName());
+    assertFalse(testTypeResults.testSuites().isEmpty());
+    assertEquals("TestSuite1", testTypeResults.testSuites().getFirst().name());
+    assertEquals(1, testTypeResults.testSuites().getFirst().testCases().size());
+    assertEquals("test1", testTypeResults.testSuites().getFirst().testCases().getFirst().name());
+
+    verify(workflowRunRepository).findPullRequestIdsByWorkflowRunId(1L);
+    verify(workflowRunRepository).findNthLatestCommitShaBehindHeadByPullRequestId(
+        42L, 0, "featureSha");
+    verify(testCaseStatisticsService).computeFlakinessInfo(
+        anyString(), anyString(), anyString(), anyMap(), anyMap());
+  }
+
+  @Test
   void sortTestCases_shouldSortCorrectly() throws Exception {
     TestCase tc1 = new TestCase();
     tc1.setName("AlphaTest");


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Opening workflow run details with test cases sometimes triggered a 500 with `HibernateException: Unable to access lob stream, caused by PostgreSQL Large Objects not being usable in auto-commit mode`. That happened when lazy-loading the run’s pull requests having a body. PRs are stored in `Issue` table which has  `@Lob body` field. The screenshot of an example UI is attached below:

<img width="2918" height="1698" alt="image" src="https://github.com/user-attachments/assets/016ea79d-12e5-4467-b82d-439367a6a088" />

### Description
<!-- Describe your changes in detail -->
- `TestResultService.getTestResultsForWorkflowRun`: stopped using `run.getPullRequests().isEmpty()` and instead loads only `PR IDs` via `WorkflowRunRepository.findPullRequestIdsByWorkflowRunId`, then picks the smallest ID (same deterministic rule as before).
- `WorkflowRunRepository`: added a JPQL query that selects `pr.id` for a given `workflow run id` instead of full PR.
- Added test for `TestResultService.getTestResultsForWorkflowRun`.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- Running Helios with a connected repository that includes at least one PR with body field

#### Flow:
1. Log in to Helios as a Developer
2. Navigate to CI/CD menu
3. Open Workflow Run menu and find a workflow run that has test cases and is associated with a PR including PR body. 
4. Open run details and ensure the test results load without `500` / `Unable to access lob stream`.
5. Open a PR view with tests and a branch view with tests; confirm results still load as before.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.
