### PR TITLE
feat: implement workflow run cancellation synchronization and add HeliosDeploymentWorkflowRunSyncService

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -27,6 +27,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -42,6 +43,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class DeploymentService {
 
+  private static final String COMPLETED_WORKFLOW_RUN_CANCELLATION_MESSAGE =
+      "cannot cancel a workflow run that is completed";
+
   private final DeploymentRepository deploymentRepository;
   private final GitHubService gitHubService;
   private final EnvironmentService environmentService;
@@ -51,6 +55,7 @@ public class DeploymentService {
   private final EnvironmentRepository environmentRepository;
   private final PullRequestRepository pullRequestRepository;
   private final GitRepoRepository gitRepoRepository;
+  private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
 
   public Optional<DeploymentDto> getDeploymentById(Long id) {
     return deploymentRepository.findById(id).map(DeploymentDto::fromDeployment);
@@ -441,8 +446,43 @@ public class DeploymentService {
 
       return "Workflow cancellation request sent successfully";
     } catch (IOException e) {
-      throw new DeploymentException("Failed to cancel workflow run: " + e.getMessage(), e);
+      if (isCompletedWorkflowRunCancellationError(e)
+          && syncTerminalWorkflowRunStateAfterFailedCancellation(workflowRunId)) {
+        return "Workflow run already completed; deployment status synchronized from GitHub";
+      }
+      throw new DeploymentException(e.getMessage(), e);
     }
+  }
+
+  private boolean isCompletedWorkflowRunCancellationError(IOException exception) {
+    String message = exception.getMessage();
+    if (message == null) {
+      return false;
+    }
+
+    String normalizedMessage = message.toLowerCase(Locale.ROOT);
+    return normalizedMessage.contains(COMPLETED_WORKFLOW_RUN_CANCELLATION_MESSAGE);
+  }
+
+  private boolean syncTerminalWorkflowRunStateAfterFailedCancellation(Long workflowRunId) {
+    Long repositoryId = RepositoryContext.getRepositoryId();
+    return gitRepoRepository
+        .findById(repositoryId)
+        .map(GitRepository::getNameWithOwner)
+        .map(repositoryNameWithOwner -> {
+          try {
+            return heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+                repositoryNameWithOwner, workflowRunId);
+          } catch (IOException syncException) {
+            log.warn(
+                "Failed to synchronize deployment state for workflow run {} after cancellation"
+                    + " failed: {}",
+                workflowRunId,
+                syncException.getMessage());
+            return false;
+          }
+        })
+        .orElse(false);
   }
 
   /**

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncService.java
@@ -1,0 +1,139 @@
+package de.tum.cit.aet.helios.deployment;
+
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
+import de.tum.cit.aet.helios.workflow.WorkflowRun;
+import de.tum.cit.aet.helios.workflow.github.GitHubWorkflowRunStateMapper;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class HeliosDeploymentWorkflowRunSyncService {
+
+  private final GitHubService gitHubService;
+  private final HeliosDeploymentRepository heliosDeploymentRepository;
+  private final DeploymentRepository deploymentRepository;
+
+  @Transactional
+  public boolean synchronizeTerminalStateFromWorkflowRun(
+      String repositoryNameWithOwner, Long workflowRunId) throws IOException {
+    if (workflowRunId == null) {
+      return false;
+    }
+
+    Optional<GitHubService.WorkflowRunState> maybeWorkflowRunState =
+        gitHubService.getWorkflowRunState(repositoryNameWithOwner, workflowRunId);
+    if (maybeWorkflowRunState.isEmpty()) {
+      return false;
+    }
+
+    Optional<HeliosDeployment.Status> maybeTerminalStatus =
+        mapTerminalWorkflowRunState(maybeWorkflowRunState.get());
+    if (maybeTerminalStatus.isEmpty()) {
+      return false;
+    }
+
+    Optional<HeliosDeployment> maybeHeliosDeployment =
+        heliosDeploymentRepository.findByWorkflowRunId(workflowRunId);
+    if (maybeHeliosDeployment.isEmpty()) {
+      log.warn("No Helios deployment found for workflow run {}", workflowRunId);
+      return false;
+    }
+
+    updateHeliosDeployment(
+        maybeHeliosDeployment.get(), maybeTerminalStatus.get(), maybeWorkflowRunState.get());
+    return true;
+  }
+
+  private void updateHeliosDeployment(
+      HeliosDeployment heliosDeployment,
+      HeliosDeployment.Status terminalStatus,
+      GitHubService.WorkflowRunState workflowRunState) {
+    boolean statusChanged = heliosDeployment.getStatus() != terminalStatus;
+    boolean timestampAdvanced =
+        isRemoteTimestampNewer(workflowRunState.updatedAt(), heliosDeployment.getUpdatedAt());
+
+    if (statusChanged) {
+      heliosDeployment.setStatus(terminalStatus);
+    }
+    if (timestampAdvanced) {
+      heliosDeployment.setUpdatedAt(workflowRunState.updatedAt());
+    }
+
+    if (statusChanged || timestampAdvanced) {
+      heliosDeploymentRepository.save(heliosDeployment);
+    }
+
+    if (heliosDeployment.getDeploymentId() != null) {
+      updateLinkedDeployment(heliosDeployment, workflowRunState.updatedAt());
+    }
+  }
+
+  private void updateLinkedDeployment(
+      HeliosDeployment heliosDeployment, OffsetDateTime workflowRunUpdatedAt) {
+    deploymentRepository
+        .findById(heliosDeployment.getDeploymentId())
+        .ifPresent(deployment -> {
+          Deployment.State deploymentState =
+              HeliosDeployment.mapHeliosStatusToDeploymentState(heliosDeployment.getStatus());
+          boolean stateChanged = deployment.getState() != deploymentState;
+          boolean timestampAdvanced =
+              isRemoteTimestampNewer(workflowRunUpdatedAt, deployment.getUpdatedAt());
+
+          if (stateChanged) {
+            deployment.setState(deploymentState);
+          }
+          if (timestampAdvanced) {
+            deployment.setUpdatedAt(workflowRunUpdatedAt);
+          }
+          if (stateChanged || timestampAdvanced) {
+            deploymentRepository.save(deployment);
+          }
+        });
+  }
+
+  private Optional<HeliosDeployment.Status> mapTerminalWorkflowRunState(
+      GitHubService.WorkflowRunState workflowRunState) {
+    WorkflowRun.Status status = GitHubWorkflowRunStateMapper.mapStatus(workflowRunState.status());
+    WorkflowRun.Conclusion conclusion =
+        GitHubWorkflowRunStateMapper.mapConclusion(workflowRunState.conclusion());
+
+    if (status == null) {
+      return Optional.empty();
+    }
+
+    return switch (status) {
+      case COMPLETED -> Optional.of(mapCompletedConclusion(conclusion));
+      case CANCELLED -> Optional.of(HeliosDeployment.Status.CANCELLED);
+      case FAILURE, ACTION_REQUIRED, TIMED_OUT -> Optional.of(HeliosDeployment.Status.FAILED);
+      case SUCCESS -> Optional.of(HeliosDeployment.Status.DEPLOYMENT_SUCCESS);
+      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> Optional.of(HeliosDeployment.Status.UNKNOWN);
+      case QUEUED, IN_PROGRESS, REQUESTED, WAITING, PENDING -> Optional.empty();
+    };
+  }
+
+  private HeliosDeployment.Status mapCompletedConclusion(WorkflowRun.Conclusion conclusion) {
+    if (conclusion == null) {
+      return HeliosDeployment.Status.UNKNOWN;
+    }
+
+    return switch (conclusion) {
+      case SUCCESS -> HeliosDeployment.Status.DEPLOYMENT_SUCCESS;
+      case CANCELLED -> HeliosDeployment.Status.CANCELLED;
+      case FAILURE, STARTUP_FAILURE, TIMED_OUT, ACTION_REQUIRED -> HeliosDeployment.Status.FAILED;
+      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> HeliosDeployment.Status.UNKNOWN;
+    };
+  }
+
+  private boolean isRemoteTimestampNewer(OffsetDateTime remote, OffsetDateTime local) {
+    return remote != null && (local == null || remote.isAfter(local));
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncService.java
@@ -110,26 +110,12 @@ public class HeliosDeploymentWorkflowRunSyncService {
       return Optional.empty();
     }
 
-    return switch (status) {
-      case COMPLETED -> Optional.of(mapCompletedConclusion(conclusion));
-      case CANCELLED -> Optional.of(HeliosDeployment.Status.CANCELLED);
-      case FAILURE, ACTION_REQUIRED, TIMED_OUT -> Optional.of(HeliosDeployment.Status.FAILED);
-      case SUCCESS -> Optional.of(HeliosDeployment.Status.DEPLOYMENT_SUCCESS);
-      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> Optional.of(HeliosDeployment.Status.UNKNOWN);
-      case QUEUED, IN_PROGRESS, REQUESTED, WAITING, PENDING -> Optional.empty();
-    };
-  }
+    HeliosDeployment.Status mappedStatus =
+        HeliosDeployment.mapWorkflowRunStatus(status, conclusion);
 
-  private HeliosDeployment.Status mapCompletedConclusion(WorkflowRun.Conclusion conclusion) {
-    if (conclusion == null) {
-      return HeliosDeployment.Status.UNKNOWN;
-    }
-
-    return switch (conclusion) {
-      case SUCCESS -> HeliosDeployment.Status.DEPLOYMENT_SUCCESS;
-      case CANCELLED -> HeliosDeployment.Status.CANCELLED;
-      case FAILURE, STARTUP_FAILURE, TIMED_OUT, ACTION_REQUIRED -> HeliosDeployment.Status.FAILED;
-      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> HeliosDeployment.Status.UNKNOWN;
+    return switch (mappedStatus) {
+      case WAITING, QUEUED, IN_PROGRESS -> Optional.empty();
+      default -> Optional.of(mappedStatus);
     };
   }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
@@ -51,17 +51,25 @@ public class OrphanHeliosDeploymentRecoveryService {
     for (HeliosDeployment deployment : stuckDeployments) {
       String repositoryNameWithOwner =
           deployment.getEnvironment().getRepository().getNameWithOwner();
+      boolean wasSynchronized = false;
       try {
-        if (heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
-            repositoryNameWithOwner, deployment.getWorkflowRunId())) {
-          synchronizedCount++;
-        }
+        wasSynchronized =
+            heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+                repositoryNameWithOwner, deployment.getWorkflowRunId());
       } catch (IOException e) {
         log.warn(
             "Failed to synchronize stuck Helios deployment {} from workflow run {}: {}",
             deployment.getId(),
             deployment.getWorkflowRunId(),
             e.getMessage());
+      }
+
+      if (wasSynchronized) {
+        synchronizedCount++;
+      } else if (deployment.getDeploymentId() == null) {
+        // Preserve the original safety net: orphan rows (no linked Deployment) must be
+        // force-finalized after the threshold even when GitHub did not yield a terminal state.
+        markStuckHeliosDeploymentAsFailed(deployment);
       }
     }
 
@@ -84,16 +92,20 @@ public class OrphanHeliosDeploymentRecoveryService {
 
     int updatedCount = 0;
     for (HeliosDeployment deployment : stuckDeployments) {
-      log.warn(
-          "Marking Helios deployment {} as FAILED, stuck in {} state since {}",
-          deployment.getId(),
-          deployment.getStatus(),
-          deployment.getStatusUpdatedAt());
-
-      deployment.setStatus(HeliosDeployment.Status.FAILED);
-      heliosDeploymentRepository.save(deployment);
+      markStuckHeliosDeploymentAsFailed(deployment);
       updatedCount++;
     }
     return updatedCount;
+  }
+
+  private void markStuckHeliosDeploymentAsFailed(HeliosDeployment deployment) {
+    log.warn(
+        "Marking Helios deployment {} as FAILED, stuck in {} state since {}",
+        deployment.getId(),
+        deployment.getStatus(),
+        deployment.getStatusUpdatedAt());
+
+    deployment.setStatus(HeliosDeployment.Status.FAILED);
+    heliosDeploymentRepository.save(deployment);
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.helios.deployment;
 
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrphanHeliosDeploymentRecoveryService {
 
   private final HeliosDeploymentRepository heliosDeploymentRepository;
+  private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
 
   /**
    * Scheduled task that runs every hour and force-finalizes very old orphan Helios deployments.
@@ -31,17 +33,45 @@ public class OrphanHeliosDeploymentRecoveryService {
     log.info("Starting orphan Helios deployment recovery task...");
     OffsetDateTime oneHourAgo = OffsetDateTime.now().minusHours(1);
 
+    int synchronizedCount = synchronizeStuckWorkflowRunBackedDeployments(oneHourAgo);
     int recoveredCount = processStuckHeliosDeployments(oneHourAgo);
 
     log.info(
-        "Orphan Helios deployment recovery completed: Marked {} deployment(s) without"
-            + " deploymentId as FAILED.",
+        "Orphan Helios deployment recovery completed: synchronized {} workflow-backed"
+            + " deployment(s), marked {} deployment(s) without workflowRunId as FAILED.",
+        synchronizedCount,
         recoveredCount);
+  }
+
+  private int synchronizeStuckWorkflowRunBackedDeployments(OffsetDateTime timeThreshold) {
+    List<HeliosDeployment> stuckDeployments =
+        heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(timeThreshold);
+
+    int synchronizedCount = 0;
+    for (HeliosDeployment deployment : stuckDeployments) {
+      String repositoryNameWithOwner =
+          deployment.getEnvironment().getRepository().getNameWithOwner();
+      try {
+        if (heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            repositoryNameWithOwner, deployment.getWorkflowRunId())) {
+          synchronizedCount++;
+        }
+      } catch (IOException e) {
+        log.warn(
+            "Failed to synchronize stuck Helios deployment {} from workflow run {}: {}",
+            deployment.getId(),
+            deployment.getWorkflowRunId(),
+            e.getMessage());
+      }
+    }
+
+    return synchronizedCount;
   }
 
   private int processStuckHeliosDeployments(OffsetDateTime timeThreshold) {
     List<HeliosDeployment> stuckDeployments =
-        heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentId(timeThreshold);
+        heliosDeploymentRepository
+            .findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(timeThreshold);
 
     if (stuckDeployments.isEmpty()) {
       log.debug("No stuck Helios deployments found.");

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -1053,28 +1053,27 @@ public class GitHubService {
       }
     }
 
-    // Try to parse the JSON error response if we have a body
     if (!responseBodyString.isEmpty()) {
       try {
         Map<String, Object> errorResponse = objectMapper.readValue(responseBodyString, Map.class);
-        String githubMessage = (String) errorResponse.get("message");
+        String githubMessage =
+            errorResponse == null ? null : (String) errorResponse.get("message");
 
-        if (githubMessage != null) {
-          throw new IOException("GitHub API error: " + githubMessage);
+        if (githubMessage != null && !githubMessage.isBlank()) {
+          throw new IOException(githubMessage);
         }
-      } catch (Exception e) {
-        // JSON parsing failed, log but continue to fallback
+      } catch (JsonProcessingException e) {
         log.warn("Failed to parse GitHub error response: {}", e.getMessage());
       }
+
+      throw new IOException(responseBodyString);
     }
 
-    // Fallback for empty or unparseable responses
     throw new IOException(
         "GitHub API "
             + context
             + " failed with response code: "
-            + response.code()
-            + (!responseBodyString.isEmpty() ? " and body: " + responseBodyString : ""));
+            + response.code());
   }
 
   private OffsetDateTime parseOffsetDateTime(JsonNode node) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
@@ -4,6 +4,7 @@ import de.tum.cit.aet.helios.deployment.Deployment;
 import de.tum.cit.aet.helios.environment.Environment;
 import de.tum.cit.aet.helios.pullrequest.PullRequest;
 import de.tum.cit.aet.helios.user.User;
+import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -24,7 +25,6 @@ import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-import org.kohsuke.github.GHWorkflowRun;
 
 @Entity
 @Table(name = "helios_deployment")
@@ -137,24 +137,30 @@ public class HeliosDeployment {
     this.statusUpdatedAt = OffsetDateTime.now();
   }
 
-  public static HeliosDeployment.Status mapWorkflowRunStatus(
-      GHWorkflowRun.Status workflowStatus, GHWorkflowRun.Conclusion workflowConclusion) {
-    if (workflowStatus == GHWorkflowRun.Status.PENDING) {
-      return Status.WAITING;
-    } else if (workflowStatus == GHWorkflowRun.Status.QUEUED) {
-      return Status.QUEUED;
-    } else if (workflowStatus == GHWorkflowRun.Status.IN_PROGRESS) {
-      return HeliosDeployment.Status.IN_PROGRESS;
-    } else if (workflowStatus == GHWorkflowRun.Status.COMPLETED) {
-      return switch (workflowConclusion) {
-        case SUCCESS -> Status.DEPLOYMENT_SUCCESS;
-        case CANCELLED -> Status.CANCELLED;
-        case FAILURE, STARTUP_FAILURE, TIMED_OUT -> Status.FAILED;
-        default -> Status.UNKNOWN;
-      };
-    } else {
+  public static Status mapWorkflowRunStatus(
+      WorkflowRun.Status status, WorkflowRun.Conclusion conclusion) {
+    return switch (status) {
+      case PENDING, WAITING, REQUESTED -> Status.WAITING;
+      case QUEUED -> Status.QUEUED;
+      case IN_PROGRESS -> Status.IN_PROGRESS;
+      case COMPLETED -> mapCompletedConclusion(conclusion);
+      case CANCELLED -> Status.CANCELLED;
+      case SUCCESS -> Status.DEPLOYMENT_SUCCESS;
+      case FAILURE, ACTION_REQUIRED, TIMED_OUT -> Status.FAILED;
+      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> Status.UNKNOWN;
+    };
+  }
+
+  private static Status mapCompletedConclusion(WorkflowRun.Conclusion conclusion) {
+    if (conclusion == null) {
       return Status.UNKNOWN;
     }
+    return switch (conclusion) {
+      case SUCCESS -> Status.DEPLOYMENT_SUCCESS;
+      case CANCELLED -> Status.CANCELLED;
+      case FAILURE, STARTUP_FAILURE, TIMED_OUT, ACTION_REQUIRED -> Status.FAILED;
+      case NEUTRAL, SKIPPED, STALE, UNKNOWN -> Status.UNKNOWN;
+    };
   }
 
   public static Deployment.State mapHeliosStatusToDeploymentState(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
@@ -76,9 +76,20 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
    */
   @Query(
       "SELECT hd FROM HeliosDeployment hd "
+          + "JOIN FETCH hd.environment e "
+          + "JOIN FETCH e.repository r "
           + "WHERE hd.status IN ('IN_PROGRESS', 'WAITING', 'QUEUED') "
           + "AND hd.statusUpdatedAt < :threshold "
-          + "AND hd.deploymentId IS NULL")
-  List<HeliosDeployment> findStuckDeploymentsWithoutDeploymentId(
+          + "AND hd.workflowRunId IS NOT NULL")
+  List<HeliosDeployment> findStuckDeploymentsWithWorkflowRunId(
+      @Param("threshold") OffsetDateTime threshold);
+
+  @Query(
+      "SELECT hd FROM HeliosDeployment hd "
+          + "WHERE hd.status IN ('IN_PROGRESS', 'WAITING', 'QUEUED') "
+          + "AND hd.statusUpdatedAt < :threshold "
+          + "AND hd.deploymentId IS NULL "
+          + "AND hd.workflowRunId IS NULL")
+  List<HeliosDeployment> findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
       @Param("threshold") OffsetDateTime threshold);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -1,7 +1,5 @@
 package de.tum.cit.aet.helios.workflow.github;
 
