### PR TITLE
fix: enhance GitHub environment synchronization with pagination and incomplete fetch handling

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -706,14 +706,22 @@ public class EnvironmentService {
       throw new EntityNotFoundException("GitHub repository not found for repository ID: " + repoId);
     }
     try {
-      List<GitHubEnvironmentDto> gitHubEnvironmentDtos =
-          gitHubService.getEnvironments(ghRepository);
+      GitHubService.EnvironmentFetchResult environmentFetchResult =
+          gitHubService.fetchEnvironments(ghRepository);
+      List<GitHubEnvironmentDto> gitHubEnvironmentDtos = environmentFetchResult.environments();
 
       for (GitHubEnvironmentDto gitHubEnvironmentDto : gitHubEnvironmentDtos) {
         environmentSyncService.processEnvironment(gitHubEnvironmentDto, ghRepository);
       }
 
-      environmentSyncService.removeDeletedEnvironments(gitHubEnvironmentDtos, repoId);
+      if (environmentFetchResult.complete()) {
+        environmentSyncService.removeDeletedEnvironments(gitHubEnvironmentDtos, repoId);
+      } else {
+        log.warn(
+            "Skipping deleted environment cleanup for repository {} because the GitHub"
+                + " environment list was incomplete.",
+            ghRepository.getFullName());
+      }
 
     } catch (IOException e) {
       log.error(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncService.java
@@ -67,6 +67,14 @@ public class GitHubEnvironmentSyncService {
   @Transactional
   public void removeDeletedEnvironments(
       @NotNull List<GitHubEnvironmentDto> gitHubEnvironments, @NotNull Long repositoryId) {
+    if (gitHubEnvironments.isEmpty()) {
+      log.warn(
+          "Skipping environment deletion for repository (ID: {}) because GitHub returned an empty"
+              + " environment list.",
+          repositoryId);
+      return;
+    }
+
     Set<Long> githubEnvironmentIds =
         gitHubEnvironments.stream().map(GitHubEnvironmentDto::getId).collect(Collectors.toSet());
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -19,6 +19,7 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -54,6 +55,9 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class GitHubService {
   private static final String GITHUB_API_VERSION = "2026-03-10";
+  private static final int GITHUB_ENVIRONMENTS_PAGE_SIZE = 100;
+
+  public record EnvironmentFetchResult(List<GitHubEnvironmentDto> environments, boolean complete) {}
 
   private final GitHubFacade github;
   private final GitHubConfig gitHubConfig;
@@ -218,10 +222,72 @@ public class GitHubService {
    * @throws IOException if an I/O error occurs
    */
   public List<GitHubEnvironmentDto> getEnvironments(GHRepository repository) throws IOException {
+    return fetchEnvironments(repository).environments();
+  }
+
+  public EnvironmentFetchResult fetchEnvironments(GHRepository repository) throws IOException {
     final String owner = repository.getOwnerName();
     final String repoName = repository.getName();
+    List<GitHubEnvironmentDto> environments = new ArrayList<>();
+    Integer expectedTotalCount = null;
+    boolean complete = true;
+
+    for (int page = 1; ; page++) {
+      GitHubEnvironmentApiResponse envResponse = fetchEnvironmentPage(owner, repoName, page);
+      List<GitHubEnvironmentDto> pageEnvironments =
+          Optional.ofNullable(envResponse.getEnvironments()).orElse(List.of());
+
+      if (expectedTotalCount == null) {
+        expectedTotalCount = envResponse.getTotalCount();
+      } else if (!expectedTotalCount.equals(envResponse.getTotalCount())) {
+        log.warn(
+            "GitHub environments total count changed during pagination for {}/{}. Skipping"
+                + " delete cleanup for this sync.",
+            owner,
+            repoName);
+        complete = false;
+        break;
+      }
+
+      environments.addAll(pageEnvironments);
+
+      if (environments.size() >= expectedTotalCount) {
+        break;
+      }
+
+      if (pageEnvironments.isEmpty()) {
+        log.warn(
+            "Incomplete environment list from GitHub for {}/{}: expected {} but received {}."
+                + " Skipping delete cleanup for this sync.",
+            owner,
+            repoName,
+            expectedTotalCount,
+            environments.size());
+        complete = false;
+        break;
+      }
+    }
+
+    if (expectedTotalCount != null && environments.size() != expectedTotalCount) {
+      log.warn(
+          "Incomplete environment list from GitHub for {}/{}: expected {} but received {}."
+              + " Skipping delete cleanup for this sync.",
+          owner,
+          repoName,
+          expectedTotalCount,
+          environments.size());
+      complete = false;
+    }
+
+    return new EnvironmentFetchResult(List.copyOf(environments), complete);
+  }
+
+  private GitHubEnvironmentApiResponse fetchEnvironmentPage(String owner, String repoName, int page)
+      throws IOException {
     final String url =
-        String.format("https://api.github.com/repos/%s/%s/environments", owner, repoName);
+        String.format(
+            "https://api.github.com/repos/%s/%s/environments?per_page=%d&page=%d",
+            owner, repoName, GITHUB_ENVIRONMENTS_PAGE_SIZE, page);
 
     Request request = getRequestBuilder().url(url).get().build();
 
@@ -235,15 +301,7 @@ public class GitHubService {
       }
 
       String responseBody = response.body().string();
-      GitHubEnvironmentApiResponse envResponse =
-          objectMapper.readValue(responseBody, GitHubEnvironmentApiResponse.class);
-      return envResponse.getEnvironments();
-    } catch (JsonProcessingException e) {
-      log.error("Error processing JSON response: {}", e.getMessage());
-      throw e;
-    } catch (IOException e) {
-      log.error("Error occurred while fetching environments: {}", e.getMessage());
-      throw e;
+      return objectMapper.readValue(responseBody, GitHubEnvironmentApiResponse.class);
     }
   }
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
@@ -11,8 +11,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.cit.aet.helios.auth.AuthService;
 import de.tum.cit.aet.helios.deployment.DeploymentRepository;
+import de.tum.cit.aet.helios.environment.github.GitHubEnvironmentSyncService;
+import de.tum.cit.aet.helios.environment.protectionrules.ProtectionRuleRepository;
+import de.tum.cit.aet.helios.filters.RepositoryContext;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsService;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
@@ -28,8 +34,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.runner.RunWith;
+import org.kohsuke.github.GHRepository;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -47,6 +55,11 @@ public class EnvironmentServiceTest {
   @Mock private EnvironmentScheduler environmentScheduler;
   @Mock private WorkflowRepository workflowRepository;
   @Mock private NatsNotificationPublisherService notificationPublisherService;
+  @Mock private ProtectionRuleRepository protectionRuleRepository;
+  @Mock private ObjectMapper objectMapper;
+  @Mock private GitHubEnvironmentSyncService environmentSyncService;
+  @Mock private GitRepoRepository gitRepoRepository;
+  @Mock private GitHubService gitHubService;
 
   @InjectMocks private EnvironmentService environmentService;
 
@@ -415,5 +428,27 @@ public class EnvironmentServiceTest {
 
     verify(environmentRepository, times(1)).findById(1L);
     verify(workflowRepository, times(1)).findById(1L);
+  }
+
+  @Test
+  public void testSyncRepositoryEnvironmentsSkipsDeletionWhenFetchIsIncomplete()
+      throws Exception {
+    gitRepository.setNameWithOwner("owner/repo");
+    GHRepository ghRepository = org.mockito.Mockito.mock(GHRepository.class);
+    when(ghRepository.getFullName()).thenReturn("owner/repo");
+    GitHubService.EnvironmentFetchResult fetchResult =
+        new GitHubService.EnvironmentFetchResult(List.of(), false);
+
+    try (MockedStatic<RepositoryContext> repositoryContext =
+        org.mockito.Mockito.mockStatic(RepositoryContext.class)) {
+      repositoryContext.when(RepositoryContext::getRepositoryId).thenReturn(1L);
+      when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(gitRepository));
+      when(gitHubService.getRepository("owner/repo")).thenReturn(ghRepository);
+      when(gitHubService.fetchEnvironments(ghRepository)).thenReturn(fetchResult);
+
+      environmentService.syncRepositoryEnvironments();
+    }
+
+    verify(environmentSyncService, times(0)).removeDeletedEnvironments(any(), any());
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/github/GitHubEnvironmentSyncServiceTest.java
@@ -74,13 +74,10 @@ class GitHubEnvironmentSyncServiceTest {
   }
 
   @Test
-  void shouldDeleteAllWhenGitHubListIsEmpty() {
-    when(environmentRepository.findByRepositoryRepositoryIdOrderByCreatedAtDesc(100L))
-        .thenReturn(List.of(createEnvironment(1L, "env1"), createEnvironment(2L, "env2")));
-
+  void shouldNotDeleteWhenGitHubListIsEmpty() {
     syncService.removeDeletedEnvironments(List.of(), 100L);
 
-    verify(environmentRepository, times(2)).delete(any());
+    verify(environmentRepository, never()).delete(any());
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
@@ -428,12 +428,110 @@ class GitHubServiceTest {
     when(objectMapper.readValue(jsonResponse, GitHubEnvironmentApiResponse.class))
         .thenReturn(apiResponse);
 
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
     List<GitHubEnvironmentDto> environments = gitHubService.getEnvironments(mockRepository);
 
     assertFalse(environments.isEmpty());
     assertEquals("env_name", environments.get(0).getName());
-    verify(okHttpClient).newCall(any(Request.class));
+    verify(okHttpClient).newCall(requestCaptor.capture());
+    assertEquals(
+        "https://api.github.com/repos/owner/repo/environments?per_page=100&page=1",
+        requestCaptor.getValue().url().toString());
     verify(objectMapper).readValue(jsonResponse, GitHubEnvironmentApiResponse.class);
+  }
+
+  @Test
+  void getEnvironmentsFetchesAllPages() throws IOException {
+    GHRepository mockRepository = mock(GHRepository.class);
+    when(mockRepository.getOwnerName()).thenReturn("owner");
+    when(mockRepository.getName()).thenReturn("repo");
+    when(clientManager.getCurrentToken()).thenReturn("test-token");
+
+    GitHubEnvironmentDto env1 = new GitHubEnvironmentDto();
+    ReflectionTestUtils.setField(env1, "id", 1L);
+    ReflectionTestUtils.setField(env1, "name", "env-1");
+    GitHubEnvironmentDto env2 = new GitHubEnvironmentDto();
+    ReflectionTestUtils.setField(env2, "id", 2L);
+    ReflectionTestUtils.setField(env2, "name", "env-2");
+
+    GitHubEnvironmentApiResponse pageOneResponse = new GitHubEnvironmentApiResponse();
+    ReflectionTestUtils.setField(pageOneResponse, "totalCount", 2);
+    ReflectionTestUtils.setField(pageOneResponse, "environments", List.of(env1));
+    GitHubEnvironmentApiResponse pageTwoResponse = new GitHubEnvironmentApiResponse();
+    ReflectionTestUtils.setField(pageTwoResponse, "totalCount", 2);
+    ReflectionTestUtils.setField(pageTwoResponse, "environments", List.of(env2));
+
+    String pageOneJson = "{\"total_count\":2,\"environments\":[{\"id\":1,\"name\":\"env-1\"}]}";
+    String pageTwoJson = "{\"total_count\":2,\"environments\":[{\"id\":2,\"name\":\"env-2\"}]}";
+
+    Call firstCall = mock(Call.class);
+    Call secondCall = mock(Call.class);
+    when(okHttpClient.newCall(any(Request.class))).thenReturn(firstCall, secondCall);
+    when(firstCall.execute()).thenReturn(buildJsonResponse(pageOneJson));
+    when(secondCall.execute()).thenReturn(buildJsonResponse(pageTwoJson));
+    when(objectMapper.readValue(pageOneJson, GitHubEnvironmentApiResponse.class))
+        .thenReturn(pageOneResponse);
+    when(objectMapper.readValue(pageTwoJson, GitHubEnvironmentApiResponse.class))
+        .thenReturn(pageTwoResponse);
+
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+
+    GitHubService.EnvironmentFetchResult fetchResult =
+        gitHubService.fetchEnvironments(mockRepository);
+    List<GitHubEnvironmentDto> environments = fetchResult.environments();
+
+    assertEquals(
+        List.of("env-1", "env-2"),
+        environments.stream().map(GitHubEnvironmentDto::getName).toList());
+    assertTrue(fetchResult.complete());
+    verify(okHttpClient, times(2)).newCall(requestCaptor.capture());
+    assertEquals(
+        "https://api.github.com/repos/owner/repo/environments?per_page=100&page=1",
+        requestCaptor.getAllValues().get(0).url().toString());
+    assertEquals(
+        "https://api.github.com/repos/owner/repo/environments?per_page=100&page=2",
+        requestCaptor.getAllValues().get(1).url().toString());
+  }
+
+  @Test
+  void fetchEnvironmentsMarksPaginationAsIncomplete() throws IOException {
+    GHRepository mockRepository = mock(GHRepository.class);
+    when(mockRepository.getOwnerName()).thenReturn("owner");
+    when(mockRepository.getName()).thenReturn("repo");
+    when(clientManager.getCurrentToken()).thenReturn("test-token");
+
+    GitHubEnvironmentDto env1 = new GitHubEnvironmentDto();
+    ReflectionTestUtils.setField(env1, "id", 1L);
+    ReflectionTestUtils.setField(env1, "name", "env-1");
+
+    GitHubEnvironmentApiResponse pageOneResponse = new GitHubEnvironmentApiResponse();
+    ReflectionTestUtils.setField(pageOneResponse, "totalCount", 2);
+    ReflectionTestUtils.setField(pageOneResponse, "environments", List.of(env1));
+    GitHubEnvironmentApiResponse pageTwoResponse = new GitHubEnvironmentApiResponse();
+    ReflectionTestUtils.setField(pageTwoResponse, "totalCount", 2);
+    ReflectionTestUtils.setField(pageTwoResponse, "environments", List.of());
+
+    String pageOneJson = "{\"total_count\":2,\"environments\":[{\"id\":1,\"name\":\"env-1\"}]}";
+    String pageTwoJson = "{\"total_count\":2,\"environments\":[]}";
+
+    Call firstCall = mock(Call.class);
+    Call secondCall = mock(Call.class);
+    when(okHttpClient.newCall(any(Request.class))).thenReturn(firstCall, secondCall);
+    when(firstCall.execute()).thenReturn(buildJsonResponse(pageOneJson));
+    when(secondCall.execute()).thenReturn(buildJsonResponse(pageTwoJson));
+    when(objectMapper.readValue(pageOneJson, GitHubEnvironmentApiResponse.class))
+        .thenReturn(pageOneResponse);
+    when(objectMapper.readValue(pageTwoJson, GitHubEnvironmentApiResponse.class))
+        .thenReturn(pageTwoResponse);
+
+    GitHubService.EnvironmentFetchResult fetchResult =
+        gitHubService.fetchEnvironments(mockRepository);
+
+    assertEquals(
+        List.of("env-1"),
+        fetchResult.environments().stream().map(GitHubEnvironmentDto::getName).toList());
+    assertFalse(fetchResult.complete());
   }
 
   @Test
@@ -1242,5 +1340,15 @@ class GitHubServiceTest {
             });
     assertTrue(exception.getMessage()
         .contains("GitHub API cancel for run " + runId + " failed with response code: 500"));
+  }
+
+  private Response buildJsonResponse(String json) {
+    return new Response.Builder()
+        .request(new Request.Builder().url("http://dummyurl").build())
+        .protocol(Protocol.HTTP_1_1)
+        .code(200)
+        .message("OK")
+        .body(ResponseBody.create(json, MediaType.parse("application/json")))
+        .build();
   }
 }


### PR DESCRIPTION
- Updated EnvironmentService to use fetchEnvironments method for improved environment retrieval.
- Added logic to skip deletion of environments if the fetched list is incomplete.
- Modified GitHubService to handle pagination and return an EnvironmentFetchResult indicating completeness.
- Updated tests to verify behavior when environment lists are empty or incomplete.


Fixes #944 