### PR TITLE
feat: enhance deployment stepper to display queued state

### DIFF
--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
@@ -63,8 +63,11 @@
               @case ('upcoming') {}
             }
           </p-tag>
-          <div class="text-sm font-medium whitespace-nowrap text-surface-500">
+          <div class="text-sm font-medium whitespace-nowrap text-surface-500 flex items-center gap-2">
             {{ getStepDisplayName(step) }}
+            @if (step === 'PENDING' && deployment()?.state === 'QUEUED') {
+              <p-tag value="Queued" severity="info" rounded styleClass="text-xs py-0 px-2" />
+            }
           </div>
         </div>
 

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.html
@@ -10,6 +10,8 @@
           Deployment Failed
         } @else if (deployment() && isUnknownState()) {
           Deployment Status Unknown
+        } @else if (deployment() && isQueuedState()) {
+          Deployment Queued
         } @else {
           Deployment in Progress
         }
@@ -43,6 +45,12 @@
     </div>
   </div>
 
+  @if (deployment() && isQueuedState()) {
+    <p-message severity="warn" class="mb-6 block text-left">
+      Waiting for GitHub Actions to start this workflow. Deployment will continue automatically once a runner is available.
+    </p-message>
+  }
+
   <!-- Vertically Aligned Steps -->
   <div class="flex flex-col gap-6 mt-6">
     @for (step of steps; track step; let i = $index) {
@@ -65,9 +73,6 @@
           </p-tag>
           <div class="text-sm font-medium whitespace-nowrap text-surface-500 flex items-center gap-2">
             {{ getStepDisplayName(step) }}
-            @if (step === 'PENDING' && deployment()?.state === 'QUEUED') {
-              <p-tag value="Queued" severity="info" rounded styleClass="text-xs py-0 px-2" />
-            }
           </div>
         </div>
 

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.spec.ts
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.spec.ts
@@ -1,0 +1,40 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { EnvironmentDeployment } from '@app/core/modules/openapi';
+import { DeploymentStepperComponent } from './deployment-stepper.component';
+
+describe('DeploymentStepperComponent', () => {
+  let fixture: ComponentFixture<DeploymentStepperComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeploymentStepperComponent],
+      providers: [provideZonelessChangeDetection(), provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeploymentStepperComponent);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('shows queued as a label in the existing pre-deployment step', async () => {
+    const deployment: EnvironmentDeployment = {
+      id: 1,
+      state: 'QUEUED',
+      createdAt: new Date().toISOString(),
+      type: 'HELIOS',
+    };
+
+    fixture.componentRef.setInput('deployment', deployment);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('PRE-DEPLOYMENT');
+    expect(text).toContain('Queued');
+    expect(text).toContain('DEPLOYMENT');
+  });
+});

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.spec.ts
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.spec.ts
@@ -20,7 +20,7 @@ describe('DeploymentStepperComponent', () => {
     TestBed.resetTestingModule();
   });
 
