### PR TITLE
feat: update flakiness overview styles and improve tooltip functionality

### DIFF
--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.html
@@ -28,17 +28,17 @@
     <div class="border border-surface rounded-xl p-4 flex flex-col gap-1">
       <span class="text-sm font-medium text-red-500">High Flakiness</span>
       <span class="text-2xl font-bold text-red-500">{{ data.summary.highFlakinessCount }}</span>
-      <span class="text-xs text-muted-color">Score &gt; 70</span>
+      <span class="text-xs text-muted-color">Score (70, 100]</span>
     </div>
     <div class="border border-surface rounded-xl p-4 flex flex-col gap-1">
       <span class="text-sm font-medium text-orange-500">Medium Flakiness</span>
       <span class="text-2xl font-bold text-orange-500">{{ data.summary.mediumFlakinessCount }}</span>
-      <span class="text-xs text-muted-color">Score 30 - 70</span>
+      <span class="text-xs text-muted-color">Score (30 - 70]</span>
     </div>
     <div class="border border-surface rounded-xl p-4 flex flex-col gap-1">
       <span class="text-sm font-medium text-yellow-500">Low Flakiness</span>
       <span class="text-2xl font-bold text-yellow-500">{{ data.summary.lowFlakinessCount }}</span>
-      <span class="text-xs text-muted-color">Score 1 - 30</span>
+      <span class="text-xs text-muted-color">Score (0 - 30]</span>
     </div>
   </div>
 
@@ -63,14 +63,12 @@
   >
     <ng-template #header>
       <tr>
-        <th colspan="8">
+        <th colspan="5">
           <app-table-filter-paginated [paginationService]="typedPaginationService" [table]="table" />
         </th>
       </tr>
       <tr>
-        <th style="min-width: 200px">Test Name</th>
-        <th style="min-width: 150px">Class</th>
-        <th style="min-width: 140px">Suite</th>
+        <th style="min-width: 200px; max-width: 350px">Test</th>
         <th style="width: 160px" pSortableColumn="flakinessScore">
           Flakiness Score
           <p-sortIcon field="flakinessScore" />
@@ -83,9 +81,23 @@
 
     <ng-template pTemplate="body" let-test>
       <tr>
-        <td class="font-mono text-sm">{{ test.testName }}</td>
-        <td class="text-sm text-muted-color">{{ test.className }}</td>
-        <td class="text-sm text-muted-color">{{ test.testSuiteName }}</td>
+        <td style="max-width: 350px">
+          <div class="flex flex-col gap-0.5 min-w-0">
+            <span
+              #nameSpan
+              class="font-mono text-sm truncate"
+              [pTooltip]="test.testName"
+              tooltipStyleClass="flaky-location-tooltip"
+              tooltipPosition="top"
+              [tooltipDisabled]="nameSpan.scrollWidth <= nameSpan.clientWidth"
+            >
+              {{ test.testName }}
+            </span>
+            <span class="text-xs text-muted-color truncate" [pTooltip]="getLocationTooltip(test)" tooltipStyleClass="flaky-location-tooltip" tooltipPosition="bottom">
+              {{ getLocationLabel(test) }}
+            </span>
+          </div>
+        </td>
         <td>
           <div class="flex items-center gap-2">
             <p-tag
@@ -104,7 +116,7 @@
 
     <ng-template pTemplate="emptymessage">
       <tr>
-        <td colspan="7">
+        <td colspan="5">
           <div class="flex flex-col items-center justify-center py-16 text-muted-color">
             <i-tabler name="bug" class="!size-12 mb-4 opacity-40" />
             @if ((data.summary.flakyTestCount ?? 0) === 0) {

--- a/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
+++ b/client/src/app/pages/flaky-tests-overview/flaky-tests-overview.component.ts
@@ -18,9 +18,9 @@ import { FlakyTestDto } from '@app/core/modules/openapi';
 function createFlakinessFilterOptions(): PaginatedFilterOption[] {
   return [
     { name: 'All', value: 'ALL' },
-    { name: 'High (> 70)', value: 'HIGH' },
-    { name: 'Medium (30 – 70)', value: 'MEDIUM' },
-    { name: 'Low (1 – 30)', value: 'LOW' },
+    { name: 'High (70, 100]', value: 'HIGH' },
+    { name: 'Medium (30 – 70]', value: 'MEDIUM' },
+    { name: 'Low (0 – 30]', value: 'LOW' },
   ];
 }
 
@@ -96,5 +96,21 @@ export class FlakyTestsOverviewComponent {
 
   formatRate(rate: number): string {
     return (rate * 100).toFixed(1) + '%';
+  }
+
+  // Extracts the simple class name from a fully qualified class name (FQCN) e.g. "com.example.MyClass" -> "MyClass"
+  getSimpleName(fqcn: string): string {
+    return fqcn.split('.').pop() ?? fqcn;
+  }
+
+  getLocationLabel(test: FlakyTestDto): string {
+    if (test.testSuiteName === test.className) {
+      return this.getSimpleName(test.className);
+    }
+    return `${this.getSimpleName(test.testSuiteName)} › ${this.getSimpleName(test.className)}`;
+  }
+
+  getLocationTooltip(test: FlakyTestDto): string {
+    return test.testSuiteName === test.className ? `Suite / Class: ${test.className}` : `Suite: ${test.testSuiteName}\nClass: ${test.className}`;
   }
 }

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -13,3 +13,6 @@
 
 }
 
+.flaky-location-tooltip.p-tooltip {
+  max-width: min(60rem, 80vw);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The flaky tests table used three wide columns (name, class, suite), which can include repeated information. Therefore, if test name, class or suite name are too long, the table does not fit into the page. Also, filter and summary text did not use the same score ranges as the backend filters. 

### Description
<!-- Describe your changes in detail -->
- Used single “Test” column in flakiness table: first line is the test name; second line shows a short suite/class label with a tooltip for full suite/class names. In short suite/class label: the simple class name is extracted from a fully qualified class name (FQCN) e.g. `com.example.MyClass` -> `MyClass`
- Summary card subtitles and filter options use the same interval-style wording for high / medium / low flakiness scores.
- Added style for flakiness location tooltip used for class/suite names, the style uses min(60rem, 80vw) for a sensible max width, and drops a fixed min-width so short text stays compact.
- Disabled test name tooltip when the test name is not truncated (scrollWidth <= clientWidth).

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- A repository in Helios that has flaky-test data. (If possible long test name, class name, suit name are preferable.)
- A normal developer account with access to that repo’s flaky tests view.

#### Flow:
1. Log in to Helios as a Developer
2. Open a repository with flaky tests.
3. Go to Flaky Tests Overview.
4. Confirm that the table shows one test column with name + short location line.
5. Hover the location line and check if the long fully qualified class names is displayed in the tooltip.
6. For a short test name that fits the cell, confirm no tooltip on the name; for a long truncated name, confirm the tooltip shows the full name.
7. Confirm summary card score ranges match the severity filter labels.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->
<img width="1470" height="709" alt="Screenshot 2026-04-03 at 20 51 55" src="https://github.com/user-attachments/assets/ec16260d-6a72-4142-8665-f2ccb1d3c013" />
<img width="1437" height="711" alt="Screenshot 2026-04-03 at 20 52 15" src="https://github.com/user-attachments/assets/4e3e4321-f173-43bc-988c-68346fd4f5e4" />
<img width="1457" height="667" alt="Screenshot 2026-04-03 at 20 52 30" src="https://github.com/user-attachments/assets/9eaa3f0b-5539-4191-b533-6adcde2eb7e2" />


### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
