### PR TITLE
chore: update privacy policy content and structure in Helios application

### DIFF
--- a/client/src/app/pages/privacy/privacy.component.html
+++ b/client/src/app/pages/privacy/privacy.component.html
@@ -4,235 +4,255 @@
     <br />
     Last updated: 2026-04-27
     <br /><br />
-    The Technical University of Munich and the Research Group for Applied Education Technologies (AET) take the protection of personal data seriously. Helios processes personal
-    data both when you visit this website and when you use Helios after signing in. Processing is carried out in compliance with applicable data protection regulations, in
-    particular:
+    The Technical University of Munich (TUM) is the sole controller for the personal data processed in Helios within the meaning of Art. 4(7) GDPR. The Research Group for Applied
+    Education Technologies (AET), a chair within the Department of Computer Science (TUM School of Computation, Information and Technology, organisational unit CIT&ndash;I1),
+    operates Helios as part of TUM. AET is not a separate or joint controller. Processing complies with applicable data protection law, in particular:
     <ul class="list-disc pl-5">
-      <li>The General Data Protection Regulation (GDPR)</li>
-      <li>The Bavarian Data Protection Act (BayDSG), which applies to public institutions in Bavaria</li>
-      <li>The Bavarian Higher Education Innovation Act (BayHIG), which defines the tasks of Bavarian universities</li>
-      <li>The Telecommunications Digital Services Data Protection Act (TDDDG), where applicable to technically necessary browser-side storage and comparable technologies</li>
+      <li>The General Data Protection Regulation (GDPR) &mdash; the EU-wide data protection law</li>
+      <li>The Bavarian Data Protection Act (BayDSG) &mdash; applies to public institutions in Bavaria, including TUM</li>
+      <li>The Bavarian Higher Education Innovation Act (BayHIG) &mdash; defines the tasks of Bavarian universities</li>
+      <li>
+        The Telecommunications Digital Services Data Protection Act (TDDDG); Helios stores information in your browser only insofar as this is strictly necessary to provide the
+        service you have explicitly requested, within the meaning of &sect;&nbsp;25(2) No.&nbsp;2 TDDDG, and therefore does not require consent.
+      </li>
     </ul>
-    Below, we inform you about the categories of personal data processed in Helios, the purposes and legal bases of the processing, the recipients of the data, the retention
-    periods and the relevant contact points.
+    Below we explain what information Helios stores about you, why we are allowed to store it, who else sees it, how long we keep it, and how to reach us.
   </div>
 </app-page-heading>
 
 <div>
   <div>
+    <h2 class="text-xl font-semibold mt-4">In short</h2>
+    <ul class="list-disc pl-5 mt-3">
+      <li>
+        <strong>Helios dashboards are public.</strong> The development activity we visualise &mdash; including GitHub usernames and avatars &mdash; is visible to anyone on the open
+        web, with no sign-in required.
+      </li>
+      <li>
+        <strong>Signing in is only for write actions.</strong> You only need to sign in (with your GitHub account) to do things like trigger a deployment or reserve a test
+        environment.
+      </li>
+      <li>
+        <strong>To exercise your data protection rights</strong> (access, correction, deletion, etc.), email the AET Administrators at
+        <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a>. The full list of rights is below.
+      </li>
+    </ul>
+
     <h2 class="text-xl font-semibold mt-4">What Helios is and who can see what</h2>
-    <br />
-    <p>
+    <p class="mt-3">
       Helios is operated by AET to manage the development, deployment, and release of AET&apos;s own open-source software (e.g. Artemis, Athena, Hephaestus). Helios is not used in
       any course.
     </p>
-    <br />
-    <p>
+    <p class="mt-3">
       The dashboards Helios builds &mdash; including the GitHub usernames and avatars of the developers behind the activity shown &mdash; are visible to anyone on the open web
       without signing in. Signing in is required only to perform write actions (e.g. triggering a deployment, reserving a test environment), and such actions additionally require
       write permission on the affected GitHub repository.
     </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Purposes and legal bases for processing</h2>
-    <br />
-    <p>The following legal bases apply to the corresponding processing operations in Helios:</p>
-    <br />
-    <h3 class="text-base font-semibold mt-3">Core service (authentication, GitHub synchronisation, dashboards) for TUM members</h3>
-    <p>
-      Art. 6(1)(e) GDPR i.V.m. Art. 2 BayHIG (tasks of Bavarian universities &mdash; research, teaching, transfer; AET is a research chair operating chair-level development and
-      release infrastructure for the chair&apos;s own software, which falls under research and transfer) i.V.m. Art. 4 BayDSG (a Bavarian public body may process personal data when
-      this is necessary to carry out its tasks).
+    <h2 class="text-xl font-semibold mt-4">Why we are allowed to process your data (legal bases)</h2>
+    <p class="mt-3">
+      Each kind of processing in Helios is permitted under one of four legal bases. Below, &ldquo;i.V.m.&rdquo; is a German legal abbreviation meaning &ldquo;in conjunction
+      with&rdquo; &mdash; it chains together the GDPR article and the Bavarian laws that together permit the processing.
     </p>
-    <br />
+
+    <h3 class="text-base font-semibold mt-3">Core service for TUM members (sign-in, GitHub sync, dashboards)</h3>
+    <p class="mt-1"><strong>Why we may do this:</strong> Helios supports the work of a Bavarian public university and is therefore covered by the public-task basis in the GDPR.</p>
+    <p class="mt-1">
+      <strong>Legal basis:</strong> Art. 6(1)(e) GDPR i.V.m. Art. 2 BayHIG (the tasks of Bavarian universities &mdash; research, teaching, transfer; AET is a research chair
+      operating chair-level development and release infrastructure for the chair&apos;s own software, which falls under research and transfer) i.V.m. Art. 4(1) BayDSG (a Bavarian
+      public body may process personal data when this is necessary to carry out a task assigned to it).
+    </p>
+
     <h3 class="text-base font-semibold mt-3">Core service for non-TUM contributors</h3>
-    <p>
-      Art. 6(1)(b) GDPR. External open-source contributors who sign in to Helios with their GitHub account do so on their own request in order to use the service; the processing
-      necessary to provide the service to them is based on this request.
+    <p class="mt-1">
+      <strong>Why we may do this:</strong> External open-source contributors choose to sign in to use Helios; processing the data needed to provide the service to them is part of
+      that request, and enabling external contributors to participate in the chair&apos;s open-source projects is itself part of TUM&apos;s knowledge-and-technology-transfer task.
     </p>
-    <br />
-    <h3 class="text-base font-semibold mt-3">Optional notification email and notification preferences</h3>
-    <p>
-      Art. 6(1)(a) GDPR (consent). Providing a notification email address and choosing notification preferences in the Helios settings page is an opt-in by affirmative action.
-      Consent can be withdrawn at any time with effect for the future, without affecting the lawfulness of processing carried out before the withdrawal (Art. 7(3) GDPR).
+    <p class="mt-1">
+      <strong>Legal basis:</strong> Art. 6(1)(b) GDPR (steps taken at the data subject&apos;s request prior to and during use of the service) in conjunction with Art. 6(1)(e) GDPR
+      i.V.m. Art. 2 BayHIG and Art. 4(1) BayDSG. The processing is strictly limited to what is necessary to provide the service to the contributor.
     </p>