-  it('shows queued as a label in the existing pre-deployment step', async () => {
+  it('shows queued as an exposed waiting state in the existing pre-deployment step', async () => {
     const deployment: EnvironmentDeployment = {
       id: 1,
       state: 'QUEUED',
@@ -33,8 +33,27 @@ describe('DeploymentStepperComponent', () => {
     await fixture.whenStable();
 
     const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Deployment Queued');
+    expect(text).toContain('Waiting for GitHub Actions to start this workflow. Deployment will continue automatically once a runner is available.');
     expect(text).toContain('PRE-DEPLOYMENT');
-    expect(text).toContain('Queued');
     expect(text).toContain('DEPLOYMENT');
+  });
+
+  it('keeps non-queued active deployments labeled as in progress', async () => {
+    const deployment: EnvironmentDeployment = {
+      id: 1,
+      state: 'IN_PROGRESS',
+      createdAt: new Date().toISOString(),
+      type: 'HELIOS',
+    };
+
+    fixture.componentRef.setInput('deployment', deployment);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain('Deployment in Progress');
+    expect(text).not.toContain('Deployment Queued');
+    expect(text).not.toContain('Waiting for GitHub Actions to start this workflow.');
   });
 });

--- a/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.ts
+++ b/client/src/app/components/environments/deployment-stepper/deployment-stepper.component.ts
@@ -5,6 +5,7 @@ import { EnvironmentDeployment } from '@app/core/modules/openapi';
 import { TooltipModule } from 'primeng/tooltip';
 import { DeploymentTimingService } from '@app/core/services/deployment-timing.service';
 import { TagModule } from 'primeng/tag';
+import { MessageModule } from 'primeng/message';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconCheck, IconClock, IconProgress, IconX } from 'angular-tabler-icons/icons';
 
@@ -16,7 +17,7 @@ interface EstimatedTimes {
 
 @Component({
   selector: 'app-deployment-stepper',
-  imports: [CommonModule, TablerIconComponent, TagModule, ProgressBarModule, TooltipModule],
+  imports: [CommonModule, TablerIconComponent, TagModule, MessageModule, ProgressBarModule, TooltipModule],
   providers: [
     provideTablerIcons({
       IconClock,
@@ -78,6 +79,10 @@ export class DeploymentStepperComponent implements OnInit {
     const deployment = this._deployment();
     if (!deployment) return false;
     return this.timingService.isSuccessState(deployment);
+  }
+
+  isQueuedState(): boolean {
+    return this._deployment()?.state === 'QUEUED';
   }
 
   // Methods that need to be called from the template with arguments

--- a/client/src/app/core/services/deployment-timing.service.spec.ts
+++ b/client/src/app/core/services/deployment-timing.service.spec.ts
@@ -1,0 +1,69 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { EnvironmentDeployment } from '@app/core/modules/openapi';
+import { DeploymentTimingService } from './deployment-timing.service';
+
+describe('DeploymentTimingService', () => {
+  let service: DeploymentTimingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
+    });
+    service = TestBed.inject(DeploymentTimingService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const deployment = (state: EnvironmentDeployment['state']): EnvironmentDeployment => ({
+    id: 1,
+    state,
+    createdAt: new Date().toISOString(),
+    type: 'HELIOS',
+  });
+
+  it('keeps the existing pre-deployment and deployment steps', () => {
+    expect(service.steps).toEqual(['PENDING', 'IN_PROGRESS']);
+    expect(service.getStepDisplayName('PENDING')).toBe('PRE-DEPLOYMENT');
+    expect(service.getStepDisplayName('IN_PROGRESS')).toBe('DEPLOYMENT');
+  });
+
+  it('activates the pre-deployment step for requested, pending, waiting, and queued states', () => {
+    for (const state of ['REQUESTED', 'PENDING', 'WAITING', 'QUEUED'] as const) {
+      expect(service.getCurrentEffectiveStepIndex(deployment(state))).toBe(0);
+      expect(service.getStepStatus(deployment(state), 0)).toBe('active');
+      expect(service.getStepStatus(deployment(state), 1)).toBe('upcoming');
+    }
+  });
+
+  it('does not start the pre-deployment timer while queued', () => {
+    service.updateDeploymentState(deployment('QUEUED'));
+    expect(service.getStepStartTime(1, 'PENDING')).toBeUndefined();
+    expect(service.getProgress(deployment('QUEUED'), 0)).toBe(0);
+
+    service.updateDeploymentState(deployment('PENDING'));
+    expect(service.getStepStartTime(1, 'PENDING')).toBeDefined();
+  });
+
+  it('activates deployment once the deployment is in progress', () => {
+    const startedDeployment = deployment('IN_PROGRESS');
+    expect(service.getCurrentEffectiveStepIndex(startedDeployment)).toBe(1);
+    expect(service.getStepStatus(startedDeployment, 0)).toBe('completed');
+    expect(service.getStepStatus(startedDeployment, 1)).toBe('active');
+  });
+
+  it('marks success as completed and failure on the last known active step', () => {
+    const startedDeployment = deployment('IN_PROGRESS');
+    service.updateDeploymentState(startedDeployment);
+
+    const failedDeployment = deployment('FAILURE');
+    service.updateDeploymentState(failedDeployment);
+
+    expect(service.getStepStatus(deployment('SUCCESS'), 0)).toBe('completed');
+    expect(service.getStepStatus(deployment('SUCCESS'), 1)).toBe('completed');
+    expect(service.getStepStatus(failedDeployment, 0)).toBe('completed');
+    expect(service.getStepStatus(failedDeployment, 1)).toBe('error');
+  });
+});

--- a/client/src/app/core/services/deployment-timing.service.ts
+++ b/client/src/app/core/services/deployment-timing.service.ts
@@ -11,9 +11,13 @@ interface DeploymentTimingData {
 
 interface EstimatedTimes {
   REQUESTED: number;
+  WAITING: number;
   PENDING: number;
+  QUEUED: number;
   IN_PROGRESS: number;
 }
+
+type DeploymentStep = 'PENDING' | 'IN_PROGRESS';
 
 @Injectable({
   providedIn: 'root',
@@ -25,7 +29,7 @@ export class DeploymentTimingService {
   private deploymentTimings = new Map<string, DeploymentTimingData>();
 
   // Define deployment steps
-  public readonly steps: ('PENDING' | 'IN_PROGRESS')[] = ['PENDING', 'IN_PROGRESS'];
+  public readonly steps: DeploymentStep[] = ['PENDING', 'IN_PROGRESS'];
 
   // Centralized current time that updates every second
   private _currentTime = signal<number>(Date.now());
@@ -94,21 +98,15 @@ export class DeploymentTimingService {
     if (newState !== timingData.lastKnownState) {
       const stepStartTime = this._currentTime();
       const previousState = timingData.lastKnownState;
+      const newStep = this.getStepForState(newState);
+      const previousStep = previousState ? this.getStepForState(previousState) : undefined;
 
-      // Special case: If transitioning from REQUESTED to PENDING, don't reset the timer
-      // since they're both part of the PRE-DEPLOYMENT step in the UI
-      if (previousState === 'REQUESTED' && newState === 'PENDING') {
-        // Keep the REQUESTED start time for PENDING
-        const requestedStartTime = timingData.stepStartTimes.get('REQUESTED');
-        if (requestedStartTime) {
-          timingData.stepStartTimes.set(newState, requestedStartTime);
-        } else {
-          // Fallback if there's no REQUESTED start time for some reason
-          timingData.stepStartTimes.set(newState, stepStartTime);
-        }
-      } else {
-        // Normal case: set new start time for the current state
-        timingData.stepStartTimes.set(newState, stepStartTime);
+      if (newStep && this.shouldStartStepTimer(newState)) {
+        const effectiveStartTime =
+          previousStep === newStep && previousStep
+            ? timingData.stepStartTimes.get(previousStep) || stepStartTime
+            : stepStartTime;
+        timingData.stepStartTimes.set(newStep, effectiveStartTime);
       }
 
       // If this is a terminal state, record the time
@@ -141,7 +139,9 @@ export class DeploymentTimingService {
 
     return {
       REQUESTED: pendingMin,
+      WAITING: pendingMin,
       PENDING: pendingMin,
+      QUEUED: pendingMin,
       IN_PROGRESS: inProgressMin,
     };
   }
@@ -179,14 +179,8 @@ export class DeploymentTimingService {
       return -1; // Special value to indicate no valid step found in error state
     }
 
-    const currentState = deployment.state;
-
-    // Special handling for REQUESTED state (map to PENDING in UI)
-    if (currentState === 'REQUESTED') {
-      return 0; // PENDING is now the first step in the UI
-    }
-
-    const index = this.steps.indexOf(currentState as 'PENDING' | 'IN_PROGRESS');
+    const currentStep = this.getStepForState(deployment.state);
+    const index = currentStep ? this.steps.indexOf(currentStep) : -1;
     return index !== -1 ? index : 0;
   }
 
@@ -194,7 +188,7 @@ export class DeploymentTimingService {
   public getRemainingTimeForCurrentStep(deployment: EnvironmentDeployment): number {
     if (!deployment?.state || !deployment.createdAt || !deployment.id) return 0;
 
-    const currentState = deployment.state;
+    const currentState = this.getStepForState(deployment.state) || deployment.state;
     const deploymentId = deployment.id;
 
     // Use the stored step start time or fall back to the current time
@@ -208,7 +202,7 @@ export class DeploymentTimingService {
   // Get step display name
   public getStepDisplayName(step: string): string {
     const stepMap = {
-      REQUESTED: 'PRE-DEPLOYMENT', // Map REQUESTED to PRE-DEPLOYMENT (though not shown in UI)
+      REQUESTED: 'PRE-DEPLOYMENT',
       PENDING: 'PRE-DEPLOYMENT',
       IN_PROGRESS: 'DEPLOYMENT',
     };
@@ -244,7 +238,7 @@ export class DeploymentTimingService {
     if (deployment.state === 'SUCCESS') return 100;
 
     const stepKey = this.steps[index] as keyof EstimatedTimes;
-    const currentState = deployment.state;
+    const currentState = this.getStepForState(deployment.state) || deployment.state;
     const effectiveStep = this.getCurrentEffectiveStepIndex(deployment);
     const deploymentId = deployment.id;
 
@@ -271,7 +265,7 @@ export class DeploymentTimingService {
     const elapsedMs = Math.max(0, currentTime - stepStartTime); // Ensure elapsed time is never negative
     const estimatedMs = this.getEstimatedTimes(deployment)[stepKey] * 60000;
 
-    const ratio = Math.min(elapsedMs / estimatedMs, 1);
+    const ratio = estimatedMs > 0 ? Math.min(elapsedMs / estimatedMs, 1) : 1;
     return Math.max(0, Math.floor(ratio * 100)); // Ensure we never return a negative percentage
   }
 
@@ -357,5 +351,23 @@ export class DeploymentTimingService {
         this.deploymentTimings.delete(deploymentId);
       }
     }
+  }
+
+  private getStepForState(state: string | undefined): DeploymentStep | undefined {
+    switch (state) {
+      case 'REQUESTED':
+      case 'WAITING':
+      case 'PENDING':
+      case 'QUEUED':
+        return 'PENDING';
+      case 'IN_PROGRESS':
+        return 'IN_PROGRESS';
+      default:
+        return undefined;
+    }
+  }
+
+  private shouldStartStepTimer(state: string | undefined): boolean {
+    return state === 'PENDING' || state === 'IN_PROGRESS';
   }
 }

--- a/client/src/app/core/services/deployment-timing.service.ts
+++ b/client/src/app/core/services/deployment-timing.service.ts
@@ -102,10 +102,7 @@ export class DeploymentTimingService {
       const previousStep = previousState ? this.getStepForState(previousState) : undefined;
 
       if (newStep && this.shouldStartStepTimer(newState)) {
-        const effectiveStartTime =
-          previousStep === newStep && previousStep
-            ? timingData.stepStartTimes.get(previousStep) || stepStartTime
-            : stepStartTime;
+        const effectiveStartTime = previousStep === newStep && previousStep ? timingData.stepStartTimes.get(previousStep) || stepStartTime : stepStartTime;
         timingData.stepStartTimes.set(newStep, effectiveStartTime);
       }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -152,7 +152,8 @@ public class LatestDeploymentUnion {
     public static State fromHeliosStatus(HeliosDeployment.Status status) {
       return switch (status) {
         case WAITING -> REQUESTED;
-        case QUEUED, IN_PROGRESS -> PENDING;
+        case QUEUED -> QUEUED;
+        case IN_PROGRESS -> PENDING;
         case DEPLOYMENT_SUCCESS -> SUCCESS;
         case FAILED -> FAILURE;
         case CANCELLED -> CANCELLED;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
@@ -1,0 +1,39 @@
+package de.tum.cit.aet.helios.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import org.junit.jupiter.api.Test;
+
+class LatestDeploymentUnionTest {
+
+  @Test
+  void fromHeliosStatusPreservesQueuedState() {
+    assertEquals(
+        LatestDeploymentUnion.State.REQUESTED,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.WAITING));
+    assertEquals(
+        LatestDeploymentUnion.State.QUEUED,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.QUEUED));
+    assertEquals(
+        LatestDeploymentUnion.State.PENDING,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.IN_PROGRESS));
+  }
+
+  @Test
+  void fromHeliosStatusKeepsTerminalStatesUnchanged() {
+    assertEquals(
+        LatestDeploymentUnion.State.SUCCESS,
+        LatestDeploymentUnion.State.fromHeliosStatus(
+            HeliosDeployment.Status.DEPLOYMENT_SUCCESS));
+    assertEquals(
+        LatestDeploymentUnion.State.FAILURE,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.FAILED));
+    assertEquals(
+        LatestDeploymentUnion.State.CANCELLED,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.CANCELLED));
+    assertEquals(
+        LatestDeploymentUnion.State.UNKNOWN,
+        LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.UNKNOWN));
+  }
+}


### PR DESCRIPTION
### Motivation

Queued deployments previously looked like generic in-progress deployments and the queued state was only shown as a small inline chip next to the pre-deployment step. This made it easy to miss that Helios was still waiting for GitHub Actions to start the workflow or assign a runner.

### Description

- Shows `Deployment Queued` as the main deployment stepper heading when the latest deployment state is `QUEUED`.
- Adds a warning message explaining that Helios is waiting for GitHub Actions to start the workflow and that deployment will continue automatically once a runner is available.
- Adds component tests for the queued state and the non-queued active deployment fallback.

### Testing Instructions

#### Prerequisites:
- Local Helios dev stack running with Postgres and client available.

#### Flow:
1. Open environment list
2. Create a deployment which will be queued
3. Verify the deployment tab shows `Deployment Queued`.
4. Verify the warning message explains that GitHub Actions has not started the workflow yet.

### Screenshots

<img width="1351" height="551" alt="Screenshot 2026-04-26 at 22 05 05" src="https://github.com/user-attachments/assets/9756a1eb-9f53-4460-aaae-b00501a3851b" />
### Checklist

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I added multiple screenshots/screencasts of my UI changes.
