### PR TITLE
refactor: simplify label rendering and improve color handling in pull request table component

### DIFF
--- a/client/src/app/components/pull-request-table/pull-request-table.component.ts
+++ b/client/src/app/components/pull-request-table/pull-request-table.component.ts
@@ -156,6 +156,7 @@ export class PullRequestTableComponent {
     return {
       'border-color': `#${color}`,
       'background-color': color === 'ededed' ? `#${color}` : `#${color}75`,
+      ...(color === 'ededed' && { color: '#000000' }),
     };
   }
 


### PR DESCRIPTION
### Motivation
Pull request tags with background #ededed is not readable. 

### Description
- Adjusts text color to make labels readable by changing text color to black.

### Testing Instructions
#### Prerequisites:
- GitHub account with Developer access to Helios.
- A configured repository that has pull requests with GitHub labels in multiple colors.
- Helios running with the client available in light and dark mode.

#### Flow:
1. Log in to Helios as a Developer.
2. Navigate to a repository with labeled pull requests.
3. Open the pull request table.
4. Verify that label text remains readable for light, dark, and saturated label colors.
5. Switch between light and dark mode and verify the labels still have sufficient contrast.

### Screenshots:

Before:
<img width="1065" height="509" alt="Screenshot 2026-05-08 at 13 08 56" src="https://github.com/user-attachments/assets/3018e1ae-ca5d-4710-982a-248ea339742b" />


After:
<img width="1065" height="509" alt="Screenshot 2026-05-08 at 13 08 37" src="https://github.com/user-attachments/assets/890f7c82-7e6e-4d4e-b752-98b35e73de5a" />

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Client
- [x] I documented the TypeScript code using JSDoc style.