-    <br />
-    <h3 class="text-base font-semibold mt-3">Server access logs and self-hosted Sentry error telemetry</h3>
-    <p>
-      Art. 6(1)(f) GDPR (legitimate interests). AET has a legitimate interest in operating Helios securely and reliably, in detecting and diagnosing errors, and in defending
-      against attacks. The balancing of interests is in favour of processing because the data is technical rather than behavioural, is not used for profiling, is retained only
-      briefly (see retention table below) and stays inside TUM-operated infrastructure.
-    </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Categories of personal data processed</h2>
-    <br />
-    <p>When you sign in, Helios authenticates you via a self-hosted Keycloak federated to GitHub OAuth and stores the following data associated with your account:</p>
-    <br />
-    <ul class="list-disc pl-5">
+    <h3 class="text-base font-semibold mt-3">Optional notification email and notification preferences</h3>
+    <p class="mt-1"><strong>Why we may do this:</strong> You opt in by entering an address and choosing preferences in the Helios settings page.</p>
+    <p class="mt-1">
+      <strong>Legal basis:</strong> Art. 6(1)(a) GDPR (consent). You can withdraw consent at any time with effect for the future, without affecting the lawfulness of processing
+      done before the withdrawal (Art. 7(3) GDPR).
+    </p>
+
+    <h3 class="text-base font-semibold mt-3">Server access logs and self-hosted error reports</h3>
+    <p class="mt-1">
+      <strong>Why we may do this:</strong> AET has a legitimate interest in running Helios securely and reliably, in finding and diagnosing errors, and in defending against
+      attacks. The same purpose applies whether you are signed in or not.
+    </p>
+    <p class="mt-1">
+      <strong>Legal basis:</strong> Art. 6(1)(f) GDPR (legitimate interests) for unauthenticated traffic, and additionally Art. 6(1)(e) GDPR i.V.m. Art. 2 BayHIG and Art. 4(1)
+      BayDSG for authenticated traffic. The balance of interests is in favour of processing because the data is technical rather than behavioural, is not used for profiling, is
+      retained only briefly (see retention table below) and stays inside TUM-operated infrastructure.
+    </p>
+
+    <h2 class="text-xl font-semibold mt-4">What information about you we store</h2>
+    <p class="mt-3">
+      When you sign in, Helios authenticates you via a self-hosted Keycloak (the sign-in service AET runs on TUM infrastructure), which delegates the actual login to GitHub using
+      OAuth (a standard protocol that lets you log in to one site using your account on another). Once signed in, we store the following data with your account:
+    </p>
+    <ul class="list-disc pl-5 mt-3">
       <li>GitHub login, display name, avatar URL and profile URL</li>
       <li>Email address provided by GitHub</li>
       <li>Optional GitHub profile fields: bio, company, blog, free-text location (from the GitHub profile, not GPS), follower and following counts</li>
-      <li>Optional notification email address you enter in the Helios settings page</li>
-      <li>Notification preferences (currently for the events DEPLOYMENT_FAILED, LOCK_EXPIRED and LOCK_UNLOCKED)</li>
-      <li>Technical UI state stored in your browser (e.g. expanded or collapsed state of the sidebar)</li>
+      <li>Optional notification email address you enter on the Helios settings page</li>
+      <li>Notification preferences (currently for the events <code>DEPLOYMENT_FAILED</code>, <code>LOCK_EXPIRED</code> and <code>LOCK_UNLOCKED</code>)</li>
+      <li>
+        Technical UI state stored in your browser (currently: pagination state per table, sidebar expanded/collapsed state, theme preference, branch-view preference) plus the
+        session token issued by the sign-in service. No tracking, analytics, advertising, or profiling cookies are set.
+      </li>
     </ul>
-    <br />
-    <p>
-      For developers who have not signed in to Helios but whose activity in AET-maintained GitHub repositories is mirrored in Helios&apos;s dashboards, the personal data shown
-      originates from the developer&apos;s own public GitHub account, accessed via the GitHub API (Art. 14 GDPR).
-    </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Logging</h2>
-    <br />
-    <p>
-      When Helios is accessed, the web application and backend services process technical information in log files in order to provide the service securely and reliably. This may
-      include the following information:
+    <p class="mt-3">
+      <strong>If you have not signed in to Helios but appear in our dashboards (Art. 14 GDPR):</strong> for developers whose activity in AET-maintained GitHub repositories is
+      mirrored in Helios&apos;s dashboards, this information notice is provided as required by Art. 14 GDPR. The categories of personal data processed for this group are: GitHub
+      login, display name, avatar URL, profile URL, and the public activity attribution (workflow runs, deployments, releases, branches, commits, issues, environment-lock history)
+      tied to that GitHub identity. The source is the GitHub REST API at <code>https://api.github.com</code>; Helios obtains only data that GitHub itself already exposes through
+      the developer&apos;s public GitHub profile. The legal bases, recipients, retention periods, third-country transfers, and subject rights described in this notice apply equally
+      to this group.
     </p>
-    <br />
-    <ul class="list-disc pl-5">
+
+    <h2 class="text-xl font-semibold mt-4">What we log when you use the site</h2>
+    <p class="mt-3">To run Helios securely and reliably, the web application and backend services write the following technical information to log files:</p>
+    <ul class="list-disc pl-5 mt-3">
       <li>IP address of the requesting computer</li>
       <li>Date and time of access</li>
       <li>Name, URL and transferred data volume of the retrieved file</li>
-      <li>Access status (requested file transferred, not found, etc.)</li>
-      <li>Identification data of the browser and operating system used (if transmitted by the requesting web browser)</li>
-      <li>Web page from which access was made (if transmitted by the requesting web browser)</li>
+      <li>Access status (e.g. file delivered, file not found)</li>
+      <li>Identification data of the browser and operating system used (if your browser sends it)</li>
+      <li>The page you came from (if your browser sends it)</li>
     </ul>
-    <br />
-    <p>The processing of the data in this log file takes place as follows:</p>
-    <br />
-    <ul class="list-disc pl-5">
-      <li>The log entries are continuously and automatically evaluated in order to detect attacks, errors and misuse and to react accordingly.</li>
-      <li>In individual cases, i.e. in the case of reported disruptions, errors and security incidents, a manual analysis is carried out.</li>
-      <li>The data is not used to create personal user profiles.</li>
+    <p class="mt-3">How we use these logs:</p>
+    <ul class="list-disc pl-5 mt-3">
+      <li>Log entries are evaluated automatically and continuously to detect attacks, errors and misuse and to react accordingly.</li>
+      <li>If a disruption, error or security incident is reported, an individual entry may be analysed manually.</li>
+      <li>The logs are not used to build personal user profiles.</li>
     </ul>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Recipients</h2>
-    <br />
-    <p>The following recipients receive personal data in the course of operating Helios:</p>
-    <br />
-    <ul class="list-disc pl-5">
+    <h2 class="text-xl font-semibold mt-4">Who else sees your data (recipients)</h2>
+    <p class="mt-3">In the course of operating Helios, the following parties receive personal data:</p>
+    <ul class="list-disc pl-5 mt-3">
       <li>
