### PR TITLE
feat: add deploy job and deployment start timestamps to environment d…

### DIFF
--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -198,6 +198,14 @@ export const EnvironmentDeploymentSchema = {
       type: 'string',
       format: 'date-time',
     },
+    deployJobStartedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
+    deploymentStartedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
     type: {
       type: 'string',
       enum: ['GITHUB', 'HELIOS'],

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -68,6 +68,8 @@ export type EnvironmentDeployment = {
   pullRequestNumber?: number;
   createdAt?: string;
   updatedAt?: string;
+  deployJobStartedAt?: string;
+  deploymentStartedAt?: string;
   type: 'GITHUB' | 'HELIOS';
   estimatedBuildDurationSeconds?: number;
   estimatedDeployDurationSeconds?: number;

--- a/client/src/app/core/services/deployment-timing.service.spec.ts
+++ b/client/src/app/core/services/deployment-timing.service.spec.ts
@@ -17,12 +17,19 @@ describe('DeploymentTimingService', () => {
     TestBed.resetTestingModule();
   });
 
-  const deployment = (state: EnvironmentDeployment['state']): EnvironmentDeployment => ({
+  const deployment = (overrides: Partial<EnvironmentDeployment> = {}): EnvironmentDeployment => ({
     id: 1,
-    state,
-    createdAt: new Date().toISOString(),
     type: 'HELIOS',
+    state: 'PENDING',
+    createdAt: '2026-04-23T10:00:00Z',
+    estimatedBuildDurationSeconds: 120,
+    estimatedDeployDurationSeconds: 300,
+    ...overrides,
   });
+
+  const setNow = (isoTime: string) => {
+    service['_currentTime'].set(new Date(isoTime).getTime());
+  };
 
   it('keeps the existing pre-deployment and deployment steps', () => {
     expect(service.steps).toEqual(['PENDING', 'IN_PROGRESS']);
@@ -32,38 +39,83 @@ describe('DeploymentTimingService', () => {
 
   it('activates the pre-deployment step for requested, pending, waiting, and queued states', () => {
     for (const state of ['REQUESTED', 'PENDING', 'WAITING', 'QUEUED'] as const) {
-      expect(service.getCurrentEffectiveStepIndex(deployment(state))).toBe(0);
-      expect(service.getStepStatus(deployment(state), 0)).toBe('active');
-      expect(service.getStepStatus(deployment(state), 1)).toBe('upcoming');
+      const currentDeployment = deployment({ state });
+
+      expect(service.getCurrentEffectiveStepIndex(currentDeployment)).toBe(0);
+      expect(service.getStepStatus(currentDeployment, 0)).toBe('active');
+      expect(service.getStepStatus(currentDeployment, 1)).toBe('upcoming');
     }
   });
 
-  it('does not start the pre-deployment timer while queued', () => {
-    service.updateDeploymentState(deployment('QUEUED'));
-    expect(service.getStepStartTime(1, 'PENDING')).toBeUndefined();
-    expect(service.getProgress(deployment('QUEUED'), 0)).toBe(0);
+  it('keeps the pre-deployment timer stopped until the deploy job has started', () => {
+    const currentDeployment = deployment({ state: 'PENDING' });
 
-    service.updateDeploymentState(deployment('PENDING'));
-    expect(service.getStepStartTime(1, 'PENDING')).toBeDefined();
+    service.updateDeploymentState(deployment({ state: 'QUEUED' }));
+    service.updateDeploymentState(currentDeployment);
+
+    expect(service.getStepStartTime(1, 'PENDING')).toBeUndefined();
+    expect(service.getCurrentEffectiveStepIndex(currentDeployment)).toBe(0);
+    expect(service.getProgress(currentDeployment, 0)).toBe(0);
+    expect(service.getStepTime(currentDeployment, 0)).toContain('estimated');
+    expect(service.getTotalRemainingTime(currentDeployment)).toBe('7m 0s');
   });
 
   it('activates deployment once the deployment is in progress', () => {
-    const startedDeployment = deployment('IN_PROGRESS');
+    const startedDeployment = deployment({ state: 'IN_PROGRESS' });
+
     expect(service.getCurrentEffectiveStepIndex(startedDeployment)).toBe(1);
     expect(service.getStepStatus(startedDeployment, 0)).toBe('completed');
     expect(service.getStepStatus(startedDeployment, 1)).toBe('active');
   });
 
   it('marks success as completed and failure on the last known active step', () => {
-    const startedDeployment = deployment('IN_PROGRESS');
+    const startedDeployment = deployment({ state: 'IN_PROGRESS' });
     service.updateDeploymentState(startedDeployment);
 
-    const failedDeployment = deployment('FAILURE');
+    const failedDeployment = deployment({ state: 'FAILURE' });
     service.updateDeploymentState(failedDeployment);
 
-    expect(service.getStepStatus(deployment('SUCCESS'), 0)).toBe('completed');
-    expect(service.getStepStatus(deployment('SUCCESS'), 1)).toBe('completed');
+    expect(service.getStepStatus(deployment({ state: 'SUCCESS' }), 0)).toBe('completed');
+    expect(service.getStepStatus(deployment({ state: 'SUCCESS' }), 1)).toBe('completed');
     expect(service.getStepStatus(failedDeployment, 0)).toBe('completed');
     expect(service.getStepStatus(failedDeployment, 1)).toBe('error');
+  });
+
+  it('uses the persisted deploy job start as the pre-deployment timer anchor', () => {
+    setNow('2026-04-23T10:01:00Z');
+    const currentDeployment = deployment({
+      state: 'PENDING',
+      deployJobStartedAt: '2026-04-23T10:00:00Z',
+    });
+
+    expect(service.getCurrentEffectiveStepIndex(currentDeployment)).toBe(0);
+    expect(service.getProgress(currentDeployment, 0)).toBe(50);
+    expect(service.getStepTime(currentDeployment, 0)).toBe('1m 0s\nremaining');
+  });
+
+  it('switches to the deployment step when the persisted deployment phase has started', () => {
+    setNow('2026-04-23T10:04:00Z');
+    const currentDeployment = deployment({
+      state: 'IN_PROGRESS',
+      deployJobStartedAt: '2026-04-23T10:00:00Z',
+      deploymentStartedAt: '2026-04-23T10:02:00Z',
+    });
+
+    expect(service.getCurrentEffectiveStepIndex(currentDeployment)).toBe(1);
+    expect(service.getProgress(currentDeployment, 0)).toBe(100);
+    expect(service.getProgress(currentDeployment, 1)).toBe(40);
+    expect(service.getStepTime(currentDeployment, 1)).toBe('3m 0s\nremaining');
+  });
+
+  it('measures the finished deployment duration from the deploy job start when available', () => {
+    const finishedDeployment = deployment({
+      state: 'SUCCESS',
+      createdAt: '2026-04-23T09:50:00Z',
+      deployJobStartedAt: '2026-04-23T10:00:00Z',
+      deploymentStartedAt: '2026-04-23T10:02:00Z',
+      updatedAt: '2026-04-23T10:07:00Z',
+    });
+
+    expect(service.getDeploymentDuration(finishedDeployment)).toBe('7m 0s');
   });
 });

--- a/client/src/app/core/services/deployment-timing.service.spec.ts
+++ b/client/src/app/core/services/deployment-timing.service.spec.ts
@@ -118,4 +118,15 @@ describe('DeploymentTimingService', () => {
 
     expect(service.getDeploymentDuration(finishedDeployment)).toBe('7m 0s');
   });
+
+  it('measures the finished deployment duration from creation when deploy job start is unavailable', () => {
+    const finishedDeployment = deployment({
+      state: 'SUCCESS',
+      createdAt: '2026-04-23T09:50:00Z',
+      deploymentStartedAt: '2026-04-23T10:02:00Z',
+      updatedAt: '2026-04-23T10:07:00Z',
+    });
+
+    expect(service.getDeploymentDuration(finishedDeployment)).toBe('17m 0s');
+  });
 });

--- a/client/src/app/core/services/deployment-timing.service.ts
+++ b/client/src/app/core/services/deployment-timing.service.ts
@@ -340,8 +340,7 @@ export class DeploymentTimingService {
       endTime = this._currentTime();
     }
 
-    const startTime =
-      this.getEffectiveStepStartTime(deployment, 'PENDING') || this.getEffectiveStepStartTime(deployment, 'IN_PROGRESS') || new Date(deployment.createdAt).getTime();
+    const startTime = this.getEffectiveStepStartTime(deployment, 'PENDING') || new Date(deployment.createdAt).getTime();
     const elapsedMs = endTime - startTime;
     if (elapsedMs < 0) {
       return '0m 0s';

--- a/client/src/app/core/services/deployment-timing.service.ts
+++ b/client/src/app/core/services/deployment-timing.service.ts
@@ -1,12 +1,14 @@
 import { DestroyRef, Injectable, Signal, computed, inject, signal } from '@angular/core';
-import { EnvironmentDeployment } from '@app/core/modules/openapi';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { EnvironmentDeployment } from '@app/core/modules/openapi';
 import { interval } from 'rxjs';
+
+type DeploymentStep = 'PENDING' | 'IN_PROGRESS';
 
 interface DeploymentTimingData {
   lastKnownState: string | undefined;
-  stepStartTimes: Map<string, number>;
-  terminatedAt?: number; // Time when the deployment reached a terminal state (SUCCESS, ERROR, FAILURE)
+  stepStartTimes: Map<DeploymentStep, number>;
+  terminatedAt?: number;
 }
 
 interface EstimatedTimes {
@@ -17,56 +19,34 @@ interface EstimatedTimes {
   IN_PROGRESS: number;
 }
 
-type DeploymentStep = 'PENDING' | 'IN_PROGRESS';
-
 @Injectable({
   providedIn: 'root',
 })
 export class DeploymentTimingService {
   private destroyRef = inject(DestroyRef);
 
-  // Map deployment IDs to their timing data
   private deploymentTimings = new Map<string, DeploymentTimingData>();
 
-  // Define deployment steps
   public readonly steps: DeploymentStep[] = ['PENDING', 'IN_PROGRESS'];
 
-  // Centralized current time that updates every second
   private _currentTime = signal<number>(Date.now());
   public readonly currentTime: Signal<number> = this._currentTime;
 
-  /**
-   * Creates a time-aware computed signal that automatically updates with time changes
-   * @param computeFn Function that computes a value, will be re-evaluated on time changes
-   * @returns A signal that updates both when dependencies change and when time changes
-   */
   public timeAwareComputed<T>(computeFn: () => T): Signal<T> {
     return computed(() => {
-      // Create dependency on the current time
       this._currentTime();
-      // Return the computed value
       return computeFn();
     });
   }
 
-  /**
-   * Creates a time-aware function that will return fresh values as time changes
-   * This is useful for template methods that need to accept parameters
-   * @param fn The function to make time-aware
-   * @returns A function that will return fresh values as time changes
-   */
   public createTimeAwareFunction<A extends unknown[], R>(fn: (...args: A) => R): (...args: A) => R {
-    // Create a closure over the current time to ensure freshness
     return (...args: A): R => {
-      // Reading the current time creates a dependency in templates that use this function
       this._currentTime();
-      // Call the original function with all arguments
       return fn(...args);
     };
   }
 
   constructor() {
-    // Update the current time every second
     interval(1000)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
@@ -74,64 +54,59 @@ export class DeploymentTimingService {
       });
   }
 
-  // Get timing data for a deployment, creating it if it doesn't exist
   getTimingData(deploymentId: string | number): DeploymentTimingData {
     const id = String(deploymentId);
     if (!this.deploymentTimings.has(id)) {
       this.deploymentTimings.set(id, {
         lastKnownState: undefined,
-        stepStartTimes: new Map<string, number>(),
+        stepStartTimes: new Map<DeploymentStep, number>(),
       });
     }
     return this.deploymentTimings.get(id)!;
   }
 
-  // Update timing data when a deployment state changes
   updateDeploymentState(deployment: EnvironmentDeployment): void {
-    if (!deployment.id || !deployment.state) return;
+    if (!deployment.id || !deployment.state) {
+      return;
+    }
 
-    const deploymentId = String(deployment.id);
-    const timingData = this.getTimingData(deploymentId);
+    const timingData = this.getTimingData(deployment.id);
     const newState = deployment.state;
 
-    // Only track state transitions
-    if (newState !== timingData.lastKnownState) {
-      const stepStartTime = this._currentTime();
-      const previousState = timingData.lastKnownState;
-      const newStep = this.getStepForState(newState);
-      const previousStep = previousState ? this.getStepForState(previousState) : undefined;
-
-      if (newStep && this.shouldStartStepTimer(newState)) {
-        const effectiveStartTime = previousStep === newStep && previousStep ? timingData.stepStartTimes.get(previousStep) || stepStartTime : stepStartTime;
-        timingData.stepStartTimes.set(newStep, effectiveStartTime);
-      }
-
-      // If this is a terminal state, record the time
-      if (['SUCCESS', 'ERROR', 'FAILURE'].includes(newState)) {
-        timingData.terminatedAt = stepStartTime;
-      }
-
-      timingData.lastKnownState = newState;
+    if (newState === timingData.lastKnownState) {
+      return;
     }
+
+    const stepStartTime = this._currentTime();
+    const previousState = timingData.lastKnownState;
+    const newStep = this.getStepForState(newState);
+    const previousStep = previousState ? this.getStepForState(previousState) : undefined;
+
+    if (newStep && this.shouldStartStepTimer(newState) && !this.getPersistedStepStartTime(deployment, newStep)) {
+      const effectiveStartTime = previousStep === newStep && previousStep ? timingData.stepStartTimes.get(previousStep) || stepStartTime : stepStartTime;
+      timingData.stepStartTimes.set(newStep, effectiveStartTime);
+    }
+
+    if (['SUCCESS', 'ERROR', 'FAILURE'].includes(newState)) {
+      timingData.terminatedAt = stepStartTime;
+    }
+
+    timingData.lastKnownState = newState;
   }
 
-  // Get the start time for a particular state of a deployment
   getStepStartTime(deploymentId: string | number, state: string): number | undefined {
-    return this.getTimingData(deploymentId).stepStartTimes.get(state);
+    return this.getTimingData(deploymentId).stepStartTimes.get(state as DeploymentStep);
   }
 
-  // Get the last known state for a deployment
   getLastKnownState(deploymentId: string | number): string | undefined {
     return this.getTimingData(deploymentId).lastKnownState;
   }
 
-  // Get the estimated times for each step based on deployment properties
   public getEstimatedTimes(deployment: EnvironmentDeployment): EstimatedTimes {
     const prExists = deployment?.prName != null;
     const defaultPending = prExists ? 2 : 11;
 
     const pendingMin = deployment?.estimatedBuildDurationSeconds != null ? deployment.estimatedBuildDurationSeconds / 60 : defaultPending;
-
     const inProgressMin = deployment?.estimatedDeployDurationSeconds != null ? deployment.estimatedDeployDurationSeconds / 60 : 4;
 
     return {
@@ -143,37 +118,37 @@ export class DeploymentTimingService {
     };
   }
 
-  // Determine if a deployment is in an error state
   public isErrorState(deployment: EnvironmentDeployment): boolean {
     return ['ERROR', 'FAILURE'].includes(deployment?.state || '');
   }
 
-  // Determine if a deployment is in a success state
   public isSuccessState(deployment: EnvironmentDeployment): boolean {
     return deployment?.state === 'SUCCESS';
   }
 
-  // Determine if a deployment is in an unknown state
   public isUnknownState(deployment: EnvironmentDeployment): boolean {
     return ['UNKNOWN', 'INACTIVE'].includes(deployment?.state || '');
   }
 
-  // Get the current effective step index for a deployment
   public getCurrentEffectiveStepIndex(deployment: EnvironmentDeployment): number {
-    if (!deployment || !deployment.createdAt || !deployment.id) return 0;
+    if (!deployment || !deployment.createdAt || !deployment.id) {
+      return 0;
+    }
 
-    // If in error state, find the last known valid state
     if (this.isErrorState(deployment)) {
-      // Look through the stepStartTimes to find the last step that was started
-      const deploymentId = deployment.id;
-
-      for (let i = this.steps.length - 1; i >= 0; i--) {
-        const step = this.steps[i];
-        if (this.getStepStartTime(deploymentId, step)) {
-          return i;
-        }
+      if (this.getEffectiveStepStartTime(deployment, 'IN_PROGRESS')) {
+        return 1;
       }
-      return -1; // Special value to indicate no valid step found in error state
+      if (this.getEffectiveStepStartTime(deployment, 'PENDING')) {
+        return 0;
+      }
+
+      const currentStep = this.getStepForState(deployment.state);
+      return currentStep ? this.steps.indexOf(currentStep) : -1;
+    }
+
+    if (this.getEffectiveStepStartTime(deployment, 'IN_PROGRESS')) {
+      return 1;
     }
 
     const currentStep = this.getStepForState(deployment.state);
@@ -181,22 +156,30 @@ export class DeploymentTimingService {
     return index !== -1 ? index : 0;
   }
 
-  // Get remaining time for the current step of a deployment
   public getRemainingTimeForCurrentStep(deployment: EnvironmentDeployment): number {
-    if (!deployment?.state || !deployment.createdAt || !deployment.id) return 0;
+    if (!deployment?.state || !deployment.createdAt || !deployment.id) {
+      return 0;
+    }
 
-    const currentState = this.getStepForState(deployment.state) || deployment.state;
-    const deploymentId = deployment.id;
+    const currentIndex = this.getCurrentEffectiveStepIndex(deployment);
+    if (currentIndex < 0) {
+      return 0;
+    }
 
-    // Use the stored step start time or fall back to the current time
-    const stepStartTime = this.getStepStartTime(deploymentId, currentState) || this._currentTime();
-    const elapsedMs = this._currentTime() - stepStartTime;
-    const estimatedMs = (this.getEstimatedTimes(deployment)[currentState as keyof EstimatedTimes] || 0) * 60000;
+    const currentStep = this.steps[currentIndex];
+    const stepStartTime = this.getEffectiveStepStartTime(deployment, currentStep);
+    const estimatedMs = this.getEstimatedTimes(deployment)[currentStep] * 60000;
+
+    if (!stepStartTime) {
+      return estimatedMs;
+    }
+
+    const currentTime = this.getProgressReferenceTime(deployment);
+    const elapsedMs = Math.max(0, currentTime - stepStartTime);
 
     return Math.max(0, estimatedMs - elapsedMs);
   }
 
-  // Get step display name
   public getStepDisplayName(step: string): string {
     const stepMap = {
       REQUESTED: 'PRE-DEPLOYMENT',
@@ -206,116 +189,138 @@ export class DeploymentTimingService {
     return stepMap[step as keyof typeof stepMap] || step;
   }
 
-  // Get step status
   public getStepStatus(deployment: EnvironmentDeployment, index: number): string {
-    if (!deployment) return 'unknown';
-
-    const effectiveStep = this.getCurrentEffectiveStepIndex(deployment);
-
-    if (this.isUnknownState(deployment)) return 'unknown';
-    if (this.isSuccessState(deployment)) return 'completed';
-
-    // If in error state, handle each step appropriately
-    if (this.isErrorState(deployment)) {
-      if (effectiveStep === -1) return 'error'; // Show all steps as error when no valid step found
-      if (index < effectiveStep) return 'completed';
-      if (index === effectiveStep) return 'error';
+    if (!deployment) {
       return 'unknown';
     }
 
-    // Normal flow (no error)
-    if (index < effectiveStep) return 'completed';
-    if (index === effectiveStep) return 'active';
+    const effectiveStep = this.getCurrentEffectiveStepIndex(deployment);
+
+    if (this.isUnknownState(deployment)) {
+      return 'unknown';
+    }
+    if (this.isSuccessState(deployment)) {
+      return 'completed';
+    }
+
+    if (this.isErrorState(deployment)) {
+      if (effectiveStep === -1) {
+        return 'error';
+      }
+      if (index < effectiveStep) {
+        return 'completed';
+      }
+      if (index === effectiveStep) {
+        return 'error';
+      }
+      return 'unknown';
+    }
+
+    if (index < effectiveStep) {
+      return 'completed';
+    }
+    if (index === effectiveStep) {
+      return 'active';
+    }
     return 'upcoming';
   }
 
-  // Get progress percentage for a step
   public getProgress(deployment: EnvironmentDeployment, index: number): number {
-    if (!deployment || !deployment.createdAt || !deployment.id) return 0;
-    if (deployment.state === 'SUCCESS') return 100;
-
-    const stepKey = this.steps[index] as keyof EstimatedTimes;
-    const currentState = this.getStepForState(deployment.state) || deployment.state;
-    const effectiveStep = this.getCurrentEffectiveStepIndex(deployment);
-    const deploymentId = deployment.id;
-
-    // If in error state with no valid step, show empty progress bars
-    if (this.isErrorState(deployment) && effectiveStep === -1) return 0;
-
-    // Skip the remaining checks if effectiveStep is -1 to avoid incorrect comparisons
-    if (effectiveStep === -1) return 0;
-
-    if (index < effectiveStep) return 100;
-    if (index > effectiveStep || (this.isErrorState(deployment) && index > effectiveStep)) return 0;
-
-    // For current step
-    const stepStartTime = this.getStepStartTime(deploymentId, currentState!) || new Date(deployment.createdAt).getTime();
-
-    // If in error state, use the updatedAt time to calculate the progress at failure
-    let currentTime: number;
-    if (this.isErrorState(deployment) && deployment.updatedAt) {
-      currentTime = new Date(deployment.updatedAt).getTime();
-    } else {
-      currentTime = this._currentTime();
+    if (!deployment || !deployment.createdAt || !deployment.id) {
+      return 0;
+    }
+    if (deployment.state === 'SUCCESS') {
+      return 100;
     }
 
-    const elapsedMs = Math.max(0, currentTime - stepStartTime); // Ensure elapsed time is never negative
-    const estimatedMs = this.getEstimatedTimes(deployment)[stepKey] * 60000;
+    const effectiveStep = this.getCurrentEffectiveStepIndex(deployment);
+    if (effectiveStep === -1) {
+      return 0;
+    }
 
+    if (index < effectiveStep) {
+      return 100;
+    }
+    if (index > effectiveStep) {
+      return 0;
+    }
+
+    const stepKey = this.steps[index];
+    const stepStartTime = this.getEffectiveStepStartTime(deployment, stepKey);
+    if (!stepStartTime) {
+      return 0;
+    }
+
+    const elapsedMs = Math.max(0, this.getProgressReferenceTime(deployment) - stepStartTime);
+    const estimatedMs = this.getEstimatedTimes(deployment)[stepKey] * 60000;
     const ratio = estimatedMs > 0 ? Math.min(elapsedMs / estimatedMs, 1) : 1;
-    return Math.max(0, Math.floor(ratio * 100)); // Ensure we never return a negative percentage
+    return Math.max(0, Math.floor(ratio * 100));
   }
 
-  // Get time display for a step
   public getStepTime(deployment: EnvironmentDeployment, index: number): string {
-    if (!deployment?.state || !deployment.createdAt) return '';
-
-    const currentIndex = this.getCurrentEffectiveStepIndex(deployment);
-
-    // Handle error state
-    if (this.isErrorState(deployment)) {
-      if (currentIndex === -1) return 'Failed'; // Show all steps as failed when no valid step found
-      if (index < currentIndex) return 'Completed';
-      if (index === currentIndex) return 'Failed';
+    if (!deployment?.state || !deployment.createdAt) {
       return '';
     }
 
-    // Handle success state
+    const currentIndex = this.getCurrentEffectiveStepIndex(deployment);
+
+    if (this.isErrorState(deployment)) {
+      if (currentIndex === -1) {
+        return 'Failed';
+      }
+      if (index < currentIndex) {
+        return 'Completed';
+      }
+      if (index === currentIndex) {
+        return 'Failed';
+      }
+      return '';
+    }
+
     if (this.isSuccessState(deployment)) {
       return 'Completed';
     }
 
-    // Handle normal flow
     if (index < currentIndex) {
       return 'Completed';
     }
 
-    if (index > currentIndex) {
-      // For upcoming steps, show estimated time
-      const stepKey = this.steps[index] as keyof EstimatedTimes;
-      const estimatedMinutes = this.getEstimatedTimes(deployment)[stepKey];
+    const stepKey = this.steps[index];
+    const estimatedMinutes = this.getEstimatedTimes(deployment)[stepKey];
+    if (index > currentIndex || !this.getEffectiveStepStartTime(deployment, stepKey)) {
       return `~${estimatedMinutes}m 0s\nestimated`;
     }
 
-    // For current step
     const remainingMs = this.getRemainingTimeForCurrentStep(deployment);
     const minutes = Math.floor(remainingMs / 60000);
     const seconds = Math.floor((remainingMs % 60000) / 1000);
-    return remainingMs > 0 ? `${minutes}m ${seconds}s\nremaining` : `0m 0s\nremaining`;
+    return `${minutes}m ${seconds}s\nremaining`;
   }
 
-  // Get the total remaining time for a deployment as a string (e.g. "5m 30s")
-  getTotalRemainingTime(deployment: EnvironmentDeployment): string {
-    if (!deployment?.state || !deployment.createdAt) return '';
-    if (this.isErrorState(deployment) || this.isSuccessState(deployment)) return '';
+  public getTotalRemainingTime(deployment: EnvironmentDeployment): string {
+    if (!deployment?.state || !deployment.createdAt) {
+      return '';
+    }
+    if (this.isErrorState(deployment) || this.isSuccessState(deployment)) {
+      return '';
+    }
 
     const currentIndex = this.getCurrentEffectiveStepIndex(deployment);
-    let totalRemainingMs = this.getRemainingTimeForCurrentStep(deployment);
+    if (currentIndex < 0) {
+      return '';
+    }
 
-    // Add estimated time for upcoming steps
-    for (let i = currentIndex + 1; i < this.steps.length; i++) {
-      const stepKey = this.steps[i] as keyof EstimatedTimes;
-      totalRemainingMs += this.getEstimatedTimes(deployment)[stepKey] * 60000;
+    let totalRemainingMs = 0;
+
+    for (let i = currentIndex; i < this.steps.length; i++) {
+      const stepKey = this.steps[i];
+      const estimatedMs = this.getEstimatedTimes(deployment)[stepKey] * 60000;
+
+      if (i === currentIndex && this.getEffectiveStepStartTime(deployment, stepKey)) {
+        totalRemainingMs += this.getRemainingTimeForCurrentStep(deployment);
+      } else {
+        totalRemainingMs += estimatedMs;
+      }
     }
 
     const minutes = Math.floor(totalRemainingMs / 60000);
@@ -323,24 +328,30 @@ export class DeploymentTimingService {
     return totalRemainingMs > 0 ? `${minutes}m ${seconds}s` : '';
   }
 
-  // Calculate the duration of a deployment
   public getDeploymentDuration(deployment: EnvironmentDeployment): string {
-    if (!deployment || !deployment.createdAt) return '';
+    if (!deployment || !deployment.createdAt) {
+      return '';
+    }
+
     let endTime: number;
     if (['SUCCESS', 'ERROR', 'FAILURE'].includes(deployment.state || '')) {
       endTime = deployment.updatedAt ? new Date(deployment.updatedAt).getTime() : this._currentTime();
     } else {
       endTime = this._currentTime();
     }
-    const startTime = new Date(deployment.createdAt).getTime();
+
+    const startTime =
+      this.getEffectiveStepStartTime(deployment, 'PENDING') || this.getEffectiveStepStartTime(deployment, 'IN_PROGRESS') || new Date(deployment.createdAt).getTime();
     const elapsedMs = endTime - startTime;
-    if (elapsedMs < 0) return '0m 0s';
+    if (elapsedMs < 0) {
+      return '0m 0s';
+    }
+
     const minutes = Math.floor(elapsedMs / 60000);
     const seconds = Math.floor((elapsedMs % 60000) / 1000);
     return `${minutes}m ${seconds}s`;
   }
 
-  // Clean up data for deployments that are in terminal states and older than a certain threshold
   cleanupOldData(maxAgeInMs: number = 24 * 60 * 60 * 1000): void {
     const now = this._currentTime();
     for (const [deploymentId, data] of this.deploymentTimings.entries()) {
@@ -365,6 +376,30 @@ export class DeploymentTimingService {
   }
 
   private shouldStartStepTimer(state: string | undefined): boolean {
-    return state === 'PENDING' || state === 'IN_PROGRESS';
+    return state === 'IN_PROGRESS';
+  }
+
+  private getProgressReferenceTime(deployment: EnvironmentDeployment): number {
+    if (this.isErrorState(deployment) && deployment.updatedAt) {
+      return new Date(deployment.updatedAt).getTime();
+    }
+    return this._currentTime();
+  }
+
+  private getPersistedStepStartTime(deployment: EnvironmentDeployment, step: DeploymentStep): number | undefined {
+    return step === 'PENDING' ? this.parseTime(deployment.deployJobStartedAt) : this.parseTime(deployment.deploymentStartedAt);
+  }
+
+  private getEffectiveStepStartTime(deployment: EnvironmentDeployment, step: DeploymentStep): number | undefined {
+    return this.getPersistedStepStartTime(deployment, step) ?? this.getTimingData(deployment.id).stepStartTimes.get(step);
+  }
+
+  private parseTime(value?: string): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = new Date(value).getTime();
+    return Number.isNaN(parsed) ? undefined : parsed;
   }
 }

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -2437,6 +2437,12 @@ components:
         updatedAt:
           type: string
           format: date-time
+        deployJobStartedAt:
+          type: string
+          format: date-time
+        deploymentStartedAt:
+          type: string
+          format: date-time
         type:
           type: string
           enum:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -230,6 +230,20 @@ public class LatestDeploymentUnion {
     }
   }
 
+  public OffsetDateTime getDeployJobStartedAt() {
+    if (hasHeliosDeployment()) {
+      return heliosDeployment.getDeployJobStartedAt();
+    }
+    return null;
+  }
+
+  public OffsetDateTime getDeploymentStartedAt() {
+    if (hasHeliosDeployment()) {
+      return heliosDeployment.getDeploymentStartedAt();
+    }
+    return null;
+  }
+
   public String getPullRequestName() {
     if (isRealDeployment()) {
       return realDeployment.getPullRequest() != null

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -231,17 +231,27 @@ public class LatestDeploymentUnion {
   }
 
   public OffsetDateTime getDeployJobStartedAt() {
-    if (hasHeliosDeployment()) {
+    if (hasMatchingHeliosDeployment()) {
       return heliosDeployment.getDeployJobStartedAt();
     }
     return null;
   }
 
   public OffsetDateTime getDeploymentStartedAt() {
-    if (hasHeliosDeployment()) {
+    if (hasMatchingHeliosDeployment()) {
       return heliosDeployment.getDeploymentStartedAt();
     }
     return null;
+  }
+
+  private boolean hasMatchingHeliosDeployment() {
+    if (isHeliosDeployment()) {
+      return true;
+    }
+    return isRealDeployment()
+        && hasHeliosDeployment()
+        && heliosDeployment.getDeploymentId() != null
+        && heliosDeployment.getDeploymentId().equals(realDeployment.getId());
   }
 
   public String getPullRequestName() {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
@@ -104,6 +104,11 @@ public class GitHubDeploymentSyncService {
       if (heliosDeployment.getDeploymentId() == null) {
         heliosDeployment.setDeploymentId(deployment.getId());
       }
+      if (deployment.getState() == Deployment.State.IN_PROGRESS
+          && heliosDeployment.getDeploymentStartedAt() == null
+          && deployment.getUpdatedAt() != null) {
+        heliosDeployment.setDeploymentStartedAt(deployment.getUpdatedAt());
+      }
       heliosDeployment.setStatus(
           HeliosDeployment.mapDeploymentStateToHeliosStatus(deployment.getState()));
       if (deployment

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
@@ -16,6 +16,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.lang.NonNull;
 
 public record EnvironmentDto(
@@ -68,26 +70,29 @@ public record EnvironmentDto(
   }
 
   /** This is the DTO for the "latestDeployment" portion inside EnvironmentDto. */
-  public static record EnvironmentDeployment(
-      @NonNull Long id,
-      String url,
-      LatestDeploymentUnion.State state,
-      String statusesUrl,
-      String sha,
-      String ref,
-      String task,
-      String workflowRunHtmlUrl,
-      List<String> releaseCandidateNames,
-      String prName,
-      UserInfoDto user,
-      Integer pullRequestNumber,
-      OffsetDateTime createdAt,
-      OffsetDateTime updatedAt,
-      OffsetDateTime deployJobStartedAt,
-      OffsetDateTime deploymentStartedAt,
-      @NonNull DeploymentType type,
-      Integer estimatedBuildDurationSeconds,
-      Integer estimatedDeployDurationSeconds) {
+  @Getter
+  @AllArgsConstructor
+  public static class EnvironmentDeployment {
+    @NonNull private final Long id;
+    private final String url;
+    private final LatestDeploymentUnion.State state;
+    private final String statusesUrl;
+    private final String sha;
+    private final String ref;
+    private final String task;
+    private final String workflowRunHtmlUrl;
+    private final List<String> releaseCandidateNames;
+    private final String prName;
+    private final UserInfoDto user;
+    private final Integer pullRequestNumber;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+    private final OffsetDateTime deployJobStartedAt;
+    private final OffsetDateTime deploymentStartedAt;
+    @NonNull private final DeploymentType type;
+    private final Integer estimatedBuildDurationSeconds;
+    private final Integer estimatedDeployDurationSeconds;
+
     /** Builds an EnvironmentDeployment from a LatestDeploymentUnion. */
     public static EnvironmentDeployment fromUnion(
         LatestDeploymentUnion union,
@@ -130,6 +135,7 @@ public record EnvironmentDto(
           estimatedBuild,
           estimatedDeploy);
     }
+
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
@@ -83,6 +83,8 @@ public record EnvironmentDto(
       Integer pullRequestNumber,
       OffsetDateTime createdAt,
       OffsetDateTime updatedAt,
+      OffsetDateTime deployJobStartedAt,
+      OffsetDateTime deploymentStartedAt,
       @NonNull DeploymentType type,
       Integer estimatedBuildDurationSeconds,
       Integer estimatedDeployDurationSeconds) {
@@ -122,6 +124,8 @@ public record EnvironmentDto(
           union.getPullRequestNumber(),
           union.getCreatedAt(),
           union.getUpdatedAt(),
+          union.getDeployJobStartedAt(),
+          union.getDeploymentStartedAt(),
           union.getType(),
           estimatedBuild,
           estimatedDeploy);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
@@ -102,6 +102,12 @@ public class HeliosDeployment {
   @Column(name = "deploy_duration_seconds")
   private Integer deployDurationSeconds;
 
+  @Column(name = "deploy_job_started_at")
+  private OffsetDateTime deployJobStartedAt;
+
+  @Column(name = "deployment_started_at")
+  private OffsetDateTime deploymentStartedAt;
+
   // Enum to represent deployment status
   public enum Status {
     /** Deployment called and waiting GitHub webhook listener. */

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
@@ -32,29 +32,7 @@ public class GitHubWorkflowJobTimingService {
     }
 
     GitHubWorkflowJobPayload.WorkflowJob job = payload.workflowJob();
-    if (!"completed".equalsIgnoreCase(payload.action())
-        || !"completed".equalsIgnoreCase(job.status())
-        || job.runId() == null
-        || job.startedAt() == null
-        || job.completedAt() == null) {
-      return;
-    }
-
-    Optional<WorkflowRun> workflowRunOpt = workflowRunRepository.findById(job.runId());
-    if (workflowRunOpt.isEmpty() || workflowRunOpt.get().getWorkflow() == null) {
-      log.debug(
-          "Skipping workflow_job timing persistence because workflow run {} "
-              + "is missing or has no workflow",
-          job.runId());
-      return;
-    }
-
-    WorkflowRun workflowRun = workflowRunOpt.get();
-    Workflow workflow = workflowRun.getWorkflow();
-
-    Optional<DeploymentWorkflowConfig> configOpt =
-        deploymentWorkflowConfigRepository.findByWorkflow(workflow);
-    if (configOpt.isEmpty()) {
+    if (job.runId() == null) {
       return;
     }
 
@@ -70,16 +48,30 @@ public class GitHubWorkflowJobTimingService {
 
     HeliosDeployment heliosDeployment = heliosDeploymentOpt.get();
     Environment environment = heliosDeployment.getEnvironment();
-    if (environment == null
-        || environment.getDeploymentWorkflow() == null
-        || !environment.getDeploymentWorkflow().getId().equals(workflow.getId())) {
+    Workflow workflow = environment != null ? environment.getDeploymentWorkflow() : null;
+    if (workflow == null) {
+      log.debug(
+          "Skipping workflow_job timing persistence because workflow run {} "
+              + "is not linked to an environment deployment workflow",
+          job.runId());
+      return;
+    }
+
+    Optional<DeploymentWorkflowConfig> configOpt =
+        deploymentWorkflowConfigRepository.findByWorkflow(workflow);
+    if (configOpt.isEmpty()) {
+      return;
+    }
+
+    Optional<WorkflowRun> workflowRunOpt = workflowRunRepository.findById(job.runId());
+    if (workflowRunOpt.isPresent()
+        && workflowRunOpt.get().getWorkflow() != null
+        && !workflowRunOpt.get().getWorkflow().getId().equals(workflow.getId())) {
       log.debug(
           "Skipping workflow_job timing persistence because workflow run {} "
               + "is not linked to the configured deployment workflow {}",
           job.runId(),
-          environment != null && environment.getDeploymentWorkflow() != null
-              ? environment.getDeploymentWorkflow().getId()
-              : null);
+          workflow.getId());
       return;
     }
 
@@ -90,25 +82,88 @@ public class GitHubWorkflowJobTimingService {
       return;
     }
 
+    boolean changed = false;
     if (payload.deployment() != null
         && heliosDeployment.getDeploymentId() == null
         && payload.deployment().id() != null) {
       heliosDeployment.setDeploymentId(payload.deployment().id());
+      changed = true;
     }
 
-    OffsetDateTime preDeploymentStart =
-        resolvePreDeploymentStart(
-            workflowRun,
-            payload.deployment() != null ? payload.deployment().createdAt() : null,
-            heliosDeployment);
-    heliosDeployment.setBuildDurationSeconds(
-        calculateDurationSeconds(preDeploymentStart, job.startedAt()));
-    heliosDeployment.setDeployDurationSeconds(
-        calculateDurationSeconds(job.startedAt(), job.completedAt()));
-    heliosDeploymentRepository.save(heliosDeployment);
+    if (isJobStartedEvent(payload.action(), job)) {
+      if (heliosDeployment.getDeployJobStartedAt() == null) {
+        heliosDeployment.setDeployJobStartedAt(job.startedAt());
+        changed = true;
+      }
+      if (changed) {
+        heliosDeploymentRepository.save(heliosDeployment);
+      }
+      return;
+    }
+
+    if (!isCompletedEvent(payload.action(), job)) {
+      if (changed) {
+        heliosDeploymentRepository.save(heliosDeployment);
+      }
+      return;
+    }
+
+    if (heliosDeployment.getDeployJobStartedAt() == null && job.startedAt() != null) {
+      heliosDeployment.setDeployJobStartedAt(job.startedAt());
+      changed = true;
+    }
+
+    if (job.startedAt() == null || job.completedAt() == null) {
+      if (changed) {
+        heliosDeploymentRepository.save(heliosDeployment);
+      }
+      return;
+    }
+
+    OffsetDateTime deploymentStartedAt = heliosDeployment.getDeploymentStartedAt();
+    if (deploymentStartedAt != null) {
+      OffsetDateTime deployJobStartedAt =
+          heliosDeployment.getDeployJobStartedAt() != null
+              ? heliosDeployment.getDeployJobStartedAt()
+              : job.startedAt();
+      heliosDeployment.setBuildDurationSeconds(
+          calculateDurationSeconds(deployJobStartedAt, deploymentStartedAt));
+      heliosDeployment.setDeployDurationSeconds(
+          calculateDurationSeconds(deploymentStartedAt, job.completedAt()));
+    } else {
+      OffsetDateTime preDeploymentStart =
+          resolveLegacyPreDeploymentStart(
+              workflowRunOpt.orElse(null),
+              payload.deployment() != null ? payload.deployment().createdAt() : null,
+              heliosDeployment);
+      heliosDeployment.setBuildDurationSeconds(
+          calculateDurationSeconds(preDeploymentStart, job.startedAt()));
+      heliosDeployment.setDeployDurationSeconds(
+          calculateDurationSeconds(job.startedAt(), job.completedAt()));
+    }
+    changed = true;
+
+    if (changed) {
+      heliosDeploymentRepository.save(heliosDeployment);
+    }
   }
 
-  private OffsetDateTime resolvePreDeploymentStart(
+  private boolean isJobStartedEvent(
+      String action, GitHubWorkflowJobPayload.WorkflowJob job) {
+    return "in_progress".equalsIgnoreCase(action)
+        && "in_progress".equalsIgnoreCase(job.status())
+        && job.startedAt() != null;
+  }
+
+  private boolean isCompletedEvent(
+      String action, GitHubWorkflowJobPayload.WorkflowJob job) {
+    return "completed".equalsIgnoreCase(action)
+        && "completed".equalsIgnoreCase(job.status())
+        && job.startedAt() != null
+        && job.completedAt() != null;
+  }
+
+  private OffsetDateTime resolveLegacyPreDeploymentStart(
       WorkflowRun workflowRun,
       OffsetDateTime deploymentCreatedAt,
       HeliosDeployment heliosDeployment) {

--- a/server/application-server/src/main/resources/db/migration/V45__add_deployment_phase_timestamps.sql
+++ b/server/application-server/src/main/resources/db/migration/V45__add_deployment_phase_timestamps.sql
@@ -1,0 +1,3 @@
+ALTER TABLE helios_deployment
+    ADD COLUMN deploy_job_started_at TIMESTAMP WITH TIME ZONE,
+    ADD COLUMN deployment_started_at TIMESTAMP WITH TIME ZONE;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
@@ -1,11 +1,18 @@
 package de.tum.cit.aet.helios.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 
 class LatestDeploymentUnionTest {
+
+  private static final OffsetDateTime DEPLOY_JOB_STARTED_AT =
+      OffsetDateTime.parse("2026-04-23T10:00:00Z");
+  private static final OffsetDateTime DEPLOYMENT_STARTED_AT =
+      OffsetDateTime.parse("2026-04-23T10:02:00Z");
 
   @Test
   void fromHeliosStatusPreservesQueuedState() {
@@ -35,5 +42,55 @@ class LatestDeploymentUnionTest {
     assertEquals(
         LatestDeploymentUnion.State.UNKNOWN,
         LatestDeploymentUnion.State.fromHeliosStatus(HeliosDeployment.Status.UNKNOWN));
+  }
+
+  @Test
+  void exposesPhaseTimestampsForHeliosDeployment() {
+    LatestDeploymentUnion union = LatestDeploymentUnion.heliosDeployment(heliosDeployment(null));
+
+    assertEquals(DEPLOY_JOB_STARTED_AT, union.getDeployJobStartedAt());
+    assertEquals(DEPLOYMENT_STARTED_AT, union.getDeploymentStartedAt());
+  }
+
+  @Test
+  void exposesPhaseTimestampsForMatchingRealDeploymentFallback() {
+    LatestDeploymentUnion union =
+        LatestDeploymentUnion.realDeployment(deployment(1L), heliosDeployment(1L));
+
+    assertEquals(DEPLOY_JOB_STARTED_AT, union.getDeployJobStartedAt());
+    assertEquals(DEPLOYMENT_STARTED_AT, union.getDeploymentStartedAt());
+  }
+
+  @Test
+  void hidesPhaseTimestampsForUnmatchedRealDeploymentFallback() {
+    LatestDeploymentUnion union =
+        LatestDeploymentUnion.realDeployment(deployment(1L), heliosDeployment(2L));
+
+    assertNull(union.getDeployJobStartedAt());
+    assertNull(union.getDeploymentStartedAt());
+  }
+
+  @Test
+  void hidesPhaseTimestampsForRealDeploymentFallbackWithoutDeploymentId() {
+    LatestDeploymentUnion union =
+        LatestDeploymentUnion.realDeployment(deployment(1L), heliosDeployment(null));
+
+    assertNull(union.getDeployJobStartedAt());
+    assertNull(union.getDeploymentStartedAt());
+  }
+
+  private Deployment deployment(Long id) {
+    Deployment deployment = new Deployment();
+    deployment.setId(id);
+    return deployment;
+  }
+
+  private HeliosDeployment heliosDeployment(Long deploymentId) {
+    HeliosDeployment heliosDeployment = new HeliosDeployment();
+    heliosDeployment.setDeploymentId(deploymentId);
+    heliosDeployment.setCreatedAt(OffsetDateTime.parse("2026-04-23T09:50:00Z"));
+    heliosDeployment.setDeployJobStartedAt(DEPLOY_JOB_STARTED_AT);
+    heliosDeployment.setDeploymentStartedAt(DEPLOYMENT_STARTED_AT);
+    return heliosDeployment;
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncServiceTest.java
@@ -1,0 +1,119 @@
+package de.tum.cit.aet.helios.deployment.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.deployment.Deployment;
+import de.tum.cit.aet.helios.deployment.DeploymentRepository;
+import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
+import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GitHubDeploymentSyncServiceTest {
+
+  @Mock private DeploymentRepository deploymentRepository;
+  @Mock private PullRequestRepository pullRequestRepository;
+  @Mock private DeploymentConverter deploymentConverter;
+  @Mock private HeliosDeploymentRepository heliosDeploymentRepository;
+
+  @InjectMocks private GitHubDeploymentSyncService gitHubDeploymentSyncService;
+
+  @Test
+  void processDeploymentLatchesDeploymentStartedAtWhenDeploymentTurnsInProgress() {
+    final OffsetDateTime deploymentStartedAt = OffsetDateTime.parse("2026-04-23T10:15:00Z");
+
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(42L);
+
+    Environment environment = new Environment();
+    environment.setName("test");
+
+    HeliosDeployment heliosDeployment = new HeliosDeployment();
+    heliosDeployment.setEnvironment(environment);
+    heliosDeployment.setBranchName("main");
+    heliosDeployment.setUpdatedAt(deploymentStartedAt.minusMinutes(1));
+
+    DeploymentSource deploymentSource = mock(DeploymentSource.class);
+    when(deploymentSource.getId()).thenReturn(99L);
+    when(deploymentRepository.findById(99L)).thenReturn(Optional.empty());
+    doAnswer(invocation -> {
+      Deployment deployment = invocation.getArgument(1);
+      deployment.setId(99L);
+      deployment.setRef("main");
+      deployment.setSha("abc123");
+      deployment.setState(Deployment.State.IN_PROGRESS);
+      deployment.setUpdatedAt(deploymentStartedAt);
+      return deployment;
+    }).when(deploymentConverter).update(any(DeploymentSource.class), any(Deployment.class));
+    when(pullRequestRepository.findOpenPrByBranchNameOrSha(42L, "main", "abc123"))
+        .thenReturn(Optional.empty());
+    when(
+            heliosDeploymentRepository
+                .findTopByEnvironmentAndBranchNameOrderByCreatedAtDesc(environment, "main"))
+        .thenReturn(Optional.of(heliosDeployment));
+
+    gitHubDeploymentSyncService.processDeployment(
+        deploymentSource, repository, environment, null);
+
+    assertEquals(deploymentStartedAt, heliosDeployment.getDeploymentStartedAt());
+    assertEquals(HeliosDeployment.Status.IN_PROGRESS, heliosDeployment.getStatus());
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+  }
+
+  @Test
+  void processDeploymentDoesNotOverwriteExistingDeploymentStartedAt() {
+    final OffsetDateTime firstDeploymentStart = OffsetDateTime.parse("2026-04-23T10:15:00Z");
+    final OffsetDateTime laterStatusUpdate = OffsetDateTime.parse("2026-04-23T10:18:00Z");
+
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(42L);
+
+    Environment environment = new Environment();
+    environment.setName("test");
+
+    HeliosDeployment heliosDeployment = new HeliosDeployment();
+    heliosDeployment.setEnvironment(environment);
+    heliosDeployment.setBranchName("main");
+    heliosDeployment.setDeploymentStartedAt(firstDeploymentStart);
+    heliosDeployment.setUpdatedAt(firstDeploymentStart);
+
+    DeploymentSource deploymentSource = mock(DeploymentSource.class);
+    when(deploymentSource.getId()).thenReturn(100L);
+    when(deploymentRepository.findById(100L)).thenReturn(Optional.empty());
+    doAnswer(invocation -> {
+      Deployment deployment = invocation.getArgument(1);
+      deployment.setId(100L);
+      deployment.setRef("main");
+      deployment.setSha("abc123");
+      deployment.setState(Deployment.State.IN_PROGRESS);
+      deployment.setUpdatedAt(laterStatusUpdate);
+      return deployment;
+    }).when(deploymentConverter).update(any(DeploymentSource.class), any(Deployment.class));
+    when(pullRequestRepository.findOpenPrByBranchNameOrSha(42L, "main", "abc123"))
+        .thenReturn(Optional.empty());
+    when(
+            heliosDeploymentRepository
+                .findTopByEnvironmentAndBranchNameOrderByCreatedAtDesc(environment, "main"))
+        .thenReturn(Optional.of(heliosDeployment));
+
+    gitHubDeploymentSyncService.processDeployment(
+        deploymentSource, repository, environment, null);
+
+    assertEquals(firstDeploymentStart, heliosDeployment.getDeploymentStartedAt());
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
@@ -70,7 +70,7 @@ class GitHubWorkflowJobTimingServiceTest {
     workflowRun.setId(23716064328L);
     workflowRun.setWorkflow(deploymentWorkflow);
     workflowRun.setRunStartedAt(OffsetDateTime.parse("2026-03-29T18:31:40Z"));
-    final GitHubWorkflowJobPayload payload = payload("deploy");
+    final GitHubWorkflowJobPayload payload = payload("completed", "completed", "deploy");
 
     when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
         .thenReturn(Optional.of(config));
@@ -87,11 +87,51 @@ class GitHubWorkflowJobTimingServiceTest {
   }
 
   @Test
+  void persistDurationsPersistsDeployJobStartOnInProgress() {
+    final GitHubWorkflowJobPayload payload = payload("in_progress", "in_progress", "deploy");
+
+    when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
+        .thenReturn(Optional.of(config));
+    when(heliosDeploymentRepository.findByWorkflowRunId(anyLong()))
+        .thenReturn(Optional.of(heliosDeployment));
+    when(workflowRunRepository.findById(any(Long.class))).thenReturn(Optional.empty());
+
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    assertEquals(
+        OffsetDateTime.parse("2026-03-29T18:31:53Z"),
+        heliosDeployment.getDeployJobStartedAt());
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+  }
+
+  @Test
+  void persistDurationsSplitsUsingPersistedDeploymentStartWhenAvailable() {
+    heliosDeployment.setDeployJobStartedAt(OffsetDateTime.parse("2026-03-29T18:31:53Z"));
+    heliosDeployment.setDeploymentStartedAt(OffsetDateTime.parse("2026-03-29T18:31:58Z"));
+    WorkflowRun workflowRun = new WorkflowRun();
+    workflowRun.setId(23716064328L);
+    workflowRun.setWorkflow(deploymentWorkflow);
+    final GitHubWorkflowJobPayload payload = payload("completed", "completed", "deploy");
+
+    when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
+        .thenReturn(Optional.of(config));
+    when(heliosDeploymentRepository.findByWorkflowRunId(anyLong()))
+        .thenReturn(Optional.of(heliosDeployment));
+    when(workflowRunRepository.findById(any(Long.class))).thenReturn(Optional.of(workflowRun));
+
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    assertEquals(Integer.valueOf(5), heliosDeployment.getBuildDurationSeconds());
+    assertEquals(Integer.valueOf(8), heliosDeployment.getDeployDurationSeconds());
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+  }
+
+  @Test
   void persistDurationsFallsBackToDeploymentCreatedAtAndBranchMatch() {
     WorkflowRun workflowRun = new WorkflowRun();
     workflowRun.setId(23716064328L);
     workflowRun.setWorkflow(deploymentWorkflow);
-    final GitHubWorkflowJobPayload payload = payload("deploy");
+    final GitHubWorkflowJobPayload payload = payload("completed", "completed", "deploy");
 
     when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
         .thenReturn(Optional.of(config));
@@ -113,8 +153,10 @@ class GitHubWorkflowJobTimingServiceTest {
     WorkflowRun workflowRun = new WorkflowRun();
     workflowRun.setId(23716064328L);
     workflowRun.setWorkflow(otherWorkflow);
-    GitHubWorkflowJobPayload payload = payload("deploy");
+    final GitHubWorkflowJobPayload payload = payload("completed", "completed", "deploy");
 
+    when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
+        .thenReturn(Optional.of(config));
     when(heliosDeploymentRepository.findByWorkflowRunId(anyLong()))
         .thenReturn(Optional.of(heliosDeployment));
     when(workflowRunRepository.findById(any(Long.class))).thenReturn(Optional.of(workflowRun));
@@ -126,7 +168,7 @@ class GitHubWorkflowJobTimingServiceTest {
 
   @Test
   void persistDurationsSkipsNonConfiguredJobs() {
-    GitHubWorkflowJobPayload payload = payload("build");
+    GitHubWorkflowJobPayload payload = payload("completed", "completed", "build");
 
     when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
         .thenReturn(Optional.of(config));
@@ -138,9 +180,10 @@ class GitHubWorkflowJobTimingServiceTest {
     verify(heliosDeploymentRepository, never()).save(any());
   }
 
-  private GitHubWorkflowJobPayload payload(String jobName) {
+  private GitHubWorkflowJobPayload payload(
+      String action, String workflowJobStatus, String jobName) {
     return new GitHubWorkflowJobPayload(
-        "completed",
+        action,
         new GitHubWorkflowJobPayload.WorkflowJob(
             69083291077L,
             23716064328L,
@@ -148,7 +191,7 @@ class GitHubWorkflowJobTimingServiceTest {
             "new-branch",
             "b49e899f86b523027348c31adce8d7b41ac0cb00",
             "https://github.com/mert-test-org/helios-test-repo/actions/runs/23716064328/job/69083291077",
-            "completed",
+            workflowJobStatus,
             "success",
             OffsetDateTime.parse("2026-03-29T18:31:49Z"),
             OffsetDateTime.parse("2026-03-29T18:31:53Z"),


### PR DESCRIPTION
### Motivation
Deployment progress timers currently depend on client-side state transitions, so they can reset or show inaccurate elapsed/remaining time after refreshes or delayed webhook updates. The deployment stepper needs persisted phase start timestamps from the backend so it can distinguish pre-deployment time from actual deployment time consistently.

### Description
- Adds `deploy_job_started_at` and `deployment_started_at` columns to `helios_deployment`.
- Persists the deploy job start timestamp from `workflow_job` `in_progress` webhook events.
- Persists the deployment phase start timestamp when the linked GitHub deployment enters `IN_PROGRESS`.
- Uses the persisted timestamps when calculating build/deploy durations after the deploy job completes.
- Exposes the new timestamps through `EnvironmentDto`, OpenAPI, and generated client types.
- Updates the client deployment timing service to anchor progress, remaining time, and final duration to persisted phase timestamps.
- Adds focused server and client tests for timestamp persistence and timer behavior.

### Testing Instructions
#### Prerequisites:
- Local Helios development setup with server and client dependencies installed.
- Local database available if testing the migration manually.
- GitHub Account without having any additional access-rights, e.g. admin or owner.

#### Flow:
1. Log in to Helios as a Developer.
2. Navigate to an environment with an active deployment.
3. Verify that the pre-deployment timer starts when the configured deploy job starts.
4. Verify that the deployment step becomes active once the GitHub deployment enters `IN_PROGRESS`.
5. Refresh the page during an active deployment and verify that the timer continues from the persisted timestamps instead of resetting.

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices