### PR TITLE
fix: reduce flakiness recomputation memory and add bounded Argon2 verification concurrency to prevent heap OOM error

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/gitreposettings/secret/RepoSecretService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/gitreposettings/secret/RepoSecretService.java
@@ -5,29 +5,41 @@ import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.security.SecureRandom;
 import java.util.Base64;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.Semaphore;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class RepoSecretService {
 
   private static final SecureRandom RNG = new SecureRandom();
   // 256‑bit suffix
   private static final int RAW_BYTES = 32;
-  private final GitRepoSettingsRepository gitRepoSettingsRepository;
 
-  /**
-   * Argon2id encoder – allocate once, reuse.
-   */
-  private final Argon2PasswordEncoder argon2 = new Argon2PasswordEncoder(
-      16,      // salt length (bytes) – internal
-      32,      // hash length (bytes)
-      1,       // parallelism
-      1 << 16, // memory = 65 536 KiB
-      3);      // iterations
+  private final GitRepoSettingsRepository gitRepoSettingsRepository;
+  private final Argon2PasswordEncoder argon2;
+  private final Semaphore argon2VerifySemaphore;
+
+  public RepoSecretService(
+      GitRepoSettingsRepository gitRepoSettingsRepository,
+      @Value("${helios.repo-secret.argon2.salt-length:16}") int saltLength,
+      @Value("${helios.repo-secret.argon2.hash-length:32}") int hashLength,
+      @Value("${helios.repo-secret.argon2.parallelism:1}") int parallelism,
+      @Value("${helios.repo-secret.argon2.memory-kib:16384}") int memoryKiB,
+      @Value("${helios.repo-secret.argon2.iterations:2}") int iterations,
+      @Value("${helios.repo-secret.max-concurrent-verifications:4}")
+          int maxConcurrentVerifications) {
+    this.gitRepoSettingsRepository = gitRepoSettingsRepository;
+    this.argon2 = new Argon2PasswordEncoder(
+        saltLength,
+        hashLength,
+        parallelism,
+        memoryKiB,
+        iterations);
+    this.argon2VerifySemaphore = new Semaphore(Math.max(1, maxConcurrentVerifications), true);
+  }
 
   /**
    * Generate or replace the repo’s shared secret.
@@ -74,6 +86,19 @@ public class RepoSecretService {
     }
 
     String suffix = parts[2];
-    return argon2.matches(suffix, settings.getSecretHash());
+    boolean acquired = false;
+    try {
+      // Bound concurrent Argon2 allocations to avoid heap spikes under request bursts.
+      argon2VerifySemaphore.acquire();
+      acquired = true;
+      return argon2.matches(suffix, settings.getSecretHash());
+    } catch (InterruptedException interruptedException) {
+      Thread.currentThread().interrupt();
+      return false;
+    } finally {
+      if (acquired) {
+        argon2VerifySemaphore.release();
+      }
+    }
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsService.java
@@ -6,10 +6,12 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -32,7 +34,7 @@ public class TestCaseStatisticsService {
   private static final double COMBINED_BRANCH_WEIGHT = 0.3;
   private static final double MIN_FLAKY_RATE = 0.01; // 1%
   private static final double MAX_FLAKY_RATE = 0.5; // 50%
-  private static final int SUITE_NAME_QUERY_CHUNK_SIZE = 250;
+  private static final int SUITE_NAME_QUERY_CHUNK_SIZE = 128;
 
   private final TestCaseStatisticsRepository statisticsRepository;
   private final TestCaseFlakinessRepository flakinessRepository;
@@ -132,9 +134,9 @@ public class TestCaseStatisticsService {
   /**
    * Recomputes and persists flakiness scores for all test cases in the given suites.
    *
-   * <p>Failure rates are pre-loaded in two bulk queries (default branch + combined) and indexed
-   * into {@link Map}s so each per-test score computation is O(1). Each score is written via a
-   * native {@code INSERT ... ON CONFLICT DO UPDATE} that bypasses the Hibernate first-level cache
+   * <p>Failure rates are loaded and indexed per suite chunk (default branch + combined) so only a
+   * bounded working set is kept in memory. Each score is written via a native
+   * {@code INSERT ... ON CONFLICT DO UPDATE} that bypasses the Hibernate first-level cache
    * entirely, preventing session growth and handling concurrent calls safely.
    *
    * @param testSuites the suites processed in this run
@@ -145,31 +147,44 @@ public class TestCaseStatisticsService {
   public void updateFlakinessForTestSuite(
       List<TestSuite> testSuites, String defaultBranch, GitRepository repository) {
 
-    var suiteNames = testSuites.stream().map(TestSuite::getName).distinct().toList();
-
-    // Two bulk DB reads and index into Maps for O(1) per-test lookup
-    Map<StatsKey, Double> defaultRates =
-        loadFailureRateIndex(suiteNames, defaultBranch, repository.getRepositoryId());
-    Map<StatsKey, Double> combinedRates =
-        loadFailureRateIndex(suiteNames, "combined", repository.getRepositoryId());
-
     OffsetDateTime now = OffsetDateTime.now();
     int count = 0;
-    for (TestSuite suite : testSuites) {
-      for (TestCase testCase : suite.getTestCases()) {
-        var info = computeFlakinessInfo(
-            testCase.getName(), testCase.getClassName(), suite.getName(),
-            defaultRates, combinedRates);
-        flakinessRepository.upsertFlakiness(
-            repository.getRepositoryId(),
-            testCase.getName(),
-            testCase.getClassName(),
-            suite.getName(),
-            info.flakinessScore(),
-            info.defaultBranchFailureRate(),
-            info.combinedFailureRate(),
-            now);
-        count++;
+    for (List<TestSuite> suiteChunk : chunked(testSuites, SUITE_NAME_QUERY_CHUNK_SIZE)) {
+      Set<String> suiteNamesInChunk =
+          suiteChunk.stream().map(TestSuite::getName).collect(Collectors.toSet());
+      Set<StatsKey> chunkKeys = collectChunkKeys(suiteChunk);
+      Map<StatsKey, Double> defaultRates =
+          loadFailureRateIndex(
+              suiteNamesInChunk,
+              defaultBranch,
+              repository.getRepositoryId(),
+              chunkKeys);
+      Map<StatsKey, Double> combinedRates =
+          loadFailureRateIndex(
+              suiteNamesInChunk,
+              "combined",
+              repository.getRepositoryId(),
+              chunkKeys);
+
+      for (TestSuite suite : suiteChunk) {
+        for (TestCase testCase : suite.getTestCases()) {
+          var info = computeFlakinessInfo(
+              testCase.getName(),
+              testCase.getClassName(),
+              suite.getName(),
+              defaultRates,
+              combinedRates);
+          flakinessRepository.upsertFlakiness(
+              repository.getRepositoryId(),
+              testCase.getName(),
+              testCase.getClassName(),
+              suite.getName(),
+              info.flakinessScore(),
+              info.defaultBranchFailureRate(),
+              info.combinedFailureRate(),
+              now);
+          count++;
+        }
       }
     }
     log.info("Finished flakiness upsert for repository {}: rows={}",
@@ -198,27 +213,47 @@ public class TestCaseStatisticsService {
   }
 
   private Map<StatsKey, Double> loadFailureRateIndex(
-      List<String> suiteNames, String branchName, Long repositoryId) {
+      Collection<String> suiteNames,
+      String branchName,
+      Long repositoryId,
+      Set<StatsKey> expectedKeys) {
+    if (suiteNames.isEmpty() || expectedKeys.isEmpty()) {
+      return Map.of();
+    }
+
     Map<StatsKey, Double> rates = new HashMap<>();
-    for (List<String> chunk : chunked(suiteNames, SUITE_NAME_QUERY_CHUNK_SIZE)) {
-      List<TestCaseStatisticsRepository.FailureRateRow> rows =
-          statisticsRepository
-              .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
-                  chunk,
-                  branchName,
-                  repositoryId);
-      for (TestCaseStatisticsRepository.FailureRateRow row : rows) {
-        rates.put(
-            new StatsKey(row.getTestName(), row.getClassName(), row.getTestSuiteName()),
-            row.getTotalRuns() > 0 ? (double) row.getFailedRuns() / row.getTotalRuns() : 0.0);
+    List<TestCaseStatisticsRepository.FailureRateRow> rows =
+        statisticsRepository
+            .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
+                suiteNames,
+                branchName,
+                repositoryId);
+    for (TestCaseStatisticsRepository.FailureRateRow row : rows) {
+      StatsKey key = new StatsKey(row.getTestName(), row.getClassName(), row.getTestSuiteName());
+      if (!expectedKeys.contains(key)) {
+        continue;
       }
+      rates.put(
+          key,
+          row.getTotalRuns() > 0 ? (double) row.getFailedRuns() / row.getTotalRuns() : 0.0);
     }
     log.info(
-        "Loaded failure rates for repository {} branch {}: rows={}",
+        "Loaded failure rates for repository {} branch {} chunkSuites={} matchedRows={}",
         repositoryId,
         branchName,
+        suiteNames.size(),
         rates.size());
     return rates;
+  }
+
+  private static Set<StatsKey> collectChunkKeys(List<TestSuite> suiteChunk) {
+    return suiteChunk.stream()
+        .flatMap(
+            suite ->
+                suite.getTestCases().stream()
+                    .map(testCase -> new StatsKey(
+                        testCase.getName(), testCase.getClassName(), suite.getName())))
+        .collect(Collectors.toSet());
   }
 
   private static <T> List<List<T>> chunked(List<T> items, int chunkSize) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -84,9 +84,7 @@ public class TestResultProcessor {
 
       // Update test statistics if the workflow run is on the default branch
       updateTestStatisticsIfDefaultBranch(testSuites, workflowRun);
-      // HOTFIX: Flakiness recomputation is temporarily disabled to avoid OOMs in production.
-      // TODO: Re-enable after memory-safe flakiness path is deployed.
-      log.warn("HOTFIX active: skipping flakiness update for workflow run {}", workflowRun.getName());
+      updateFlakiness(testSuites, workflowRun);
     } catch (Exception e) {
       log.error("Failed to process test results for workflow run {}", workflowRun.getName(), e);
       workflowRun.setTestProcessingStatus(WorkflowRun.TestProcessingStatus.FAILED);

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/gitreposettings/secret/RepoSecretServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/gitreposettings/secret/RepoSecretServiceTest.java
@@ -1,0 +1,87 @@
+package de.tum.cit.aet.helios.gitreposettings.secret;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.gitreposettings.GitRepoSettings;
+import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class RepoSecretServiceTest {
+
+  @Mock private GitRepoSettingsRepository gitRepoSettingsRepository;
+
+  private RepoSecretService repoSecretService;
+
+  @BeforeEach
+  void setUp() {
+    repoSecretService =
+        new RepoSecretService(
+            gitRepoSettingsRepository,
+            16,
+            32,
+            1,
+            4096,
+            3,
+            4);
+  }
+
+  @Test
+  void matches_acceptsLegacyHighMemoryHashes() {
+    long repositoryId = 69562331L;
+    String suffix = "abcdefghijklmnopqrstuvwxyzABCDEFGH1234567";
+    String token = "repo-%d-%s".formatted(repositoryId, suffix);
+
+    // Legacy prod setting: memory = 65_536 KiB.
+    Argon2PasswordEncoder legacyEncoder = new Argon2PasswordEncoder(16, 32, 1, 1 << 16, 3);
+    String legacyHash = legacyEncoder.encode(suffix);
+
+    GitRepoSettings settings = createSettings(repositoryId, legacyHash);
+
+    assertTrue(repoSecretService.matches(settings, token));
+  }
+
+  @Test
+  void rotate_usesConfiguredMemorySettingAndTokenStaysValid() {
+    long repositoryId = 42L;
+    GitRepoSettings settings = createSettings(
+        repositoryId, "$argon2id$v=19$m=4096,t=3,p=1$dummy$dummy");
+
+    when(gitRepoSettingsRepository.findByRepositoryRepositoryId(repositoryId))
+        .thenReturn(Optional.of(settings));
+    when(gitRepoSettingsRepository.save(any(GitRepoSettings.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    String token = repoSecretService.rotate(repositoryId);
+
+    assertNotNull(token);
+    assertTrue(token.startsWith("repo-42-"));
+    assertEquals(51, token.length());
+    assertTrue(settings.getSecretHash().contains("m=4096"));
+    assertTrue(repoSecretService.matches(settings, token));
+
+    verify(gitRepoSettingsRepository).save(settings);
+  }
+
+  private static GitRepoSettings createSettings(long repositoryId, String secretHash) {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(repositoryId);
+
+    GitRepoSettings settings = new GitRepoSettings();
+    settings.setRepository(repository);
+    settings.setSecretHash(secretHash);
+    return settings;
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestCaseStatisticsServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsFilterType;
 import de.tum.cit.aet.helios.tests.pagination.FlakyTestsPageRequest;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -194,7 +195,7 @@ class TestCaseStatisticsServiceTest {
   }
 
   @Test
-  void updateFlakinessForTestSuite_chunksQueriesAndBatchesWrites() {
+  void updateFlakinessForTestSuite_chunksQueriesAndBatchesWrites() throws Exception {
     List<TestSuite> testSuites = new ArrayList<>();
     for (int i = 0; i < 260; i++) {
       testSuites.add(createSuiteWithSingleTest("Suite-" + i, "test-" + i, "Class-" + i));
@@ -207,10 +208,16 @@ class TestCaseStatisticsServiceTest {
 
     service.updateFlakinessForTestSuite(testSuites, "main", repository);
 
-    verify(statisticsRepository, times(2))
+    Field chunkSizeField = TestCaseStatisticsService.class.getDeclaredField(
+        "SUITE_NAME_QUERY_CHUNK_SIZE");
+    chunkSizeField.setAccessible(true);
+    int chunkSize = (int) chunkSizeField.get(null);
+    int expectedChunks = (testSuites.size() + chunkSize - 1) / chunkSize;
+
+    verify(statisticsRepository, times(expectedChunks))
         .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyCollection(), eq("main"), any());
-    verify(statisticsRepository, times(2))
+    verify(statisticsRepository, times(expectedChunks))
         .findFailureRateRowsByTestSuiteNameInAndBranchNameAndRepositoryRepositoryId(
             anyCollection(), eq("combined"), any());
     verify(flakinessRepository, times(260)).upsertFlakiness(


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
In Production environment, we experienced repeated `Java heap space` failures triggered by two high-pressure paths:
1. Flakiness recomputation loaded very large failure-rate datasets into memory at once.
2. Concurrent repo-secret verification requests allocated large Argon2 working buffers.
So, we need to reduce peak heap pressure in both paths while preserving compatibility for already issued repo secrets.

### Description
<!-- Describe your changes in detail -->
- Refactored flakiness recomputation to process test suites in chunks and keep only chunk-local lookup structures in memory, instead of building large global failure-rate maps.
- Made repo-secret Argon2 settings configurable (with defaults), and reduced default memory pressure for newly generated hashes.
- Added a bounded semaphore around `RepoSecretService.matches(...)` to cap concurrent Argon2 verifications and prevent burst-induced heap spikes.
- Preserved existing token compatibility: legacy hashes (created with previous Argon2 parameters) still validate because verification uses parameters encoded in stored hash strings.
-  Updated/added tests:
  - Flakiness chunk-query expectation now derives expected chunk count dynamically.
  - New `RepoSecretServiceTest` verifies legacy hash compatibility and new-hash behavior.

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- Running Helios instance with at least one repository including test cases.
#### Flow:
1. Verify legacy token compatibility:
1.1. Use an existing repo secret token created before this change.
1.2. Call an endpoint protected by RepoSecretFilter. (e.g. `/api/environments/status`, `/api/tests/flakiness-scores`)
1.3. Confirm request still succeeds (not rejected as invalid solely due to parameter changes)
2. Verify new token generation/validation:
2.1. Generate a new repo secret for a repository.
2.2. Use newly returned token on protected endpoint.
2.3. Confirm request succeeds.
3. Verify bounded concurrency behavior:
3.1. Send more concurrent protected requests than maxConcurrentVerifications (e.g. 8-12 parallel).
3.2. Confirm service remains stable (no immediate OOM), excess requests wait and complete/fail normally.
4. Verify flakiness recomputation path:
4.1. Trigger test processing for a large workflow run.
4.2. Confirm flakiness upsert completes and logs chunked loading (chunkSuites=...).

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.