-        <strong>Anyone on the open web</strong> &mdash; the dashboards Helios builds (workflow runs, deployments, environments, environment-lock history, branches, commits, pull
-        requests, releases, issues, test results) include the GitHub-derived developer attribution attached to each item and are served without authentication via every GET
-        endpoint under <code>/api/**</code>.
+        <strong>Anyone on the open web.</strong> The dashboards Helios builds (workflow runs, deployments, environments, environment-lock history, branches, commits, pull requests,
+        releases, issues, test results) include the GitHub-derived developer attribution attached to each item and are served without authentication via every read (GET) endpoint
+        under <code>/api/**</code>.
       </li>
       <li>
-        <strong>GitHub, Inc.</strong> &mdash; Helios reads repository activity from GitHub via the GitHub API and also sends deployment-trigger actions back to GitHub Actions on
-        behalf of a signed-in user when that user triggers a deployment.
+        <strong>GitHub, Inc.</strong> Helios reads repository activity from GitHub via the GitHub API. When a signed-in user triggers a deployment, Helios additionally sends a
+        deployment-trigger action back to GitHub Actions (GitHub&apos;s built-in automation system); the only personal data transmitted to GitHub in this direction is the GitHub
+        identity of the signed-in user, which GitHub already holds as the owner of that account. No further personal data is transferred outbound to GitHub.
       </li>
-      <li><strong>Self-hosted Keycloak</strong> operated within TUM &mdash; authentication.</li>
+      <li><strong>Self-hosted Keycloak</strong> (the sign-in service, run on TUM infrastructure) &mdash; for authentication.</li>
       <li>
-        <strong>Self-hosted Sentry</strong> at <a href="https://sentry.ase.in.tum.de" class="text-primary" target="_blank" rel="noopener noreferrer">sentry.ase.in.tum.de</a>,
-        operated within TUM &mdash; error telemetry. No external Sentry SaaS is used.
+        <strong>Self-hosted Sentry</strong> (an error-reporting tool, run by AET on TUM infrastructure at
+        <a href="https://sentry.ase.in.tum.de" class="text-primary" target="_blank" rel="noopener noreferrer">sentry.ase.in.tum.de</a>) &mdash; for error reports. We do not use any
+        external Sentry cloud service.
       </li>
-      <li><strong>TUM SMTP / AET mail relay</strong> operated within TUM &mdash; delivery of notification emails.</li>
+      <li><strong>TUM SMTP / AET mail relay</strong> (TUM&apos;s outgoing-mail servers) &mdash; for delivering notification emails.</li>
     </ul>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Transfer to a third country</h2>
-    <br />
-    <p>
-      GitHub, Inc. is based in the USA. The transfer of personal data to GitHub is covered by GitHub&apos;s own certification under the EU&ndash;U.S. Data Privacy Framework (Art.
-      45 GDPR) and by Standard Contractual Clauses (Art. 46(2)(c) GDPR; Commission Implementing Decision 2021/914), as set out in the GitHub Data Protection Agreement, which
-      applies to every github.com user. No personal data is transferred to any other recipient outside the European Economic Area.
+    <h2 class="text-xl font-semibold mt-4">Transfer to a third country (USA)</h2>
+    <p class="mt-3">
+      GitHub, Inc. is based in the USA. The transfer of personal data to GitHub is covered by two safeguards: GitHub&apos;s certification under the EU&ndash;U.S. Data Privacy
+      Framework (DPF &mdash; an EU adequacy decision under Art. 45(3) GDPR allowing transfers to certified U.S. companies; Commission Implementing Decision (EU) 2023/1795 of 10
+      July 2023), and Standard Contractual Clauses (SCC &mdash; a standard EU-approved data-transfer contract under Art. 46(2)(c) GDPR; Commission Implementing Decision (EU)
+      2021/914 of 4 June 2021). Both safeguards are set out in the GitHub Data Protection Agreement, which applies to every github.com user. No personal data is transferred to any
+      other recipient outside the European Economic Area.
     </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Retention periods</h2>
-    <br />
-    <ul class="list-disc pl-5">
-      <li><strong>Account and profile data:</strong> for as long as the account exists; deleted on request (see &ldquo;Your rights&rdquo; below).</li>
+    <h2 class="text-xl font-semibold mt-4">How long we keep data (retention)</h2>
+    <ul class="list-disc pl-5 mt-3">
       <li>
-        <strong>Workflow run records (database):</strong> a nightly cleanup task at 01:00 keeps the two newest <code>PROCESSED</code> runs per repository and branch and deletes
-        runs in state <code>FAILED</code> or with no terminal state that are older than five days.
+        <strong>Account and profile data:</strong> kept for as long as your account exists; deleted on request (see &ldquo;Your rights&rdquo; below). Active retention is required
+        because Helios&apos;s dashboards attribute past activity to the contributor&apos;s account; deletion is on request so that erasure remains under the data subject&apos;s
+        control.
       </li>
-      <li><strong>Workflow run logs (filesystem):</strong> a nightly cleanup task at 02:00 deletes log files older than one day.</li>
-      <li><strong>Self-hosted Sentry error telemetry:</strong> retained for at most 30 days.</li>
-      <li><strong>Database backups:</strong> daily backups with a retention of 7 days.</li>
-      <li><strong>Server access logs:</strong> standard log rotation.</li>
+      <li>
+        <strong>Workflow run records (database):</strong> a nightly cleanup at 01:00 keeps the two newest <code>PROCESSED</code> runs (finished successfully) per repository and
+        branch, and deletes runs in state <code>FAILED</code> (errored) or with no terminal state that are older than five days.
+      </li>
+      <li><strong>Workflow run logs (filesystem):</strong> a nightly cleanup at 02:00 deletes log files older than one day.</li>
+      <li><strong>Self-hosted Sentry error reports:</strong> kept for at most 30 days.</li>
+      <li><strong>Database backups:</strong> daily backups, kept for 7 days.</li>
+      <li><strong>Server access logs:</strong> rotated daily by the host system; not retained for longer than 14 days under normal operation, then automatically deleted.</li>
     </ul>
-    <br />
-    <p>
-      Unless statutory retention obligations require otherwise, personal data is stored only for as long as necessary to operate Helios and fulfil the respective processing
-      purpose.
+    <p class="mt-3">
+      Unless statutory retention obligations require otherwise, personal data is stored only for as long as necessary to operate Helios and fulfil the relevant processing purpose.
     </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">Technical operation and cookies</h2>
-    <br />
-    <p>
-      The technical operation of Helios is carried out within the environment of the Technical University of Munich and the Research Group for Applied Education Technologies. The
-      Helios web servers are operated by AET itself at Boltzmannstraße 3, 85748 Garching b. München.
+    <h2 class="text-xl font-semibold mt-4">Where Helios runs</h2>
+    <p class="mt-3">
+      Helios runs entirely within the infrastructure of the Technical University of Munich and the Research Group for Applied Education Technologies. The Helios web servers are
+      operated by AET itself at Boltzmannstraße 3, 85748 Garching b. München.
     </p>
-    <br />
-    <p>
-      Helios uses technically necessary browser-side storage and comparable session mechanisms to provide the application. This includes, for example, storing UI state in the
-      browser. If you disable such storage mechanisms, parts of the application may no longer work correctly.
-    </p>
-    <br />
 
-    <h2 class="text-xl font-semibold mt-4">No automated decision-making</h2>
-    <br />
-    <p>Helios does not perform automated decision-making, including profiling, within the meaning of Art. 22 GDPR.</p>
-    <br />
+    <h2 class="text-xl font-semibold mt-4">Whether providing data is required</h2>
+    <p class="mt-3">
+      Provision of personal data to Helios is voluntary. There is neither a statutory nor a contractual obligation to use Helios. If you do not sign in, you can still browse the
+      publicly visible dashboards, but you cannot perform write actions (e.g. trigger deployments, reserve test environments) and you cannot receive notification emails. If you
+      sign in but do not provide an optional notification email address, the only consequence is that no notifications will be sent to you. There is no other disadvantage from
+      declining to provide data.
+    </p>
+
+    <h2 class="text-xl font-semibold mt-4">No automated decisions</h2>
+    <p class="mt-3">Helios does not perform automated decision-making, including profiling, within the meaning of Art. 22 GDPR.</p>
 
     <h2 class="text-xl font-semibold mt-4">Notification email (consent)</h2>
-    <br />
-    <p>
+    <p class="mt-3">
       You may optionally enter a notification email address and choose notification preferences on the Helios settings page. This processing is based on your consent (Art. 6(1)(a)
-      GDPR). You can change or remove the notification email address and your notification preferences at any time on the same settings page. Withdrawing consent does not affect
-      the lawfulness of processing carried out before the withdrawal (Art. 7(3) GDPR).
+      GDPR). You can change or remove the address and preferences at any time on the same settings page. Withdrawing consent does not affect the lawfulness of processing carried
+      out before the withdrawal (Art. 7(3) GDPR).
     </p>
-    <br />
-
-    <h2 class="text-xl font-semibold mt-4">Correspondence by email</h2>
-    <br />
-    <p>
-      If you contact us by email, your email address and the content of your message are processed solely for the purpose of handling your enquiry. Please note that data
-      transmission over the internet can have security gaps; complete protection of data from access by third parties is not possible.
-    </p>
-    <br />
 
     <h2 class="text-xl font-semibold mt-4">Your rights</h2>
-    <br />
-    <p>You have the following rights with respect to the personal data Helios processes about you:</p>
-    <br />
-    <ul class="list-disc pl-5">
-      <li>Right of access (Art. 15 GDPR)</li>
-      <li>Right to rectification (Art. 16 GDPR)</li>
-      <li>Right to erasure (Art. 17 GDPR)</li>
-      <li>Right to restriction of processing (Art. 18 GDPR)</li>
-      <li>Right to data portability (Art. 20 GDPR)</li>
-      <li>
-        Right to object (Art. 21 GDPR) &mdash; in particular against processing based on legitimate interests (Art. 6(1)(f) GDPR), namely server access logs and self-hosted Sentry
-        error telemetry
-      </li>
-      <li>
-        Right to withdraw consent (Art. 7(3) GDPR) &mdash; in particular with respect to the optional notification email address and notification preferences; withdrawal does not
-        affect the lawfulness of processing carried out before the withdrawal
-      </li>
-      <li>Right to lodge a complaint with a supervisory authority (Art. 77 GDPR; see below)</li>
-    </ul>
-    <br />
-    <p>
-      To exercise these rights, you can contact the AET Administrators at
+    <p class="mt-3">
+      To exercise any of the rights below, contact the AET Administrators at
       <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a>
-      or the official TUM data protection officer at
-      <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a>.
+      or the TUM data protection officer at
+      <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a>. You do not need to give a reason.
     </p>
-    <br />
+    <p class="mt-3">You have the following rights with respect to the personal data Helios processes about you:</p>
+    <ul class="list-disc pl-5 mt-3">
+      <li><strong>Right of access</strong> (Art. 15 GDPR) &mdash; ask us what data we hold about you.</li>
+      <li><strong>Right to rectification</strong> (Art. 16 GDPR) &mdash; ask us to correct inaccurate data.</li>
+      <li><strong>Right to erasure</strong> (Art. 17 GDPR) &mdash; ask us to delete your data.</li>
+      <li><strong>Right to restriction of processing</strong> (Art. 18 GDPR) &mdash; ask us to pause processing while a question is resolved.</li>
+      <li>
+        <strong>Right to be informed of recipients</strong> (Art. 19 GDPR) &mdash; ask us who else received any rectification, erasure or restriction we carried out at your
+        request.
+      </li>
+      <li><strong>Right to data portability</strong> (Art. 20 GDPR) &mdash; receive your data in a portable format.</li>
+      <li>
+        <strong>Right to object</strong> (Art. 21 GDPR) &mdash; in particular against processing based on legitimate interests (Art. 6(1)(f) GDPR), namely server access logs and
+        self-hosted Sentry error reports.
+      </li>
+      <li>
+        <strong>Right to withdraw consent</strong> (Art. 7(3) GDPR) &mdash; in particular for the optional notification email and preferences. Withdrawal does not affect the
+        lawfulness of processing done before the withdrawal.
+      </li>
+      <li><strong>Right to lodge a complaint with a supervisory authority</strong> (Art. 77 GDPR) &mdash; the responsible authority and its full address are listed below.</li>
+    </ul>
+
+    <h2 class="text-xl font-semibold mt-4">If you email us</h2>
+    <p class="mt-3">
+      If you contact us by email, your email address and the content of your message are processed solely to handle your enquiry. Please note that data transmission over the
+      internet can have security gaps; complete protection against access by third parties is not possible.
+    </p>
 
     <h2 class="text-xl font-semibold mt-4">Right to lodge a complaint with the supervisory authority</h2>
-    <br />
-    <p>
-      If you believe that the processing of your personal data violates applicable data protection laws, you have the right to lodge a complaint with a supervisory authority.
-      <br /><br />
-      Since Helios is operated at the <strong>Technical University of Munich (TUM)</strong>, a public institution in Bavaria, the applicable law is the
-      <strong>Bavarian Data Protection Act (BayDSG)</strong>, which supplements the <strong>General Data Protection Regulation (GDPR)</strong>. The responsible supervisory
-      authority is: <br /><br />
+    <p class="mt-3">
+      If you believe that the processing of your personal data violates applicable data protection law, you have the right to lodge a complaint with a supervisory authority.
+    </p>
+    <p class="mt-3">
+      Since the controller is a Bavarian public body, the competent supervisory authority pursuant to Art. 15(1) BayDSG is the Bavarian State Commissioner for Data Protection
+      (Bayerischer Landesbeauftragter für den Datenschutz, BayLfD):
+    </p>
+    <p class="mt-3">
       <strong>Bavarian State Commissioner for Data Protection (BayLfD)</strong><br />
       Wagmüllerstraße 18<br />
       80538 Munich<br />
@@ -240,46 +260,46 @@
       Phone: +49 89 212672-0<br />
       Fax: +49 89 212672-50<br />
       Email: <a href="mailto:poststelle@datenschutz-bayern.de" class="text-primary">poststelle&#64;datenschutz-bayern.de</a><br />
-      Website: <a href="https://www.datenschutz-bayern.de" class="text-primary" target="_blank" rel="noopener noreferrer">https://www.datenschutz-bayern.de</a> <br /><br />
-      Alternatively, you may contact the supervisory authority in your place of residence or workplace. The supervisory authority will inform you about the progress and outcome of
-      your complaint, including the possibility of a judicial remedy pursuant to Article 78 GDPR.
+      Website: <a href="https://www.datenschutz-bayern.de" class="text-primary" target="_blank" rel="noopener noreferrer">https://www.datenschutz-bayern.de</a>
     </p>
-    <br />
+    <p class="mt-3">
+      Alternatively, you may contact the supervisory authority in your place of residence or workplace. The supervisory authority will inform you about the progress and outcome of
+      your complaint, including the possibility of a judicial remedy under Art. 78 GDPR.
+    </p>
 
     <h2 class="text-xl font-semibold mt-4">SSL/TLS encryption</h2>
-    <br />
-    <p>
-      For security reasons and to protect the transmission of confidential content, Helios uses SSL/TLS encryption. This means that data transmitted via this website cannot be read
-      by third parties during transport. You can recognise an encrypted connection by the &ldquo;https://&rdquo; address in your browser and by the lock symbol in the browser
-      interface.
+    <p class="mt-3">
+      For security reasons and to protect the transmission of confidential content, Helios uses SSL/TLS encryption. Data transmitted via this website cannot be read by third
+      parties in transit. You can recognise an encrypted connection by the &ldquo;https://&rdquo; address in your browser and by the lock symbol in the browser interface.
     </p>
-    <br />
 
     <h2 class="text-xl font-semibold mt-4">Name and contact details of the controller</h2>
-    <br />
-    <p>
+    <p class="mt-3">
       Controller:<br />
-      Technical University of Munich<br />
+      Technical University of Munich (Technische Universität München), a statutory body under public law (Körperschaft des öffentlichen Rechts)<br />
+      represented by its President, Prof. Dr. Thomas F. Hofmann<br />
       Arcisstraße 21<br />
       80333 Munich<br />
+      Germany<br />
       Email: <a href="mailto:poststelle@tum.de" class="text-primary">poststelle&#64;tum.de</a><br />
-      <br />
-      Operational contact for Helios:<br />
+      Telephone: +49 89 289 01
+    </p>
+    <p class="mt-3">
+      Operational contact for Helios (also for data subject requests):<br />
       AET Administrators<br />
-      Research Group for Applied Education Technologies, headed by Prof. Dr. Stephan Krusche (CIT&ndash;I1)<br />
+      Research Group for Applied Education Technologies (CIT&ndash;I1)<br />
       Boltzmannstraße 3<br />
       85748 Garching b. München<br />
       Office: <a href="https://nav.tum.de/room/5607.01.044" class="text-primary" target="_blank" rel="noopener noreferrer">01.07.044</a><br />
-      Email: <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a><br />
-      <br />
+      Email: <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a>
+    </p>
+    <p class="mt-3">
       Official data protection officer of the Technical University of Munich:<br />
       Dr. Fabian Franzen<br />
       Datenschutzbüro, Boltzmannstraße 3, 85748 Garching<br />
       Email: <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a><br />
       Website:
-      <a href="https://www.datenschutz.tum.de/en/datenschutz/der-datenschutzbeauftragte/" class="text-primary" target="_blank" rel="noopener noreferrer">www.datenschutz.tum.de</a
-      ><br />
+      <a href="https://www.datenschutz.tum.de/en/datenschutz/der-datenschutzbeauftragte/" class="text-primary" target="_blank" rel="noopener noreferrer">www.datenschutz.tum.de</a>
     </p>
-    <br />
   </div>
 </div>

--- a/client/src/app/pages/privacy/privacy.component.html
+++ b/client/src/app/pages/privacy/privacy.component.html
@@ -73,11 +73,14 @@
       i.V.m. Art. 2 BayHIG and Art. 4(1) BayDSG. The processing is strictly limited to what is necessary to provide the service to the contributor.
     </p>
 
-    <h3 class="text-base font-semibold mt-3">Optional notification email and notification preferences</h3>
-    <p class="mt-1"><strong>Why we may do this:</strong> You opt in by entering an address and choosing preferences in the Helios settings page.</p>
+    <h3 class="text-base font-semibold mt-3">Notification email and notification preferences</h3>
     <p class="mt-1">
-      <strong>Legal basis:</strong> Art. 6(1)(a) GDPR (consent). You can withdraw consent at any time with effect for the future, without affecting the lawfulness of processing
-      done before the withdrawal (Art. 7(3) GDPR).
+      Helios may initialise your notification email from GitHub and enable notification preferences on first login. You can disable notifications, change the notification email,
+      and adjust preferences in the Helios settings page.
+    </p>
+    <p class="mt-1">
+      <strong>Legal basis:</strong> the same legal basis as the core service applies; if you manually enter a different notification email address, processing that additional
+      address is based on consent (Art. 6(1)(a) GDPR).
     </p>
 
     <h3 class="text-base font-semibold mt-3">Server access logs and self-hosted error reports</h3>
@@ -102,6 +105,10 @@
       <li>Optional GitHub profile fields: bio, company, blog, free-text location (from the GitHub profile, not GPS), follower and following counts</li>
       <li>Optional notification email address you enter on the Helios settings page</li>
       <li>Notification preferences (currently for the events <code>DEPLOYMENT_FAILED</code>, <code>LOCK_EXPIRED</code> and <code>LOCK_UNLOCKED</code>)</li>
+      <li>
+        User-linked action records created while using Helios, including deployments, workflow reruns or cancellations, environment lock and unlock history, release candidate
+        actions, release evaluations and comments, and pinned branch or pull request preferences
+      </li>
       <li>
         Technical UI state stored in your browser (currently: pagination state per table, sidebar expanded/collapsed state, theme preference, branch-view preference) plus the
         session token issued by the sign-in service. No tracking, analytics, advertising, or profiling cookies are set.
@@ -161,8 +168,8 @@
       GitHub, Inc. is based in the USA. The transfer of personal data to GitHub is covered by two safeguards: GitHub&apos;s certification under the EU&ndash;U.S. Data Privacy
       Framework (DPF &mdash; an EU adequacy decision under Art. 45(3) GDPR allowing transfers to certified U.S. companies; Commission Implementing Decision (EU) 2023/1795 of 10
       July 2023), and Standard Contractual Clauses (SCC &mdash; a standard EU-approved data-transfer contract under Art. 46(2)(c) GDPR; Commission Implementing Decision (EU)
-      2021/914 of 4 June 2021). Both safeguards are set out in the GitHub Data Protection Agreement, which applies to every github.com user. No personal data is transferred to any
-      other recipient outside the European Economic Area.
+      2021/914 of 4 June 2021). GitHub describes these safeguards in its Privacy Statement and, where applicable, in its Data Protection Agreement. No personal data is transferred
+      to any other recipient outside the European Economic Area.
     </p>
 
     <h2 class="text-xl font-semibold mt-4">How long we keep data (retention)</h2>
@@ -173,12 +180,12 @@
         control.
       </li>
       <li>
-        <strong>Workflow run records (database):</strong> a nightly cleanup at 01:00 keeps the two newest <code>PROCESSED</code> runs (finished successfully) per repository and
-        branch, and deletes runs in state <code>FAILED</code> (errored) or with no terminal state that are older than five days.
+        <strong>Workflow run records (database):</strong> a nightly cleanup at 01:00 keeps the two newest records per repository, workflow and branch for each configured processing
+        status; older <code>PROCESSED</code> runs may be deleted immediately, while older <code>FAILED</code> runs or runs with no terminal state are deleted only after five days.
       </li>
       <li><strong>Workflow run logs (filesystem):</strong> a nightly cleanup at 02:00 deletes log files older than one day.</li>
       <li><strong>Self-hosted Sentry error reports:</strong> kept for at most 30 days.</li>
-      <li><strong>Database backups:</strong> daily backups, kept for 7 days.</li>
+      <li><strong>Database backups:</strong> bidaily backups, kept for 7 days.</li>
       <li><strong>Server access logs:</strong> rotated daily by the host system; not retained for longer than 14 days under normal operation, then automatically deleted.</li>
     </ul>
     <p class="mt-3">
@@ -204,9 +211,9 @@
 
     <h2 class="text-xl font-semibold mt-4">Notification email (consent)</h2>
     <p class="mt-3">
-      You may optionally enter a notification email address and choose notification preferences on the Helios settings page. This processing is based on your consent (Art. 6(1)(a)
-      GDPR). You can change or remove the address and preferences at any time on the same settings page. Withdrawing consent does not affect the lawfulness of processing carried
-      out before the withdrawal (Art. 7(3) GDPR).
+      Helios may initialise your notification email from GitHub and enable notification preferences on first login. You can disable notifications, change the notification email
+      address, and adjust preferences on the Helios settings page. Withdrawing consent does not affect the lawfulness of processing carried out before the withdrawal (Art. 7(3)
+      GDPR).
     </p>
 
     <h2 class="text-xl font-semibold mt-4">Your rights</h2>

--- a/client/src/app/pages/privacy/privacy.component.html
+++ b/client/src/app/pages/privacy/privacy.component.html
@@ -2,24 +2,38 @@
   <div heading>Privacy Policy</div>
   <div description>
     <br />
-    The Research Group for Applied Education Technologies (referred to as AET in the following paragraphs) from the Technical University of Munich takes the protection of private
-    data seriously. We process automatically collected personal data obtained when you visit our website in compliance with applicable data protection regulations, in particular:
+    The Technical University of Munich and the Research Group for Applied Education Technologies (AET) take the protection of personal data seriously. Helios processes personal
+    data both when you visit this website and when you use Helios after signing in. Processing is carried out in compliance with applicable data protection regulations, in
+    particular:
     <ul class="list-disc pl-5">
       <li>The General Data Protection Regulation (GDPR)</li>
       <li>The Bavarian Data Protection Act (BayDSG), which applies to public institutions in Bavaria</li>
-      <li>The Telecommunications Telemedia Data Protection Act (TTDSG), which governs online services and the use of cookies.</li>
+      <li>The Telecommunications Digital Services Data Protection Act (TDDDG), where applicable to technically necessary browser-side storage and comparable technologies</li>
     </ul>
-    Below, we inform you about the type, scope and purpose of the collection and use of personal data.
+    Below, we inform you about the most important categories of personal data processed in Helios, the purpose of the processing and the relevant contact points.
   </div>
 </app-page-heading>
 
 <div>
   <div>
+    <h2 class="text-xl font-semibold mt-4">Purpose and legal basis for processing</h2>
+    <br />
+    <p>
+      Helios is operated to provide technical support for software-engineering and development workflows in the university context. Personal data is processed only to provide the
+      service, authenticate users, operate the system securely, troubleshoot incidents and enable optional notification features.
+    </p>
+    <br />
+    <p>
+      Unless otherwise stated, processing is carried out on the basis of the applicable public-law tasks of the Technical University of Munich and the corresponding legal obligations
+      and responsibilities under Art. 6(1)(c) and, where applicable, Art. 6(1)(e) GDPR in conjunction with the applicable university and Bavarian data protection provisions.
+    </p>
+    <br />
+
     <h2 class="text-xl font-semibold mt-4">Logging</h2>
     <br />
     <p>
-      The web servers of the AET are operated by the AET itself, based in Boltzmannstr. 3, 85748 Garching b. Munich. Every time our website is accessed, the web server temporarily
-      processes the following information in log files:
+      When Helios is accessed, the web application and backend services process technical information in log files in order to provide the service securely and reliably. This may
+      include the following information:
     </p>
     <br />
     <ul class="list-disc pl-5">
@@ -28,33 +42,72 @@
       <li>Name, URL and transferred data volume of the retrieved file</li>
       <li>Access status (requested file transferred, not found, etc.)</li>
       <li>Identification data of the browser and operating system used (if transmitted by the requesting web browser)</li>
-      <li>Web page from which access was made (if transmitted by the requesting web browser) The processing of the data in this log file can be done as follows:</li>
+      <li>Web page from which access was made (if transmitted by the requesting web browser)</li>
     </ul>
     <br />
     <p>The processing of the data in this log file takes place as follows:</p>
     <br />
     <ul class="list-disc pl-5">
-      <li>The log entries are continuously updated automatically evaluated in order to be able to detect attacks on the web server and react accordingly.</li>
+      <li>The log entries are continuously and automatically evaluated in order to detect attacks, errors and misuse and to react accordingly.</li>
       <li>In individual cases, i.e. in the case of reported disruptions, errors and security incidents, a manual analysis is carried out.</li>
-      <li>The IP addresses contained in the log entries are not merged with other databases by AET, so that no conclusions can be drawn about individual persons.</li>
+      <li>The data is not used to create personal user profiles.</li>
     </ul>
+    <br />
+    <p>
+      Helios also stores workflow run logs temporarily for troubleshooting and status analysis. These technical workflow log caches are deleted according to the configured retention
+      policy; the current default retention period is one day.
+    </p>
+    <br />
+    <p>
+      Unless statutory retention obligations require otherwise, personal data is stored only for as long as necessary to operate Helios and fulfill the respective processing purpose.
+      Technical logs and caches are deleted or overwritten as part of the configured operational retention rules.
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Technical operation, cookies and recipients</h2>
+    <br />
+    <p>
+      The technical operation of Helios is carried out within the environment of the Technical University of Munich and the Research Group for Applied Education Technologies.
+      The Helios web servers are operated by AET itself at Boltzmannstraße 3, 85748 Garching b. München. In the course of operation, personal data may be processed by the
+      technical systems and services required to provide Helios securely and reliably.
+    </p>
+    <br />
+    <p>
+      Helios uses technically necessary browser-side storage and comparable session mechanisms to provide the application. This includes, for example, storing UI state in the browser.
+      If you disable such storage mechanisms, parts of the application may no longer work correctly.
+    </p>
+    <br />
+    <p>
+      Recipients or technically involved services may include the authentication infrastructure, GitHub services used by Helios, the mail delivery infrastructure for notifications and
+      the Sentry error-monitoring service hosted at <a href="https://sentry.ase.in.tum.de" class="text-primary" target="_blank" rel="noopener noreferrer">sentry.ase.in.tum.de</a>.
+    </p>
     <br />
 
     <h2 class="text-xl font-semibold mt-4">Use and transfer of personal data</h2>
     <br />
     <p>
-      Our website can be used without providing personal data. All services that might require any form of personal data (e.g. registration for events, contact forms) are offered
-      on external sites, linked here. The use of contact data published as part of the imprint obligation by third parties to send unsolicited advertising and information material
-      is hereby prohibited. The operators of the pages reserve the right to take legal action in the event of the unsolicited sending of advertising information, such as spam
-      mails.
+      Helios can be viewed publicly only to a limited extent. When you sign in, Helios authenticates you via Keycloak and processes identifiers contained in the authentication
+      token, in particular your user ID, GitHub ID and GitHub username. To provide Helios features, the application stores GitHub profile data associated with your account, such as
+      your login, display name, avatar URL, profile URL and, if available from GitHub, profile fields such as company, blog, location and email address.
+    </p>
+    <br />
+    <p>
+      If you use the settings page, Helios also stores the notification email address entered by you and your notification preferences. In addition, the frontend stores technical
+      UI settings in your browser that are required for a consistent user experience, for example the expanded or collapsed state of the sidebar.
+    </p>
+    <br />
+    <p>
+      Personal data is processed only to provide, operate, secure and improve Helios. Data is not sold and is not used for advertising. Data may be transferred to the technical
+      services required to operate Helios only to the extent necessary for the respective function.
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">Revocation of your consent to data processing</h2>
+    <h2 class="text-xl font-semibold mt-4">Voluntary information and consent</h2>
     <br />
     <p>
-      Some data processing operations require your express consent possible. You can revoke your consent that you have already given at any time. A message bye-mail is sufficient
-      for the revocation. The lawfulness of the data processing that took place up until the revocation remains unaffected by the revocation.
+      Some information is provided by you voluntarily, in particular a notification email address that you enter yourself or information that you send to us by email. You can change
+      or remove such information within Helios where the application provides this functionality. Where processing is based on consent, you may revoke that consent at any time with
+      effect for the future. The lawfulness of the processing carried out before the revocation remains unaffected.
     </p>
     <br />
 
@@ -92,17 +145,18 @@
     <br />
     <p>
       You have at any time within the framework of the applicable legal provisions the right to request information about your stored personal data, the origin of the data, its
-      recipient and the purpose of the data processing, and if necessary, a right to correction, blocking or deletion of this data. You can contact us at any time via
-      <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a> regarding this and other questions on the subject of personal data.
+      recipient and the purpose of the data processing, and if necessary, a right to correction, blocking or deletion of this data. You can contact the Helios project team at any
+      time via <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a> or the official TUM data protection officer via
+      <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a> regarding this and other questions on the subject of personal
+      data.
     </p>
     <br />
 
     <h2 class="text-xl font-semibold mt-4">SSL/TLS encryption</h2>
     <br />
     <p>
-      For security reasons and to protect the transmission of confidential content that you send to us send as a site operator, our website uses an SSL/TLS encryption. This means
-      that data that you transmit via this website cannot be read by third parties. You can recognize an encrypted connection by the"https://" address line in your browser and by
-      the lock symbol in the browser line.
+      For security reasons and to protect the transmission of confidential content, Helios uses SSL/TLS encryption. This means that data transmitted via this website cannot be read by
+      third parties during transport. You can recognize an encrypted connection by the "https://" address in your browser and by the lock symbol in the browser interface.
     </p>
     <br />
 
@@ -117,10 +171,24 @@
     <h2 class="text-xl font-semibold mt-4">Name and contact details of the person responsible</h2>
     <br />
     <p>
+      Controller:<br />
       Technical University of Munich<br />
-      Postal address: Prof. Dr. Stephan Krusche (CIT–I1) Boltzmannstraße 3 85748 Garching b. München<br />
-      Office: <a href="https://nav.tum.de/room/5607.01.044" class="text-primary" target="_blank">01.07.044</a><br />
-      E-mail: <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a><br />
+      Arcisstraße 21<br />
+      80333 Munich<br />
+      Email: <a href="mailto:poststelle@tum.de" class="text-primary">poststelle&#64;tum.de</a><br />
+      <br />
+      Operational contact for Helios:<br />
+      Prof. Dr. Stephan Krusche (CIT–I1)<br />
+      Boltzmannstraße 3<br />
+      85748 Garching b. München<br />
+      Office: <a href="https://nav.tum.de/room/5607.01.044" class="text-primary" target="_blank" rel="noopener noreferrer">01.07.044</a><br />
+      Email: <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a><br />
+      <br />
+      Official data protection officer of the Technical University of Munich:<br />
+      Dr. Fabian Franzen<br />
+      Datenschutzbüro, Boltzmannstraße 3, 85748 Garching<br />
+      Email: <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a><br />
+      Website: <a href="https://www.datenschutz.tum.de/en/datenschutz/der-datenschutzbeauftragte/" class="text-primary" target="_blank" rel="noopener noreferrer">www.datenschutz.tum.de</a><br />
     </p>
     <br />
   </div>

--- a/client/src/app/pages/privacy/privacy.component.html
+++ b/client/src/app/pages/privacy/privacy.component.html
@@ -2,30 +2,85 @@
   <div heading>Privacy Policy</div>
   <div description>
     <br />
+    Last updated: 2026-04-27
+    <br /><br />
     The Technical University of Munich and the Research Group for Applied Education Technologies (AET) take the protection of personal data seriously. Helios processes personal
     data both when you visit this website and when you use Helios after signing in. Processing is carried out in compliance with applicable data protection regulations, in
     particular:
     <ul class="list-disc pl-5">
       <li>The General Data Protection Regulation (GDPR)</li>
       <li>The Bavarian Data Protection Act (BayDSG), which applies to public institutions in Bavaria</li>
+      <li>The Bavarian Higher Education Innovation Act (BayHIG), which defines the tasks of Bavarian universities</li>
       <li>The Telecommunications Digital Services Data Protection Act (TDDDG), where applicable to technically necessary browser-side storage and comparable technologies</li>
     </ul>
-    Below, we inform you about the most important categories of personal data processed in Helios, the purpose of the processing and the relevant contact points.
+    Below, we inform you about the categories of personal data processed in Helios, the purposes and legal bases of the processing, the recipients of the data, the retention
+    periods and the relevant contact points.
   </div>
 </app-page-heading>
 
 <div>
   <div>
-    <h2 class="text-xl font-semibold mt-4">Purpose and legal basis for processing</h2>
+    <h2 class="text-xl font-semibold mt-4">What Helios is and who can see what</h2>
     <br />
     <p>
-      Helios is operated to provide technical support for software-engineering and development workflows in the university context. Personal data is processed only to provide the
-      service, authenticate users, operate the system securely, troubleshoot incidents and enable optional notification features.
+      Helios is operated by AET to manage the development, deployment, and release of AET&apos;s own open-source software (e.g. Artemis, Athena, Hephaestus). Helios is not used in
+      any course.
     </p>
     <br />
     <p>
-      Unless otherwise stated, processing is carried out on the basis of the applicable public-law tasks of the Technical University of Munich and the corresponding legal obligations
-      and responsibilities under Art. 6(1)(c) and, where applicable, Art. 6(1)(e) GDPR in conjunction with the applicable university and Bavarian data protection provisions.
+      The dashboards Helios builds &mdash; including the GitHub usernames and avatars of the developers behind the activity shown &mdash; are visible to anyone on the open web
+      without signing in. Signing in is required only to perform write actions (e.g. triggering a deployment, reserving a test environment), and such actions additionally require
+      write permission on the affected GitHub repository.
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Purposes and legal bases for processing</h2>
+    <br />
+    <p>The following legal bases apply to the corresponding processing operations in Helios:</p>
+    <br />
+    <h3 class="text-base font-semibold mt-3">Core service (authentication, GitHub synchronisation, dashboards) for TUM members</h3>
+    <p>
+      Art. 6(1)(e) GDPR i.V.m. Art. 2 BayHIG (tasks of Bavarian universities &mdash; research, teaching, transfer; AET is a research chair operating chair-level development and
+      release infrastructure for the chair&apos;s own software, which falls under research and transfer) i.V.m. Art. 4 BayDSG (a Bavarian public body may process personal data when
+      this is necessary to carry out its tasks).
+    </p>
+    <br />
+    <h3 class="text-base font-semibold mt-3">Core service for non-TUM contributors</h3>
+    <p>
+      Art. 6(1)(b) GDPR. External open-source contributors who sign in to Helios with their GitHub account do so on their own request in order to use the service; the processing
+      necessary to provide the service to them is based on this request.
+    </p>
+    <br />
+    <h3 class="text-base font-semibold mt-3">Optional notification email and notification preferences</h3>
+    <p>
+      Art. 6(1)(a) GDPR (consent). Providing a notification email address and choosing notification preferences in the Helios settings page is an opt-in by affirmative action.
+      Consent can be withdrawn at any time with effect for the future, without affecting the lawfulness of processing carried out before the withdrawal (Art. 7(3) GDPR).
+    </p>
+    <br />
+    <h3 class="text-base font-semibold mt-3">Server access logs and self-hosted Sentry error telemetry</h3>
+    <p>
+      Art. 6(1)(f) GDPR (legitimate interests). AET has a legitimate interest in operating Helios securely and reliably, in detecting and diagnosing errors, and in defending
+      against attacks. The balancing of interests is in favour of processing because the data is technical rather than behavioural, is not used for profiling, is retained only
+      briefly (see retention table below) and stays inside TUM-operated infrastructure.
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Categories of personal data processed</h2>
+    <br />
+    <p>When you sign in, Helios authenticates you via a self-hosted Keycloak federated to GitHub OAuth and stores the following data associated with your account:</p>
+    <br />
+    <ul class="list-disc pl-5">
+      <li>GitHub login, display name, avatar URL and profile URL</li>
+      <li>Email address provided by GitHub</li>
+      <li>Optional GitHub profile fields: bio, company, blog, free-text location (from the GitHub profile, not GPS), follower and following counts</li>
+      <li>Optional notification email address you enter in the Helios settings page</li>
+      <li>Notification preferences (currently for the events DEPLOYMENT_FAILED, LOCK_EXPIRED and LOCK_UNLOCKED)</li>
+      <li>Technical UI state stored in your browser (e.g. expanded or collapsed state of the sidebar)</li>
+    </ul>
+    <br />
+    <p>
+      For developers who have not signed in to Helios but whose activity in AET-maintained GitHub repositories is mirrored in Helios&apos;s dashboards, the personal data shown
+      originates from the developer&apos;s own public GitHub account, accessed via the GitHub API (Art. 14 GDPR).
     </p>
     <br />
 
@@ -53,72 +108,131 @@
       <li>The data is not used to create personal user profiles.</li>
     </ul>
     <br />
-    <p>
-      Helios also stores workflow run logs temporarily for troubleshooting and status analysis. These technical workflow log caches are deleted according to the configured retention
-      policy; the current default retention period is one day.
-    </p>
+
+    <h2 class="text-xl font-semibold mt-4">Recipients</h2>
+    <br />
+    <p>The following recipients receive personal data in the course of operating Helios:</p>
+    <br />
+    <ul class="list-disc pl-5">
+      <li>
+        <strong>Anyone on the open web</strong> &mdash; the dashboards Helios builds (workflow runs, deployments, environments, environment-lock history, branches, commits, pull
+        requests, releases, issues, test results) include the GitHub-derived developer attribution attached to each item and are served without authentication via every GET
+        endpoint under <code>/api/**</code>.
+      </li>
+      <li>
+        <strong>GitHub, Inc.</strong> &mdash; Helios reads repository activity from GitHub via the GitHub API and also sends deployment-trigger actions back to GitHub Actions on
+        behalf of a signed-in user when that user triggers a deployment.
+      </li>
+      <li><strong>Self-hosted Keycloak</strong> operated within TUM &mdash; authentication.</li>
+      <li>
+        <strong>Self-hosted Sentry</strong> at <a href="https://sentry.ase.in.tum.de" class="text-primary" target="_blank" rel="noopener noreferrer">sentry.ase.in.tum.de</a>,
+        operated within TUM &mdash; error telemetry. No external Sentry SaaS is used.
+      </li>
+      <li><strong>TUM SMTP / AET mail relay</strong> operated within TUM &mdash; delivery of notification emails.</li>
+    </ul>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Transfer to a third country</h2>
     <br />
     <p>
-      Unless statutory retention obligations require otherwise, personal data is stored only for as long as necessary to operate Helios and fulfill the respective processing purpose.
-      Technical logs and caches are deleted or overwritten as part of the configured operational retention rules.
+      GitHub, Inc. is based in the USA. The transfer of personal data to GitHub is covered by GitHub&apos;s own certification under the EU&ndash;U.S. Data Privacy Framework (Art.
+      45 GDPR) and by Standard Contractual Clauses (Art. 46(2)(c) GDPR; Commission Implementing Decision 2021/914), as set out in the GitHub Data Protection Agreement, which
+      applies to every github.com user. No personal data is transferred to any other recipient outside the European Economic Area.
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">Technical operation, cookies and recipients</h2>
+    <h2 class="text-xl font-semibold mt-4">Retention periods</h2>
+    <br />
+    <ul class="list-disc pl-5">
+      <li><strong>Account and profile data:</strong> for as long as the account exists; deleted on request (see &ldquo;Your rights&rdquo; below).</li>
+      <li>
+        <strong>Workflow run records (database):</strong> a nightly cleanup task at 01:00 keeps the two newest <code>PROCESSED</code> runs per repository and branch and deletes
+        runs in state <code>FAILED</code> or with no terminal state that are older than five days.
+      </li>
+      <li><strong>Workflow run logs (filesystem):</strong> a nightly cleanup task at 02:00 deletes log files older than one day.</li>
+      <li><strong>Self-hosted Sentry error telemetry:</strong> retained for at most 30 days.</li>
+      <li><strong>Database backups:</strong> daily backups with a retention of 7 days.</li>
+      <li><strong>Server access logs:</strong> standard log rotation.</li>
+    </ul>
     <br />
     <p>
-      The technical operation of Helios is carried out within the environment of the Technical University of Munich and the Research Group for Applied Education Technologies.
-      The Helios web servers are operated by AET itself at Boltzmannstraße 3, 85748 Garching b. München. In the course of operation, personal data may be processed by the
-      technical systems and services required to provide Helios securely and reliably.
-    </p>
-    <br />
-    <p>
-      Helios uses technically necessary browser-side storage and comparable session mechanisms to provide the application. This includes, for example, storing UI state in the browser.
-      If you disable such storage mechanisms, parts of the application may no longer work correctly.
-    </p>
-    <br />
-    <p>
-      Recipients or technically involved services may include the authentication infrastructure, GitHub services used by Helios, the mail delivery infrastructure for notifications and
-      the Sentry error-monitoring service hosted at <a href="https://sentry.ase.in.tum.de" class="text-primary" target="_blank" rel="noopener noreferrer">sentry.ase.in.tum.de</a>.
-    </p>
-    <br />
-
-    <h2 class="text-xl font-semibold mt-4">Use and transfer of personal data</h2>
-    <br />
-    <p>
-      Helios can be viewed publicly only to a limited extent. When you sign in, Helios authenticates you via Keycloak and processes identifiers contained in the authentication
-      token, in particular your user ID, GitHub ID and GitHub username. To provide Helios features, the application stores GitHub profile data associated with your account, such as
-      your login, display name, avatar URL, profile URL and, if available from GitHub, profile fields such as company, blog, location and email address.
-    </p>
-    <br />
-    <p>
-      If you use the settings page, Helios also stores the notification email address entered by you and your notification preferences. In addition, the frontend stores technical
-      UI settings in your browser that are required for a consistent user experience, for example the expanded or collapsed state of the sidebar.
-    </p>
-    <br />
-    <p>
-      Personal data is processed only to provide, operate, secure and improve Helios. Data is not sold and is not used for advertising. Data may be transferred to the technical
-      services required to operate Helios only to the extent necessary for the respective function.
+      Unless statutory retention obligations require otherwise, personal data is stored only for as long as necessary to operate Helios and fulfil the respective processing
+      purpose.
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">Voluntary information and consent</h2>
+    <h2 class="text-xl font-semibold mt-4">Technical operation and cookies</h2>
     <br />
     <p>
-      Some information is provided by you voluntarily, in particular a notification email address that you enter yourself or information that you send to us by email. You can change
-      or remove such information within Helios where the application provides this functionality. Where processing is based on consent, you may revoke that consent at any time with
-      effect for the future. The lawfulness of the processing carried out before the revocation remains unaffected.
+      The technical operation of Helios is carried out within the environment of the Technical University of Munich and the Research Group for Applied Education Technologies. The
+      Helios web servers are operated by AET itself at Boltzmannstraße 3, 85748 Garching b. München.
+    </p>
+    <br />
+    <p>
+      Helios uses technically necessary browser-side storage and comparable session mechanisms to provide the application. This includes, for example, storing UI state in the
+      browser. If you disable such storage mechanisms, parts of the application may no longer work correctly.
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">Right to file a complaint with the responsible supervisory authority</h2>
+    <h2 class="text-xl font-semibold mt-4">No automated decision-making</h2>
+    <br />
+    <p>Helios does not perform automated decision-making, including profiling, within the meaning of Art. 22 GDPR.</p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Notification email (consent)</h2>
+    <br />
+    <p>
+      You may optionally enter a notification email address and choose notification preferences on the Helios settings page. This processing is based on your consent (Art. 6(1)(a)
+      GDPR). You can change or remove the notification email address and your notification preferences at any time on the same settings page. Withdrawing consent does not affect
+      the lawfulness of processing carried out before the withdrawal (Art. 7(3) GDPR).
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Correspondence by email</h2>
+    <br />
+    <p>
+      If you contact us by email, your email address and the content of your message are processed solely for the purpose of handling your enquiry. Please note that data
+      transmission over the internet can have security gaps; complete protection of data from access by third parties is not possible.
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Your rights</h2>
+    <br />
+    <p>You have the following rights with respect to the personal data Helios processes about you:</p>
+    <br />
+    <ul class="list-disc pl-5">
+      <li>Right of access (Art. 15 GDPR)</li>
+      <li>Right to rectification (Art. 16 GDPR)</li>
+      <li>Right to erasure (Art. 17 GDPR)</li>
+      <li>Right to restriction of processing (Art. 18 GDPR)</li>
+      <li>Right to data portability (Art. 20 GDPR)</li>
+      <li>
+        Right to object (Art. 21 GDPR) &mdash; in particular against processing based on legitimate interests (Art. 6(1)(f) GDPR), namely server access logs and self-hosted Sentry
+        error telemetry
+      </li>
+      <li>
+        Right to withdraw consent (Art. 7(3) GDPR) &mdash; in particular with respect to the optional notification email address and notification preferences; withdrawal does not
+        affect the lawfulness of processing carried out before the withdrawal
+      </li>
+      <li>Right to lodge a complaint with a supervisory authority (Art. 77 GDPR; see below)</li>
+    </ul>
+    <br />
+    <p>
+      To exercise these rights, you can contact the AET Administrators at
+      <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a>
+      or the official TUM data protection officer at
+      <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a>.
+    </p>
+    <br />
+
+    <h2 class="text-xl font-semibold mt-4">Right to lodge a complaint with the supervisory authority</h2>
     <br />
     <p>
       If you believe that the processing of your personal data violates applicable data protection laws, you have the right to lodge a complaint with a supervisory authority.
       <br /><br />
-      Since this project is developed at the <strong>Technical University of Munich (TUM)</strong>, a public institution in Bavaria, the applicable law is the
+      Since Helios is operated at the <strong>Technical University of Munich (TUM)</strong>, a public institution in Bavaria, the applicable law is the
       <strong>Bavarian Data Protection Act (BayDSG)</strong>, which supplements the <strong>General Data Protection Regulation (GDPR)</strong>. The responsible supervisory
-      authority for enforcing these regulations is: <br /><br />
+      authority is: <br /><br />
       <strong>Bavarian State Commissioner for Data Protection (BayLfD)</strong><br />
       Wagmüllerstraße 18<br />
       80538 Munich<br />
@@ -132,43 +246,16 @@
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">Right to data portability</h2>
-    <br />
-    <p>
-      You have the right to request the data that we process automatically on the basis of your consent or in fulfillment of a contract to be handed over to you or a third party.
-      The data is provided in a machine-readable format. If you request the direct transfer of the data to another person responsible, this will only be done if it is technically
-      feasible.
-    </p>
-    <br />
-
-    <h2 class="text-xl font-semibold mt-4">Right to information, correction, blocking, and deletion</h2>
-    <br />
-    <p>
-      You have at any time within the framework of the applicable legal provisions the right to request information about your stored personal data, the origin of the data, its
-      recipient and the purpose of the data processing, and if necessary, a right to correction, blocking or deletion of this data. You can contact the Helios project team at any
-      time via <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a> or the official TUM data protection officer via
-      <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a> regarding this and other questions on the subject of personal
-      data.
-    </p>
-    <br />
-
     <h2 class="text-xl font-semibold mt-4">SSL/TLS encryption</h2>
     <br />
     <p>
-      For security reasons and to protect the transmission of confidential content, Helios uses SSL/TLS encryption. This means that data transmitted via this website cannot be read by
-      third parties during transport. You can recognize an encrypted connection by the "https://" address in your browser and by the lock symbol in the browser interface.
+      For security reasons and to protect the transmission of confidential content, Helios uses SSL/TLS encryption. This means that data transmitted via this website cannot be read
+      by third parties during transport. You can recognise an encrypted connection by the &ldquo;https://&rdquo; address in your browser and by the lock symbol in the browser
+      interface.
     </p>
     <br />
 
-    <h2 class="text-xl font-semibold mt-4">E-mail security</h2>
-    <br />
-    <p>
-      If you e-mail us, your e-mail address will only be used for correspondence with you. Please note that data transmission on the Internet can have security gaps. Complete
-      protection of data from access by third parties is not possible.
-    </p>
-    <br />
-
-    <h2 class="text-xl font-semibold mt-4">Name and contact details of the person responsible</h2>
+    <h2 class="text-xl font-semibold mt-4">Name and contact details of the controller</h2>
     <br />
     <p>
       Controller:<br />
@@ -178,17 +265,20 @@
       Email: <a href="mailto:poststelle@tum.de" class="text-primary">poststelle&#64;tum.de</a><br />
       <br />
       Operational contact for Helios:<br />
-      Prof. Dr. Stephan Krusche (CIT–I1)<br />
+      AET Administrators<br />
+      Research Group for Applied Education Technologies, headed by Prof. Dr. Stephan Krusche (CIT&ndash;I1)<br />
       Boltzmannstraße 3<br />
       85748 Garching b. München<br />
       Office: <a href="https://nav.tum.de/room/5607.01.044" class="text-primary" target="_blank" rel="noopener noreferrer">01.07.044</a><br />
-      Email: <a href="mailto:krusche@tum.de" class="text-primary">krusche&#64;tum.de</a><br />
+      Email: <a href="mailto:ls1.admin@in.tum.de" class="text-primary">ls1.admin&#64;in.tum.de</a><br />
       <br />
       Official data protection officer of the Technical University of Munich:<br />
       Dr. Fabian Franzen<br />
       Datenschutzbüro, Boltzmannstraße 3, 85748 Garching<br />
       Email: <a href="mailto:beauftragter@datenschutz.tum.de" class="text-primary">beauftragter&#64;datenschutz.tum.de</a><br />
-      Website: <a href="https://www.datenschutz.tum.de/en/datenschutz/der-datenschutzbeauftragte/" class="text-primary" target="_blank" rel="noopener noreferrer">www.datenschutz.tum.de</a><br />
+      Website:
+      <a href="https://www.datenschutz.tum.de/en/datenschutz/der-datenschutzbeauftragte/" class="text-primary" target="_blank" rel="noopener noreferrer">www.datenschutz.tum.de</a
+      ><br />
     </p>
     <br />
   </div>


### PR DESCRIPTION
### Motivation

  The privacy page still used generic boilerplate that did not match how Helios actually processes personal data. In particular, it did not clearly reflect Helios-specific authentication, GitHub profile data usage, notification settings, technical recipients, or updated legal references.

  ### Description

  - update the privacy page content to better reflect Helios-specific processing activities
  - add short sections for:
      - purpose and legal basis for processing
      - technical operation, cookies/browser-side storage, and recipients
      - retention wording for technical logs and workflow log caches
  - clarify the controller, operational contact, and TUM data protection officer details
  - replace outdated or misleading wording, including the TTDSG reference with TDDDG
  - restore the AET server operator address in the technical operation section
  - strengthen the privacy page test to assert the new Helios-specific content and structure

  ### Testing Instructions

  #### Prerequisites:

  - Helios client dependencies installed
  - No special permissions required

  #### Flow:

  1. Open client/src/app/pages/privacy/privacy.component.html and verify the privacy text now explicitly mentions:
      - Keycloak authentication
      - GitHub profile data
      - notification email/preferences
      - Sentry
      - browser-side storage / cookies
      - TDDDG
  2. Verify the page now includes the additional legal-structure sections:
      - Purpose and legal basis for processing
      - Technical operation, cookies and recipients

  ### Checklist

  #### General

  - [x] PR description explains the purpose and changes. (f.e. following the 'Conventional Commits') (https://www.conventionalcommits.org/en/v1.0.0/)
  - [x] Changes have been tested locally.

  #### Client

  - [x] I translated all newly inserted strings into English and German.