### PR TITLE
feat: single click login

### DIFF
--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.html
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.html
@@ -5,8 +5,13 @@
       <span class="hidden md:block text-md runcate overflow-hidden whitespace-nowrap max-w-[130px]">{{ fullName() }}</span>
     </p-button>
   } @else {
-    <p-button (click)="login()" class="rounded-xl flex items-center justify-center gap-2 w-full" size="small">
-      <i-tabler name="login" class="!size-5 !stroke-1"></i-tabler>
+    <p-button
+      (click)="login()"
+      class="rounded-xl flex items-center justify-center gap-2 w-full"
+      styleClass="!bg-white !border-white !text-primary hover:!bg-surface-100 hover:!border-surface-100 dark:!bg-surface-100 dark:!border-surface-100 dark:!text-primary"
+      size="small"
+    >
+      <i-tabler name="brand-github" class="!size-5 !stroke-1"></i-tabler>
       <span class="hidden md:block">Sign In</span>
     </p-button>
   }

--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.html
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.html
@@ -5,12 +5,7 @@
       <span class="hidden md:block text-md runcate overflow-hidden whitespace-nowrap max-w-[130px]">{{ fullName() }}</span>
     </p-button>
   } @else {
-    <p-button
-      (click)="login()"
-      class="rounded-xl flex items-center justify-center gap-2 w-full"
-      styleClass="!bg-white !border-white !text-primary hover:!bg-surface-100 hover:!border-surface-100 dark:!bg-surface-100 dark:!border-surface-100 dark:!text-primary"
-      size="small"
-    >
+    <p-button (click)="login()" class="rounded-xl flex items-center justify-center gap-2 w-full" size="small">
       <i-tabler name="brand-github" class="!size-5 !stroke-1"></i-tabler>
       <span class="hidden md:block">Sign In</span>
     </p-button>

--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
@@ -11,7 +11,7 @@ import { DividerModule } from 'primeng/divider';
 import { AvatarModule } from 'primeng/avatar';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import { IconLogin, IconLogout, IconSettings } from 'angular-tabler-icons/icons';
+import { IconBrandGithub, IconLogout, IconSettings } from 'angular-tabler-icons/icons';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { filter } from 'rxjs';
 
@@ -33,7 +33,7 @@ import { filter } from 'rxjs';
   ],
   providers: [
     provideTablerIcons({
-      IconLogin,
+      IconBrandGithub,
       IconLogout,
       IconSettings,
     }),

--- a/client/src/app/core/services/keycloak/keycloak.service.spec.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.spec.ts
@@ -1,6 +1,13 @@
 import { KeycloakService } from './keycloak.service';
+import { environment } from 'environments/environment';
 
 describe('KeycloakService', () => {
+  const originalSkipLoginPage = environment.keycloak.skipLoginPage;
+
+  afterEach(() => {
+    environment.keycloak.skipLoginPage = originalSkipLoginPage;
+  });
+
   it('should read tokenParsed claims and handle missing tokenParsed', () => {
     const service = new KeycloakService();
     const keycloakStub = {
@@ -22,5 +29,29 @@ describe('KeycloakService', () => {
 
     expect(() => service.getUserGithubId()).not.toThrow();
     expect(service.getUserGithubId()).toBeUndefined();
+  });
+
+  it('should login directly with GitHub when the login page is skipped', () => {
+    const service = new KeycloakService();
+    const login = vi.fn();
+    environment.keycloak.skipLoginPage = true;
+    (service as unknown as { _keycloak: unknown })._keycloak = { login };
+
+    service.login();
+
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(login).toHaveBeenCalledWith({ idpHint: 'github' });
+  });
+
+  it('should show the Keycloak login page when the login page is not skipped', () => {
+    const service = new KeycloakService();
+    const login = vi.fn();
+    environment.keycloak.skipLoginPage = false;
+    (service as unknown as { _keycloak: unknown })._keycloak = { login };
+
+    service.login();
+
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(login).toHaveBeenCalledWith();
   });
 });

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -82,6 +82,10 @@ export class KeycloakService {
   }
 
   login() {
+    if (environment.keycloak.skipLoginPage) {
+      return this.keycloak.login({ idpHint: 'github' });
+    }
+
     return this.keycloak.login();
   }
 


### PR DESCRIPTION
### Motivation
Signing in to Helios required two user actions: clicking the Helios sign-in button and then selecting GitHub on the Keycloak login page. Since GitHub is the intended default identity provider, the extra intermediate page made the login flow slower and less clear.
Fixes #997 #984 
### Description
- Redirect the Helios sign-in action directly to the GitHub identity provider when `environment.keycloak.skipLoginPage` is enabled.
- Preserve the existing Keycloak login page fallback when `skipLoginPage` is disabled.
- Replace the generic login icon with the GitHub brand icon on the sign-in button.
- Adjust the sign-in button styling so it is visually distinct from the dark header.
- Add unit tests for both direct GitHub login and fallback Keycloak login behavior.

### Testing Instructions
#### Prerequisites:
- GitHub account that can sign in to Helios.
- Helios frontend configured with `environment.keycloak.skipLoginPage = true`.

#### Flow:
1. Open Helios while logged out.
2. Verify the header sign-in button shows the GitHub icon and is visually distinguishable from the header background.
3. Click `Sign In`.
4. Verify the browser redirects directly to GitHub authentication instead of first showing the Keycloak login page.
5. Complete GitHub authentication and verify the user returns to Helios authenticated.
6. Set `skipLoginPage` to `false` in the active frontend environment and repeat the sign-in flow.
7. Verify the normal Keycloak login page is shown.

### Screenshots
https://github.com/user-attachments/assets/92e56012-e732-47f8-a3d5-891e0172ae40


### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I translated all newly inserted strings into English and German.