### PR TITLE
fix: avoid NULL cursor in queries in deployment/workflow run reconciliation services

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentRepository.java
@@ -24,13 +24,30 @@ public interface DeploymentRepository extends JpaRepository<Deployment, Long> {
   Optional<Deployment> findFirstByEnvironmentIdOrderByCreatedAtDesc(Long environmentId);
 
   /**
-   * Finds stale deployments in incomplete states (e.g., IN_PROGRESS, QUEUED) that have not been
-   * updated before the specified threshold and paginates them using a keyset cursor.
+   * Finds the first page of stale deployments in incomplete states (e.g., IN_PROGRESS, QUEUED).
    *
    * @param threshold stale threshold for updatedAt/createdAt
    * @param states incomplete states to reconcile
-   * @param cursorTime cursor timestamp of the last processed row (exclusive), nullable for the
-   *     first page
+   * @param pageable limits the number of rows processed per reconciliation run
+   * @return stale deployments ordered by oldest first using timestamp+id ordering
+   */
+  @Query(
+      "SELECT d FROM Deployment d "
+          + "JOIN FETCH d.repository r "
+          + "WHERE d.state IN :states "
+          + "AND COALESCE(d.updatedAt, d.createdAt) < :threshold "
+          + "ORDER BY COALESCE(d.updatedAt, d.createdAt) ASC, d.id ASC")
+  List<Deployment> findStaleIncompleteDeploymentsFirstPage(
+      @Param("threshold") OffsetDateTime threshold,
+      @Param("states") List<Deployment.State> states,
+      Pageable pageable);
+
+  /**
+   * Finds stale deployments in incomplete states after the given keyset cursor.
+   *
+   * @param threshold stale threshold for updatedAt/createdAt
+   * @param states incomplete states to reconcile
+   * @param cursorTime cursor timestamp of the last processed row (exclusive)
    * @param cursorId cursor id of the last processed row (exclusive tie-breaker)
    * @param pageable limits the number of rows processed per reconciliation run
    * @return stale deployments ordered by oldest first using timestamp+id ordering
@@ -41,12 +58,11 @@ public interface DeploymentRepository extends JpaRepository<Deployment, Long> {
           + "WHERE d.state IN :states "
           + "AND COALESCE(d.updatedAt, d.createdAt) < :threshold "
           + "AND ("
-          + "  :cursorTime IS NULL "
-          + "  OR COALESCE(d.updatedAt, d.createdAt) > :cursorTime "
+          + "  COALESCE(d.updatedAt, d.createdAt) > :cursorTime "
           + "  OR (COALESCE(d.updatedAt, d.createdAt) = :cursorTime AND d.id > :cursorId)"
           + ") "
           + "ORDER BY COALESCE(d.updatedAt, d.createdAt) ASC, d.id ASC")
-  List<Deployment> findStaleIncompleteDeployments(
+  List<Deployment> findStaleIncompleteDeploymentsAfterCursor(
       @Param("threshold") OffsetDateTime threshold,
       @Param("states") List<Deployment.State> states,
       @Param("cursorTime") OffsetDateTime cursorTime,

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/DeploymentReconciliationService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/DeploymentReconciliationService.java
@@ -53,14 +53,16 @@ public class DeploymentReconciliationService {
     int pages = 0;
     OffsetDateTime cursorTime = null;
     long cursorId = 0L;
+    boolean firstPage = true;
+    PageRequest batchRequest = PageRequest.of(0, BATCH_SIZE);
 
     while (true) {
-      List<Deployment> staleDeployments = deploymentRepository.findStaleIncompleteDeployments(
-          threshold,
-          INCOMPLETE_DEPLOYMENT_STATES,
-          cursorTime,
-          cursorId,
-          PageRequest.of(0, BATCH_SIZE));
+      List<Deployment> staleDeployments =
+          firstPage
+              ? deploymentRepository.findStaleIncompleteDeploymentsFirstPage(
+                  threshold, INCOMPLETE_DEPLOYMENT_STATES, batchRequest)
+              : deploymentRepository.findStaleIncompleteDeploymentsAfterCursor(
+                  threshold, INCOMPLETE_DEPLOYMENT_STATES, cursorTime, cursorId, batchRequest);
 
       if (staleDeployments.isEmpty()) {
         break;
@@ -68,9 +70,6 @@ public class DeploymentReconciliationService {
 
       pages++;
       processed += staleDeployments.size();
-      Deployment lastInBatch = staleDeployments.getLast();
-      OffsetDateTime nextCursorTime = getSortKey(lastInBatch);
-      long nextCursorId = lastInBatch.getId();
 
       for (Deployment deployment : staleDeployments) {
         String repositoryNameWithOwner = resolveRepositoryNameWithOwner(deployment.getRepository());
@@ -99,8 +98,13 @@ public class DeploymentReconciliationService {
         }
       }
 
+      Deployment lastInBatch = staleDeployments.getLast();
+      OffsetDateTime nextCursorTime = getSortKey(lastInBatch);
+      long nextCursorId = lastInBatch.getId();
+
       cursorTime = nextCursorTime;
       cursorId = nextCursorId;
+      firstPage = false;
     }
 
     log.info(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/WorkflowRunReconciliationService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/sync/WorkflowRunReconciliationService.java
@@ -53,15 +53,20 @@ public class WorkflowRunReconciliationService {
     int pages = 0;
     OffsetDateTime cursorTime = null;
     long cursorId = 0L;
+    boolean firstPage = true;
+    PageRequest batchRequest = PageRequest.of(0, BATCH_SIZE);
 
     while (true) {
       List<WorkflowRun> staleWorkflowRuns =
-          workflowRunRepository.findStaleIncompleteRuns(
-              threshold,
-              INCOMPLETE_WORKFLOW_STATUSES,
-              cursorTime,
-              cursorId,
-              PageRequest.of(0, BATCH_SIZE));
+          firstPage
+              ? workflowRunRepository.findStaleIncompleteRunsFirstPage(
+                  threshold, INCOMPLETE_WORKFLOW_STATUSES, batchRequest)
+              : workflowRunRepository.findStaleIncompleteRunsAfterCursor(
+                  threshold,
+                  INCOMPLETE_WORKFLOW_STATUSES,
+                  cursorTime,
+                  cursorId,
+                  batchRequest);
 
       if (staleWorkflowRuns.isEmpty()) {
         break;
@@ -69,9 +74,6 @@ public class WorkflowRunReconciliationService {
 
       pages++;
       processed += staleWorkflowRuns.size();
-      WorkflowRun lastInBatch = staleWorkflowRuns.getLast();
-      OffsetDateTime nextCursorTime = getSortKey(lastInBatch);
-      long nextCursorId = lastInBatch.getId();
 
       for (WorkflowRun workflowRun : staleWorkflowRuns) {
         String repositoryNameWithOwner =
@@ -101,8 +103,13 @@ public class WorkflowRunReconciliationService {
         }
       }
 
+      WorkflowRun lastInBatch = staleWorkflowRuns.getLast();
+      OffsetDateTime nextCursorTime = getSortKey(lastInBatch);
+      long nextCursorId = lastInBatch.getId();
+
       cursorTime = nextCursorTime;
       cursorId = nextCursorId;
+      firstPage = false;
     }
 
     log.info(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -110,13 +110,31 @@ public interface WorkflowRunRepository
       @Param("head") String headCommit);
 
   /**
-   * Finds stale workflow runs in non-terminal states and eagerly fetches their repository to avoid
-   * lazy-loading issues during reconciliation, using keyset pagination.
+   * Finds the first page of stale workflow runs in non-terminal states and eagerly fetches their
+   * repository to avoid lazy-loading issues during reconciliation.
    *
    * @param threshold stale threshold for updatedAt/createdAt
    * @param statuses incomplete statuses to reconcile
-   * @param cursorTime cursor timestamp of the last processed row (exclusive), nullable for the
-   *     first page
+   * @param pageable limits the number of rows processed per reconciliation run
+   * @return stale workflow runs ordered by oldest first using timestamp+id ordering
+   */
+  @Query(
+      "SELECT wr FROM WorkflowRun wr "
+          + "JOIN FETCH wr.repository r "
+          + "WHERE wr.status IN :statuses "
+          + "AND COALESCE(wr.updatedAt, wr.createdAt) < :threshold "
+          + "ORDER BY COALESCE(wr.updatedAt, wr.createdAt) ASC, wr.id ASC")
+  List<WorkflowRun> findStaleIncompleteRunsFirstPage(
+      @Param("threshold") java.time.OffsetDateTime threshold,
+      @Param("statuses") List<WorkflowRun.Status> statuses,
+      Pageable pageable);
+
+  /**
+   * Finds stale workflow runs in non-terminal states after the given keyset cursor.
+   *
+   * @param threshold stale threshold for updatedAt/createdAt
+   * @param statuses incomplete statuses to reconcile
+   * @param cursorTime cursor timestamp of the last processed row (exclusive)
    * @param cursorId cursor id of the last processed row (exclusive tie-breaker)
    * @param pageable limits the number of rows processed per reconciliation run
    * @return stale workflow runs ordered by oldest first using timestamp+id ordering
@@ -127,12 +145,11 @@ public interface WorkflowRunRepository
           + "WHERE wr.status IN :statuses "
           + "AND COALESCE(wr.updatedAt, wr.createdAt) < :threshold "
           + "AND ("
-          + "  :cursorTime IS NULL "
-          + "  OR COALESCE(wr.updatedAt, wr.createdAt) > :cursorTime "
+          + "  COALESCE(wr.updatedAt, wr.createdAt) > :cursorTime "
           + "  OR (COALESCE(wr.updatedAt, wr.createdAt) = :cursorTime AND wr.id > :cursorId)"
           + ") "
           + "ORDER BY COALESCE(wr.updatedAt, wr.createdAt) ASC, wr.id ASC")
-  List<WorkflowRun> findStaleIncompleteRuns(
+  List<WorkflowRun> findStaleIncompleteRunsAfterCursor(
       @Param("threshold") java.time.OffsetDateTime threshold,
       @Param("statuses") List<WorkflowRun.Status> statuses,
       @Param("cursorTime") java.time.OffsetDateTime cursorTime,

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/DeploymentReconciliationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/DeploymentReconciliationServiceTest.java
@@ -1,7 +1,6 @@
 package de.tum.cit.aet.helios.github.sync;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -70,9 +69,13 @@ class DeploymentReconciliationServiceTest {
     OffsetDateTime remoteUpdatedAt = OffsetDateTime.now();
 
     when(
-            deploymentRepository.findStaleIncompleteDeployments(
+            deploymentRepository.findStaleIncompleteDeploymentsFirstPage(
+                any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(deployment));
+    when(
+            deploymentRepository.findStaleIncompleteDeploymentsAfterCursor(
                 any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(List.of(deployment), List.of());
+        .thenReturn(List.of());
     when(heliosDeploymentRepository.findByDeploymentId(501L))
         .thenReturn(Optional.of(heliosDeployment));
     when(gitHubService.getLatestDeploymentState("owner/repo", 501L))
@@ -86,8 +89,11 @@ class DeploymentReconciliationServiceTest {
     assertEquals(remoteUpdatedAt, heliosDeployment.getUpdatedAt());
     verify(deploymentRepository).save(deployment);
     verify(heliosDeploymentRepository).save(heliosDeployment);
-    verify(deploymentRepository, times(2))
-        .findStaleIncompleteDeployments(any(), anyList(), any(), anyLong(), any(Pageable.class));
+    verify(deploymentRepository)
+        .findStaleIncompleteDeploymentsFirstPage(any(), anyList(), any(Pageable.class));
+    verify(deploymentRepository)
+        .findStaleIncompleteDeploymentsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class));
   }
 
   @Test
@@ -111,9 +117,13 @@ class DeploymentReconciliationServiceTest {
     OffsetDateTime remoteUpdatedAt = OffsetDateTime.now();
 
     when(
-            deploymentRepository.findStaleIncompleteDeployments(
-                any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(List.of(unresolvableDeployment), List.of(reconcilableDeployment), List.of());
+        deploymentRepository.findStaleIncompleteDeploymentsFirstPage(
+            any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(unresolvableDeployment));
+    when(
+        deploymentRepository.findStaleIncompleteDeploymentsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class)))
+        .thenReturn(List.of(reconcilableDeployment), List.of());
     when(gitHubService.getLatestDeploymentState("owner/repo", 901L))
         .thenReturn(Optional.of(new GitHubService.DeploymentState("success", remoteUpdatedAt)));
     when(heliosDeploymentRepository.findByDeploymentId(anyLong())).thenReturn(Optional.empty());
@@ -123,8 +133,11 @@ class DeploymentReconciliationServiceTest {
     assertEquals(Deployment.State.SUCCESS, reconcilableDeployment.getState());
     assertEquals(remoteUpdatedAt, reconcilableDeployment.getUpdatedAt());
     verify(deploymentRepository).save(reconcilableDeployment);
-    verify(deploymentRepository, times(3))
-        .findStaleIncompleteDeployments(any(), anyList(), any(), anyLong(), any(Pageable.class));
+    verify(deploymentRepository)
+        .findStaleIncompleteDeploymentsFirstPage(any(), anyList(), any(Pageable.class));
+    verify(deploymentRepository, times(2))
+        .findStaleIncompleteDeploymentsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class));
   }
 
   @Test
@@ -147,9 +160,14 @@ class DeploymentReconciliationServiceTest {
     second.setState(Deployment.State.IN_PROGRESS);
     second.setUpdatedAt(secondTs);
 
-    when(deploymentRepository.findStaleIncompleteDeployments(
-        any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(List.of(first), List.of(second), List.of());
+    when(
+            deploymentRepository.findStaleIncompleteDeploymentsFirstPage(
+                any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(first));
+    when(
+            deploymentRepository.findStaleIncompleteDeploymentsAfterCursor(
+                any(), anyList(), any(), anyLong(), any(Pageable.class)))
+        .thenReturn(List.of(second), List.of());
     when(gitHubService.getLatestDeploymentState("owner/repo", 1001L))
         .thenReturn(
             Optional.of(new GitHubService.DeploymentState("success", firstTs.plusMinutes(1))));
@@ -162,27 +180,32 @@ class DeploymentReconciliationServiceTest {
 
     ArgumentCaptor<OffsetDateTime> cursorTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
     ArgumentCaptor<Long> cursorIdCaptor = ArgumentCaptor.forClass(Long.class);
-    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    ArgumentCaptor<Pageable> firstPageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    ArgumentCaptor<Pageable> cursorPageableCaptor = ArgumentCaptor.forClass(Pageable.class);
 
-    verify(deploymentRepository, times(3))
-        .findStaleIncompleteDeployments(
-            any(), anyList(), cursorTimeCaptor.capture(), cursorIdCaptor.capture(),
-            pageableCaptor.capture());
+    verify(deploymentRepository)
+        .findStaleIncompleteDeploymentsFirstPage(
+            any(), anyList(), firstPageableCaptor.capture());
+    verify(deploymentRepository, times(2))
+        .findStaleIncompleteDeploymentsAfterCursor(
+            any(),
+            anyList(),
+            cursorTimeCaptor.capture(),
+            cursorIdCaptor.capture(),
+            cursorPageableCaptor.capture());
 
     List<OffsetDateTime> cursorTimes = cursorTimeCaptor.getAllValues();
-    assertNull(cursorTimes.get(0));
-    assertEquals(firstTs, cursorTimes.get(1));
-    assertEquals(secondTs, cursorTimes.get(2));
+    assertEquals(firstTs.plusMinutes(1), cursorTimes.get(0));
+    assertEquals(secondTs.plusMinutes(1), cursorTimes.get(1));
 
     List<Long> cursorIds = cursorIdCaptor.getAllValues();
-    assertEquals(0L, cursorIds.get(0));
-    assertEquals(1001L, cursorIds.get(1));
-    assertEquals(1002L, cursorIds.get(2));
+    assertEquals(1001L, cursorIds.get(0));
+    assertEquals(1002L, cursorIds.get(1));
 
-    List<Pageable> pageableList = pageableCaptor.getAllValues();
-    assertEquals(0, pageableList.get(0).getPageNumber());
-    assertEquals(0, pageableList.get(1).getPageNumber());
-    assertEquals(0, pageableList.get(2).getPageNumber());
+    assertEquals(0, firstPageableCaptor.getValue().getPageNumber());
+    List<Pageable> cursorPageables = cursorPageableCaptor.getAllValues();
+    assertEquals(0, cursorPageables.get(0).getPageNumber());
+    assertEquals(0, cursorPageables.get(1).getPageNumber());
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/WorkflowRunReconciliationServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/sync/WorkflowRunReconciliationServiceTest.java
@@ -1,7 +1,6 @@
 package de.tum.cit.aet.helios.github.sync;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -59,9 +58,13 @@ class WorkflowRunReconciliationServiceTest {
     OffsetDateTime remoteUpdatedAt = OffsetDateTime.now();
 
     when(
-            workflowRunRepository.findStaleIncompleteRuns(
-                any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(List.of(workflowRun), List.of());
+        workflowRunRepository.findStaleIncompleteRunsFirstPage(
+            any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(workflowRun));
+    when(
+        workflowRunRepository.findStaleIncompleteRunsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class)))
+        .thenReturn(List.of());
     when(gitHubService.getWorkflowRunState("owner/repo", 1001L))
         .thenReturn(
             Optional.of(new GitHubService.WorkflowRunState(
@@ -74,8 +77,11 @@ class WorkflowRunReconciliationServiceTest {
     assertEquals(remoteUpdatedAt, workflowRun.getUpdatedAt());
 
     verify(workflowRunRepository).save(workflowRun);
-    verify(workflowRunRepository, times(2))
-        .findStaleIncompleteRuns(any(), anyList(), any(), anyLong(), any(Pageable.class));
+    verify(workflowRunRepository)
+        .findStaleIncompleteRunsFirstPage(any(), anyList(), any(Pageable.class));
+    verify(workflowRunRepository)
+        .findStaleIncompleteRunsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class));
   }
 
   @Test
@@ -99,12 +105,13 @@ class WorkflowRunReconciliationServiceTest {
     OffsetDateTime remoteUpdatedAt = OffsetDateTime.now();
 
     when(
-            workflowRunRepository.findStaleIncompleteRuns(
+            workflowRunRepository.findStaleIncompleteRunsFirstPage(
+                any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(unresolvableWorkflowRun));
+    when(
+            workflowRunRepository.findStaleIncompleteRunsAfterCursor(
                 any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(
-            List.of(unresolvableWorkflowRun),
-            List.of(reconcilableWorkflowRun),
-            List.of());
+        .thenReturn(List.of(reconcilableWorkflowRun), List.of());
     when(gitHubService.getWorkflowRunState("owner/repo", 2002L))
         .thenReturn(
             Optional.of(new GitHubService.WorkflowRunState(
@@ -117,8 +124,11 @@ class WorkflowRunReconciliationServiceTest {
         WorkflowRun.Conclusion.SUCCESS, reconcilableWorkflowRun.getConclusion().orElse(null));
     assertEquals(remoteUpdatedAt, reconcilableWorkflowRun.getUpdatedAt());
     verify(workflowRunRepository).save(reconcilableWorkflowRun);
-    verify(workflowRunRepository, times(3))
-        .findStaleIncompleteRuns(any(), anyList(), any(), anyLong(), any(Pageable.class));
+    verify(workflowRunRepository)
+        .findStaleIncompleteRunsFirstPage(any(), anyList(), any(Pageable.class));
+    verify(workflowRunRepository, times(2))
+        .findStaleIncompleteRunsAfterCursor(
+            any(), anyList(), any(), anyLong(), any(Pageable.class));
   }
 
   @Test
@@ -141,9 +151,14 @@ class WorkflowRunReconciliationServiceTest {
     second.setStatus(WorkflowRun.Status.IN_PROGRESS);
     second.setUpdatedAt(secondTs);
 
-    when(workflowRunRepository.findStaleIncompleteRuns(
-        any(), anyList(), any(), anyLong(), any(Pageable.class)))
-        .thenReturn(List.of(first), List.of(second), List.of());
+    when(
+            workflowRunRepository.findStaleIncompleteRunsFirstPage(
+                any(), anyList(), any(Pageable.class)))
+        .thenReturn(List.of(first));
+    when(
+            workflowRunRepository.findStaleIncompleteRunsAfterCursor(
+                any(), anyList(), any(), anyLong(), any(Pageable.class)))
+        .thenReturn(List.of(second), List.of());
     when(gitHubService.getWorkflowRunState("owner/repo", 3001L))
         .thenReturn(
             Optional.of(new GitHubService.WorkflowRunState(
@@ -157,27 +172,32 @@ class WorkflowRunReconciliationServiceTest {
 
     ArgumentCaptor<OffsetDateTime> cursorTimeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
     ArgumentCaptor<Long> cursorIdCaptor = ArgumentCaptor.forClass(Long.class);
-    ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    ArgumentCaptor<Pageable> firstPageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+    ArgumentCaptor<Pageable> cursorPageableCaptor = ArgumentCaptor.forClass(Pageable.class);
 
-    verify(workflowRunRepository, times(3))
-        .findStaleIncompleteRuns(
-            any(), anyList(), cursorTimeCaptor.capture(), cursorIdCaptor.capture(),
-            pageableCaptor.capture());
+    verify(workflowRunRepository)
+        .findStaleIncompleteRunsFirstPage(
+            any(), anyList(), firstPageableCaptor.capture());
+    verify(workflowRunRepository, times(2))
+        .findStaleIncompleteRunsAfterCursor(
+            any(),
+            anyList(),
+            cursorTimeCaptor.capture(),
+            cursorIdCaptor.capture(),
+            cursorPageableCaptor.capture());
 
     List<OffsetDateTime> cursorTimes = cursorTimeCaptor.getAllValues();
-    assertNull(cursorTimes.get(0));
-    assertEquals(firstTs, cursorTimes.get(1));
-    assertEquals(secondTs, cursorTimes.get(2));
+    assertEquals(firstTs.plusMinutes(1), cursorTimes.get(0));
+    assertEquals(secondTs.plusMinutes(1), cursorTimes.get(1));
 
     List<Long> cursorIds = cursorIdCaptor.getAllValues();
-    assertEquals(0L, cursorIds.get(0));
-    assertEquals(3001L, cursorIds.get(1));
-    assertEquals(3002L, cursorIds.get(2));
+    assertEquals(3001L, cursorIds.get(0));
+    assertEquals(3002L, cursorIds.get(1));
 
-    List<Pageable> pageableList = pageableCaptor.getAllValues();
-    assertEquals(0, pageableList.get(0).getPageNumber());
-    assertEquals(0, pageableList.get(1).getPageNumber());
-    assertEquals(0, pageableList.get(2).getPageNumber());
+    assertEquals(0, firstPageableCaptor.getValue().getPageNumber());
+    List<Pageable> cursorPageables = cursorPageableCaptor.getAllValues();
+    assertEquals(0, cursorPageables.get(0).getPageNumber());
+    assertEquals(0, cursorPageables.get(1).getPageNumber());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fix reconciliation DB queries that could pass a NULL cursor on the first page, causing invalid SQL predicate evaluation.

### Description
<!-- Describe your changes in detail -->
- Split stale deployment/workflow-run queries into:
  - first-page query (no cursor filter)
  - after-cursor query (strict keyset filter)
- Updated reconciliation services and tests accordingly.

### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.