-import static de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment.mapWorkflowRunStatus;
-
 import de.tum.cit.aet.helios.github.GitHubClientManager;
 import de.tum.cit.aet.helios.github.GitHubFacade;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -260,7 +258,8 @@ public class GitHubWorkflowRunSyncService {
                   heliosDeployment.setUpdatedAt(
                       DateUtil.convertToOffsetDateTime(workflowRun.getUpdatedAt()));
                   HeliosDeployment.Status mappedStatus =
-                      mapWorkflowRunStatus(workflowRun.getStatus(), workflowRun.getConclusion());
+                      mapLiveWorkflowRunStatus(
+                          workflowRun.getStatus(), workflowRun.getConclusion());
                   log.debug("Mapped status {} to {}", workflowRun.getStatus(), mappedStatus);
 
                   try {
@@ -321,5 +320,25 @@ public class GitHubWorkflowRunSyncService {
                 e.printStackTrace();
               }
             });
+  }
+
+  static HeliosDeployment.Status mapLiveWorkflowRunStatus(
+      GHWorkflowRun.Status workflowStatus, GHWorkflowRun.Conclusion workflowConclusion) {
+    if (workflowStatus == GHWorkflowRun.Status.PENDING) {
+      return HeliosDeployment.Status.WAITING;
+    } else if (workflowStatus == GHWorkflowRun.Status.QUEUED) {
+      return HeliosDeployment.Status.QUEUED;
+    } else if (workflowStatus == GHWorkflowRun.Status.IN_PROGRESS) {
+      return HeliosDeployment.Status.IN_PROGRESS;
+    } else if (workflowStatus == GHWorkflowRun.Status.COMPLETED) {
+      return switch (workflowConclusion) {
+        case SUCCESS -> HeliosDeployment.Status.DEPLOYMENT_SUCCESS;
+        case CANCELLED -> HeliosDeployment.Status.CANCELLED;
+        case FAILURE, STARTUP_FAILURE, TIMED_OUT -> HeliosDeployment.Status.FAILED;
+        default -> HeliosDeployment.Status.UNKNOWN;
+      };
+    } else {
+      return HeliosDeployment.Status.UNKNOWN;
+    }
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
@@ -6,7 +6,9 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -18,19 +20,23 @@ import de.tum.cit.aet.helios.environment.EnvironmentLockHistory;
 import de.tum.cit.aet.helios.environment.EnvironmentLockHistoryRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentService;
+import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.github.WorkflowDispatchResult;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import de.tum.cit.aet.helios.pullrequest.PullRequestRepository;
 import de.tum.cit.aet.helios.workflow.Workflow;
 import de.tum.cit.aet.helios.workflow.WorkflowService;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,6 +63,8 @@ public class DeploymentServiceTest {
   @Mock private EnvironmentRepository environmentRepository;
   @Mock private BranchService branchService;
   @Mock private PullRequestRepository pullRequestRepository;
+  @Mock private GitRepoRepository gitRepoRepository;
+  @Mock private HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
 
   private Deployment deployment;
   private GitRepository gitRepository;
@@ -65,6 +73,7 @@ public class DeploymentServiceTest {
 
   @BeforeEach
   public void setUp() {
+    RepositoryContext.setRepositoryId("1");
     heliosDeployment = new HeliosDeployment();
     heliosDeployment.setId(1L);
     heliosDeployment.setEnvironment(environment);
@@ -81,6 +90,11 @@ public class DeploymentServiceTest {
     deployment.setId(1L);
     deployment.setRepository(gitRepository);
     deployment.setEnvironment(environment);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    RepositoryContext.clear();
   }
 
   @Test
@@ -477,5 +491,75 @@ public class DeploymentServiceTest {
     when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
         .thenReturn(Optional.of(heliosDeployment));
     assertFalse((boolean) canRedeployMethod.invoke(deploymentService, environment, 10L));
+  }
+
+  @Test
+  public void testCancelDeploymentMarksHeliosDeploymentCancelled() throws Exception {
+    heliosDeployment.setWorkflowRunId(123L);
+
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(gitRepository));
+    when(heliosDeploymentRepository.findByWorkflowRunId(123L))
+        .thenReturn(Optional.of(heliosDeployment));
+
+    String result = deploymentService.cancelDeployment(new CancelDeploymentRequest(123L));
+
+    assertEquals("Workflow cancellation request sent successfully", result);
+    assertEquals(HeliosDeployment.Status.CANCELLED, heliosDeployment.getStatus());
+    verify(gitHubService).cancelWorkflowRun("owner/repo", 123L);
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+  }
+
+  @Test
+  public void testCancelDeploymentSynchronizesTerminalStateWhenGitHubRunAlreadyCompleted()
+      throws Exception {
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(gitRepository));
+    org.mockito.Mockito.doThrow(new IOException("Cannot cancel a workflow run that is completed."))
+        .when(gitHubService)
+        .cancelWorkflowRun("owner/repo", 123L);
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            eq("owner/repo"), eq(123L)))
+        .thenReturn(true);
+
+    String result = deploymentService.cancelDeployment(new CancelDeploymentRequest(123L));
+
+    assertEquals("Workflow run already completed; deployment status synchronized from GitHub",
+        result);
+  }
+
+  @Test
+  public void testCancelDeploymentReturnsGithubErrorWhenSynchronizationCannotRecover()
+      throws Exception {
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(gitRepository));
+    org.mockito.Mockito.doThrow(new IOException("Cannot cancel a workflow run that is completed."))
+        .when(gitHubService)
+        .cancelWorkflowRun("owner/repo", 123L);
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            eq("owner/repo"), eq(123L)))
+        .thenReturn(false);
+
+    DeploymentException exception =
+        assertThrows(
+            DeploymentException.class,
+            () -> deploymentService.cancelDeployment(new CancelDeploymentRequest(123L)));
+
+    assertEquals("Cannot cancel a workflow run that is completed.", exception.getMessage());
+  }
+
+  @Test
+  public void testCancelDeploymentReturnsGithubErrorWithoutSyncForOtherFailures()
+      throws Exception {
+    when(gitRepoRepository.findById(1L)).thenReturn(Optional.of(gitRepository));
+    org.mockito.Mockito.doThrow(new IOException("GitHub rate limit exceeded"))
+        .when(gitHubService)
+        .cancelWorkflowRun("owner/repo", 123L);
+
+    DeploymentException exception =
+        assertThrows(
+            DeploymentException.class,
+            () -> deploymentService.cancelDeployment(new CancelDeploymentRequest(123L)));
+
+    assertEquals("GitHub rate limit exceeded", exception.getMessage());
+    verify(heliosDeploymentWorkflowRunSyncService, never())
+        .synchronizeTerminalStateFromWorkflowRun(anyString(), any());
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/HeliosDeploymentWorkflowRunSyncServiceTest.java
@@ -1,0 +1,76 @@
+package de.tum.cit.aet.helios.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HeliosDeploymentWorkflowRunSyncServiceTest {
+
+  @Mock private GitHubService gitHubService;
+  @Mock private HeliosDeploymentRepository heliosDeploymentRepository;
+  @Mock private DeploymentRepository deploymentRepository;
+
+  @InjectMocks private HeliosDeploymentWorkflowRunSyncService syncService;
+
+  @Test
+  void synchronizeTerminalStateFromWorkflowRunUpdatesHeliosAndLinkedDeployment()
+      throws Exception {
+    OffsetDateTime remoteUpdatedAt = OffsetDateTime.now();
+    HeliosDeployment heliosDeployment = new HeliosDeployment();
+    heliosDeployment.setId(1L);
+    heliosDeployment.setWorkflowRunId(123L);
+    heliosDeployment.setDeploymentId(501L);
+    heliosDeployment.setStatus(HeliosDeployment.Status.IN_PROGRESS);
+    heliosDeployment.setUpdatedAt(remoteUpdatedAt.minusMinutes(5));
+
+    Deployment deployment = new Deployment();
+    deployment.setId(501L);
+    deployment.setState(Deployment.State.IN_PROGRESS);
+    deployment.setUpdatedAt(remoteUpdatedAt.minusMinutes(5));
+
+    when(gitHubService.getWorkflowRunState("owner/repo", 123L))
+        .thenReturn(
+            Optional.of(
+                new GitHubService.WorkflowRunState("completed", "success", remoteUpdatedAt)));
+    when(heliosDeploymentRepository.findByWorkflowRunId(123L))
+        .thenReturn(Optional.of(heliosDeployment));
+    when(deploymentRepository.findById(501L)).thenReturn(Optional.of(deployment));
+
+    assertTrue(syncService.synchronizeTerminalStateFromWorkflowRun("owner/repo", 123L));
+
+    assertEquals(HeliosDeployment.Status.DEPLOYMENT_SUCCESS, heliosDeployment.getStatus());
+    assertEquals(Deployment.State.SUCCESS, deployment.getState());
+    assertEquals(remoteUpdatedAt, heliosDeployment.getUpdatedAt());
+    assertEquals(remoteUpdatedAt, deployment.getUpdatedAt());
+    verify(heliosDeploymentRepository).save(heliosDeployment);
+    verify(deploymentRepository).save(deployment);
+  }
+
+  @Test
+  void synchronizeTerminalStateFromWorkflowRunSkipsNonTerminalRuns() throws Exception {
+    when(gitHubService.getWorkflowRunState("owner/repo", 123L))
+        .thenReturn(
+            Optional.of(
+                new GitHubService.WorkflowRunState(
+                    "in_progress", null, OffsetDateTime.now())));
+
+    assertFalse(syncService.synchronizeTerminalStateFromWorkflowRun("owner/repo", 123L));
+
+    verify(heliosDeploymentRepository, never()).findByWorkflowRunId(123L);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
@@ -2,13 +2,19 @@ package de.tum.cit.aet.helios.deployment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -59,6 +65,90 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
   }
 
   @Test
+  void synchronizesWorkflowBackedDeploymentsAndForceFailsOrphansWhenSyncMissesTerminalState()
+      throws IOException {
+    HeliosDeployment synced =
+        createWorkflowBackedHeliosDeployment(10L, 1001L, true, "owner/synced");
+    HeliosDeployment orphanFallback =
+        createWorkflowBackedHeliosDeployment(11L, 1002L, true, "owner/orphan");
+    HeliosDeployment linkedNoSync =
+        createWorkflowBackedHeliosDeployment(12L, 1003L, false, "owner/linked");
+
+    when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
+        .thenReturn(List.of(synced, orphanFallback, linkedNoSync));
+    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any()))
+        .thenReturn(List.of());
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            eq("owner/synced"), eq(1001L)))
+        .thenReturn(true);
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            eq("owner/orphan"), eq(1002L)))
+        .thenReturn(false);
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            eq("owner/linked"), eq(1003L)))
+        .thenReturn(false);
+    when(heliosDeploymentRepository.save(any(HeliosDeployment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    deploymentRecoveryService.markStuckOrphanHeliosDeploymentsAsFailure();
+
+    // Orphan with no terminal state from GitHub falls back to FAILED.
+    assertEquals(HeliosDeployment.Status.FAILED, orphanFallback.getStatus());
+    // Linked deployment (deploymentId != null) is left alone — old code never touched these.
+    assertEquals(HeliosDeployment.Status.IN_PROGRESS, linkedNoSync.getStatus());
+    // Synced row is updated by the sync service (mocked here), so its status is unchanged
+    // in this assertion — what matters is that we did NOT also force-fail it.
+    assertEquals(HeliosDeployment.Status.IN_PROGRESS, synced.getStatus());
+
+    // Only the orphan fallback save should hit the repository.
+    verify(heliosDeploymentRepository, times(1)).save(any(HeliosDeployment.class));
+  }
+
+  @Test
+  void synchronizesAllAndForceFailsNoneWhenSyncCoversEveryStuckDeployment() throws IOException {
+    HeliosDeployment stuck =
+        createWorkflowBackedHeliosDeployment(20L, 2001L, true, "owner/repo");
+
+    when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
+        .thenReturn(List.of(stuck));
+    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any()))
+        .thenReturn(List.of());
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            anyString(), anyLong()))
+        .thenReturn(true);
+
+    deploymentRecoveryService.markStuckOrphanHeliosDeploymentsAsFailure();
+
+    // Sync handled it, so no force-fail save should happen here.
+    verify(heliosDeploymentRepository, never()).save(any(HeliosDeployment.class));
+    assertEquals(HeliosDeployment.Status.IN_PROGRESS, stuck.getStatus());
+  }
+
+  @Test
+  void forceFailsOrphanWorkflowBackedDeploymentWhenSyncThrowsIoException() throws IOException {
+    HeliosDeployment orphan =
+        createWorkflowBackedHeliosDeployment(30L, 3001L, true, "owner/repo");
+
+    when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
+        .thenReturn(List.of(orphan));
+    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any()))
+        .thenReturn(List.of());
+    when(heliosDeploymentWorkflowRunSyncService.synchronizeTerminalStateFromWorkflowRun(
+            anyString(), anyLong()))
+        .thenThrow(new IOException("github down"));
+    when(heliosDeploymentRepository.save(any(HeliosDeployment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    deploymentRecoveryService.markStuckOrphanHeliosDeploymentsAsFailure();
+
+    assertEquals(HeliosDeployment.Status.FAILED, orphan.getStatus());
+    verify(heliosDeploymentRepository, times(1)).save(any(HeliosDeployment.class));
+  }
+
+  @Test
   void markStuckOrphanDeploymentsSkipsWhenNoneFound() {
     when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
         .thenReturn(List.of());
@@ -85,6 +175,24 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
     deployment.setStatusUpdatedAt(OffsetDateTime.now().minusHours(3));
     deployment.setUpdatedAt(OffsetDateTime.now().minusHours(3));
     deployment.setCreatedAt(OffsetDateTime.now().minusHours(3));
+    return deployment;
+  }
+
+  private HeliosDeployment createWorkflowBackedHeliosDeployment(
+      Long id, Long workflowRunId, boolean orphan, String repositoryNameWithOwner) {
+    HeliosDeployment deployment =
+        createStuckHeliosDeployment(id, HeliosDeployment.Status.IN_PROGRESS);
+    deployment.setWorkflowRunId(workflowRunId);
+    if (!orphan) {
+      deployment.setDeploymentId(id + 5000L);
+    }
+
+    GitRepository repository = new GitRepository();
+    repository.setNameWithOwner(repositoryNameWithOwner);
+    Environment environment = new Environment();
+    environment.setRepository(repository);
+    deployment.setEnvironment(environment);
+
     return deployment;
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
@@ -23,6 +23,9 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
   @Mock
   private HeliosDeploymentRepository heliosDeploymentRepository;
 
+  @Mock
+  private HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
+
   @InjectMocks
   private OrphanHeliosDeploymentRecoveryService deploymentRecoveryService;
 
@@ -33,7 +36,10 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
     HeliosDeployment notStuck = createStuckHeliosDeployment(3L, HeliosDeployment.Status.QUEUED);
     notStuck.setStatusUpdatedAt(OffsetDateTime.now().minusMinutes(30));
 
-    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentId(any()))
+    when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
+        .thenReturn(List.of());
+    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any()))
         .thenReturn(List.of(stuck1, stuck2));
     when(heliosDeploymentRepository.save(any(HeliosDeployment.class)))
         .thenAnswer(invocation -> invocation.getArgument(0));
@@ -42,7 +48,10 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
 
     // Assert
     verify(heliosDeploymentRepository, times(1))
-        .findStuckDeploymentsWithoutDeploymentId(any(OffsetDateTime.class));
+        .findStuckDeploymentsWithWorkflowRunId(any(OffsetDateTime.class));
+    verify(heliosDeploymentRepository, times(1))
+        .findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any(OffsetDateTime.class));
     verify(heliosDeploymentRepository, times(2)).save(any(HeliosDeployment.class));
     assertEquals(HeliosDeployment.Status.FAILED, stuck1.getStatus());
     assertEquals(HeliosDeployment.Status.FAILED, stuck2.getStatus());
@@ -51,14 +60,20 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
 
   @Test
   void markStuckOrphanDeploymentsSkipsWhenNoneFound() {
-    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentId(any()))
+    when(heliosDeploymentRepository.findStuckDeploymentsWithWorkflowRunId(any()))
+        .thenReturn(List.of());
+    when(heliosDeploymentRepository.findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any()))
         .thenReturn(List.of());
 
     deploymentRecoveryService.markStuckOrphanHeliosDeploymentsAsFailure();
 
     // Assert
     verify(heliosDeploymentRepository, times(1))
-        .findStuckDeploymentsWithoutDeploymentId(any(OffsetDateTime.class));
+        .findStuckDeploymentsWithWorkflowRunId(any(OffsetDateTime.class));
+    verify(heliosDeploymentRepository, times(1))
+        .findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
+            any(OffsetDateTime.class));
     verify(heliosDeploymentRepository, never()).save(any(HeliosDeployment.class));
   }
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/github/GitHubServiceTest.java
@@ -366,10 +366,7 @@ class GitHubServiceTest {
             () -> {
               gitHubService.dispatchWorkflow(repoNameWithOwners, workflowFileNameOrId, ref, inputs);
             });
-    assertTrue(
-        exception
-            .getMessage()
-            .contains("GitHub API workflow dispatch failed with response code: 500"));
+    assertEquals("Error", exception.getMessage());
   }
 
   @Test
@@ -1205,10 +1202,7 @@ class GitHubServiceTest {
                   repoNameWithOwner, "v1", "main", "name", "body", false, githubUserLogin);
             });
 
-    assertTrue(
-        exception
-            .getMessage()
-            .contains("GitHub API create release failed with response code: 500"));
+    assertEquals("Error", exception.getMessage());
   }
 
   @Test
@@ -1385,8 +1379,41 @@ class GitHubServiceTest {
             () -> {
               gitHubService.cancelWorkflowRun(repoNameWithOwner, runId);
             });
-    assertTrue(exception.getMessage()
-        .contains("GitHub API cancel for run " + runId + " failed with response code: 500"));
+    assertEquals("Error details", exception.getMessage());
+  }
+
+  @Test
+  void cancelWorkflowRunApiFailureUsesGithubMessage() throws IOException {
+    String repoNameWithOwner = "owner/repo";
+    long runId = 123L;
+    when(clientManager.getCurrentToken()).thenReturn("test-token");
+    when(objectMapper.readValue(
+            "{\"message\":\"Cannot cancel a workflow run that is completed.\"}", Map.class))
+        .thenReturn(Map.of("message", "Cannot cancel a workflow run that is completed."));
+
+    ResponseBody responseBody =
+        ResponseBody.create(
+            "{\"message\":\"Cannot cancel a workflow run that is completed.\"}",
+            MediaType.parse("application/json"));
+    Response mockResponse =
+        new Response.Builder()
+            .request(new Request.Builder().url("http://dummyurl").build())
+            .protocol(Protocol.HTTP_1_1)
+            .code(409)
+            .message("Conflict")
+            .body(responseBody)
+            .build();
+    Call mockCall = mock(Call.class);
+    when(okHttpClient.newCall(any(Request.class))).thenReturn(mockCall);
+    when(mockCall.execute()).thenReturn(mockResponse);
+
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> {
+              gitHubService.cancelWorkflowRun(repoNameWithOwner, runId);
+            });
+    assertEquals("Cannot cancel a workflow run that is completed.", exception.getMessage());
   }
 
   private Response buildJsonResponse(String json) {

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncServiceTest.java
@@ -1,0 +1,75 @@
+package de.tum.cit.aet.helios.workflow.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHWorkflowRun;
+
+class GitHubWorkflowRunSyncServiceTest {
+
+  @Test
+  void mapLiveWorkflowRunStatusPreservesPreviousNonCompletedStatusMapping() {
+    GHWorkflowRun.Status[] unknownStatuses = {
+      GHWorkflowRun.Status.ACTION_REQUIRED,
+      GHWorkflowRun.Status.CANCELLED,
+      GHWorkflowRun.Status.FAILURE,
+      GHWorkflowRun.Status.NEUTRAL,
+      GHWorkflowRun.Status.REQUESTED,
+      GHWorkflowRun.Status.SKIPPED,
+      GHWorkflowRun.Status.STALE,
+      GHWorkflowRun.Status.SUCCESS,
+      GHWorkflowRun.Status.TIMED_OUT,
+      GHWorkflowRun.Status.UNKNOWN,
+      GHWorkflowRun.Status.WAITING
+    };
+
+    for (GHWorkflowRun.Status status : unknownStatuses) {
+      assertEquals(
+          HeliosDeployment.Status.UNKNOWN,
+          GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(status, null));
+    }
+  }
+
+  @Test
+  void mapLiveWorkflowRunStatusPreservesPreviousActiveStatusMapping() {
+    assertEquals(
+        HeliosDeployment.Status.WAITING,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(GHWorkflowRun.Status.PENDING, null));
+    assertEquals(
+        HeliosDeployment.Status.QUEUED,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(GHWorkflowRun.Status.QUEUED, null));
+    assertEquals(
+        HeliosDeployment.Status.IN_PROGRESS,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.IN_PROGRESS, null));
+  }
+
+  @Test
+  void mapLiveWorkflowRunStatusPreservesPreviousCompletedConclusionMapping() {
+    assertEquals(
+        HeliosDeployment.Status.DEPLOYMENT_SUCCESS,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.SUCCESS));
+    assertEquals(
+        HeliosDeployment.Status.CANCELLED,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.CANCELLED));
+    assertEquals(
+        HeliosDeployment.Status.FAILED,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.FAILURE));
+    assertEquals(
+        HeliosDeployment.Status.FAILED,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.STARTUP_FAILURE));
+    assertEquals(
+        HeliosDeployment.Status.FAILED,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.TIMED_OUT));
+    assertEquals(
+        HeliosDeployment.Status.UNKNOWN,
+        GitHubWorkflowRunSyncService.mapLiveWorkflowRunStatus(
+            GHWorkflowRun.Status.COMPLETED, GHWorkflowRun.Conclusion.ACTION_REQUIRED));
+  }
+}


### PR DESCRIPTION


### Motivation
GitHub can reject cancellation when a workflow run has already reached a terminal state, leaving Helios deployments stale even though GitHub has the final status. Queued workflow runs also need to stay visible as a distinct waiting state so reviewers understand that deployment is blocked on GitHub Actions runner availability.

Fixes #990 

### Description
- Add `HeliosDeploymentWorkflowRunSyncService` to synchronize terminal workflow run states from GitHub back into Helios deployments and linked deployments.
- Recover completed workflow runs after failed cancellation attempts instead of surfacing a generic cancellation failure.
- Update orphan deployment recovery to synchronize stuck workflow-backed deployments before only failing deployments that have neither deployment nor workflow run IDs.
- Update deployment timing logic so `REQUESTED`, `WAITING`, `PENDING`, and `QUEUED` stay in the pre-deployment step while timers start only when the deployment actually reaches `PENDING`.
- Add focused server and client tests for synchronization, cancellation recovery, queued-state mapping, deployment timing, and stepper rendering.

### Testing Instructions
#### Prerequisites:
- GitHub Account with Developer access to a Helios repository.
- A configured environment with a deployment workflow.

#### Flow:
1. Log in to Helios as a Developer.
2. Trigger a deployment whose GitHub Actions.
3. Disable ngrok before receiving a completed event for the workflow
4. Cancel a deployment after its GitHub workflow run has already completed and verify Helios synchronizes the terminal status from GitHub instead of keeping the deployment stale.


### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices