### PR TITLE
perf: introduce Caffeine cache to optimize GitHub workflow job relevance resolution and minimize database lookups

### DIFF
--- a/server/application-server/build.gradle
+++ b/server/application-server/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-oauth2-jose'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
     implementation 'org.openapitools:jackson-databind-nullable:0.2.9'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     implementation 'io.nats:jnats:2.25.2'
     implementation 'org.kohsuke:github-api:1.330'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
@@ -1,5 +1,7 @@
 package de.tum.cit.aet.helios.workflow.github;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfig;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfigRepository;
 import de.tum.cit.aet.helios.environment.Environment;
@@ -9,6 +11,7 @@ import de.tum.cit.aet.helios.workflow.Workflow;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import jakarta.transaction.Transactional;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
@@ -24,6 +27,8 @@ public class GitHubWorkflowJobTimingService {
   private final DeploymentWorkflowConfigRepository deploymentWorkflowConfigRepository;
   private final HeliosDeploymentRepository heliosDeploymentRepository;
   private final WorkflowRunRepository workflowRunRepository;
+  private final Cache<Long, RunRelevance> runRelevanceCache =
+      Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofHours(1)).build();
 
   @Transactional
   public void persistDurations(GitHubWorkflowJobPayload payload) {
@@ -32,68 +37,47 @@ public class GitHubWorkflowJobTimingService {
     }
 
     GitHubWorkflowJobPayload.WorkflowJob job = payload.workflowJob();
+    GitHubWorkflowJobPayload.Deployment deployment = payload.deployment();
     if (job.runId() == null) {
       return;
     }
 
-    Optional<HeliosDeployment> heliosDeploymentOpt =
-        heliosDeploymentRepository.findByWorkflowRunId(job.runId());
-    if (heliosDeploymentOpt.isEmpty()) {
-      log.debug(
-          "Skipping workflow_job timing persistence because no HeliosDeployment "
-              + "matched workflow run {}",
-          job.runId());
+    if ("queued".equalsIgnoreCase(payload.action()) && deployment == null) {
       return;
     }
 
-    HeliosDeployment heliosDeployment = heliosDeploymentOpt.get();
-    Environment environment = heliosDeployment.getEnvironment();
-    Workflow workflow = environment != null ? environment.getDeploymentWorkflow() : null;
-    if (workflow == null) {
-      log.debug(
-          "Skipping workflow_job timing persistence because workflow run {} "
-              + "is not linked to an environment deployment workflow",
-          job.runId());
+    RunRelevance cachedRelevance = getCachedRelevance(job.runId());
+    if (cachedRelevance instanceof NotDeployment && deployment != null) {
+      runRelevanceCache.invalidate(job.runId());
+    } else if (cachedRelevance != null && !(cachedRelevance instanceof Relevant)) {
       return;
     }
 
-    Optional<WorkflowRun> workflowRunOpt = workflowRunRepository.findById(job.runId());
-    if (workflowRunOpt.isPresent()
-        && workflowRunOpt.get().getWorkflow() != null
-        && !workflowRunOpt.get().getWorkflow().getId().equals(workflow.getId())) {
-      log.debug(
-          "Skipping workflow_job timing persistence because workflow run {} "
-              + "is not linked to the configured deployment workflow {}",
-          job.runId(),
-          workflow.getId());
+    ResolvedRunRelevance resolvedRelevance = resolveRelevance(job.runId());
+    if (!(resolvedRelevance.relevance() instanceof Relevant)) {
+      runRelevanceCache.put(job.runId(), resolvedRelevance.relevance());
       return;
     }
 
-    boolean changed = persistWorkflowStart(heliosDeployment, workflowRunOpt.orElse(null), payload);
+    runRelevanceCache.put(job.runId(), resolvedRelevance.relevance());
 
-    Optional<DeploymentWorkflowConfig> configOpt =
-        deploymentWorkflowConfigRepository.findByWorkflow(workflow);
-    if (configOpt.isEmpty()) {
+    HeliosDeployment heliosDeployment = resolvedRelevance.heliosDeployment();
+    WorkflowRun workflowRun = resolvedRelevance.workflowRun();
+    Relevant relevance = (Relevant) resolvedRelevance.relevance();
+
+    boolean changed = persistWorkflowStart(heliosDeployment, workflowRun, payload);
+
+    if (!relevance.deployJobName().equals(job.name())) {
       if (changed) {
         heliosDeploymentRepository.save(heliosDeployment);
       }
       return;
     }
 
-    DeploymentWorkflowConfig config = configOpt.get();
-    if (config.getDeployJobName() == null
-        || config.getDeployJobName().isBlank()
-        || !config.getDeployJobName().equals(job.name())) {
-      if (changed) {
-        heliosDeploymentRepository.save(heliosDeployment);
-      }
-      return;
-    }
-
-    if (payload.deployment() != null
+    if (deployment != null
         && heliosDeployment.getDeploymentId() == null
-        && payload.deployment().id() != null) {
-      heliosDeployment.setDeploymentId(payload.deployment().id());
+        && deployment.id() != null) {
+      heliosDeployment.setDeploymentId(deployment.id());
       changed = true;
     }
 
@@ -133,8 +117,8 @@ public class GitHubWorkflowJobTimingService {
             : job.startedAt();
     OffsetDateTime preDeploymentStart =
         resolvePreDeploymentStart(
-            workflowRunOpt.orElse(null),
-            payload.deployment() != null ? payload.deployment().createdAt() : null,
+            workflowRun,
+            deployment != null ? deployment.createdAt() : null,
             heliosDeployment);
     heliosDeployment.setPreDeployDurationSeconds(
         calculateDurationSeconds(preDeploymentStart, deployJobStartedAt));
@@ -145,6 +129,69 @@ public class GitHubWorkflowJobTimingService {
     if (changed) {
       heliosDeploymentRepository.save(heliosDeployment);
     }
+  }
+
+  private RunRelevance getCachedRelevance(Long runId) {
+    RunRelevance cachedRelevance = runRelevanceCache.getIfPresent(runId);
+    log.debug(
+        "workflow_job run relevance cache {} for workflow run {}",
+        cachedRelevance == null ? "miss" : "hit",
+        runId);
+    return cachedRelevance;
+  }
+
+  private ResolvedRunRelevance resolveRelevance(Long runId) {
+    Optional<HeliosDeployment> heliosDeploymentOpt =
+        heliosDeploymentRepository.findByWorkflowRunId(runId);
+    if (heliosDeploymentOpt.isEmpty()) {
+      log.debug(
+          "Skipping workflow_job timing persistence because no HeliosDeployment "
+              + "matched workflow run {}",
+          runId);
+      return new ResolvedRunRelevance(new NotDeployment(), null, null);
+    }
+
+    HeliosDeployment heliosDeployment = heliosDeploymentOpt.get();
+    Environment environment = heliosDeployment.getEnvironment();
+    Workflow workflow = environment != null ? environment.getDeploymentWorkflow() : null;
+    if (workflow == null) {
+      log.debug(
+          "Skipping workflow_job timing persistence because workflow run {} "
+              + "is not linked to an environment deployment workflow",
+          runId);
+      return new ResolvedRunRelevance(new WrongWorkflow(), heliosDeployment, null);
+    }
+
+    Optional<WorkflowRun> workflowRunOpt = workflowRunRepository.findById(runId);
+    WorkflowRun workflowRun = workflowRunOpt.orElse(null);
+    if (workflowRun != null
+        && workflowRun.getWorkflow() != null
+        && !workflowRun.getWorkflow().getId().equals(workflow.getId())) {
+      log.debug(
+          "Skipping workflow_job timing persistence because workflow run {} "
+              + "is not linked to the configured deployment workflow {}",
+          runId,
+          workflow.getId());
+      return new ResolvedRunRelevance(new WrongWorkflow(), heliosDeployment, workflowRun);
+    }
+
+    Optional<DeploymentWorkflowConfig> configOpt =
+        deploymentWorkflowConfigRepository.findByWorkflow(workflow);
+    if (configOpt.isEmpty()) {
+      return new ResolvedRunRelevance(
+          new NoConfig(heliosDeployment.getId()), heliosDeployment, workflowRun);
+    }
+
+    DeploymentWorkflowConfig config = configOpt.get();
+    if (config.getDeployJobName() == null || config.getDeployJobName().isBlank()) {
+      return new ResolvedRunRelevance(
+          new NoConfig(heliosDeployment.getId()), heliosDeployment, workflowRun);
+    }
+
+    return new ResolvedRunRelevance(
+        new Relevant(heliosDeployment.getId(), config.getDeployJobName()),
+        heliosDeployment,
+        workflowRun);
   }
 
   private boolean persistWorkflowStart(
@@ -210,4 +257,17 @@ public class GitHubWorkflowJobTimingService {
     }
     return Math.max(0, (int) ChronoUnit.SECONDS.between(start, end));
   }
+
+  private record ResolvedRunRelevance(
+      RunRelevance relevance, HeliosDeployment heliosDeployment, WorkflowRun workflowRun) {}
+
+  private sealed interface RunRelevance permits NotDeployment, WrongWorkflow, NoConfig, Relevant {}
+
+  private record NotDeployment() implements RunRelevance {}
+
+  private record WrongWorkflow() implements RunRelevance {}
+
+  private record NoConfig(Long heliosDeploymentId) implements RunRelevance {}
+
+  private record Relevant(Long heliosDeploymentId, String deployJobName) implements RunRelevance {}
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfig;
@@ -62,6 +64,83 @@ class GitHubWorkflowJobTimingServiceTest {
     heliosDeployment.setEnvironment(environment);
     heliosDeployment.setWorkflowRunId(23716064328L);
     heliosDeployment.setCreatedAt(OffsetDateTime.parse("2026-03-29T18:31:49Z"));
+  }
+
+  @Test
+  void persistDurationsSkipsQueuedWithoutDeploymentBeforeDatabaseLookup() {
+    GitHubWorkflowJobPayload payload = payloadWithoutDeployment("queued", "queued", "build");
+
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    verifyNoInteractions(
+        deploymentWorkflowConfigRepository, heliosDeploymentRepository, workflowRunRepository);
+  }
+
+  @Test
+  void persistDurationsProcessesRelevantCacheHitThroughTimingPath() {
+    WorkflowRun workflowRun = new WorkflowRun();
+    workflowRun.setId(23716064328L);
+    workflowRun.setWorkflow(deploymentWorkflow);
+    workflowRun.setRunStartedAt(OffsetDateTime.parse("2026-03-29T18:31:40Z"));
+    final GitHubWorkflowJobPayload payload = payload("completed", "completed", "deploy");
+
+    when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
+        .thenReturn(Optional.of(config));
+    when(heliosDeploymentRepository.findByWorkflowRunId(anyLong()))
+        .thenReturn(Optional.of(heliosDeployment));
+    when(workflowRunRepository.findById(any(Long.class))).thenReturn(Optional.of(workflowRun));
+
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    assertEquals(Integer.valueOf(13), heliosDeployment.getPreDeployDurationSeconds());
+    assertEquals(Integer.valueOf(13), heliosDeployment.getDeployDurationSeconds());
+    verify(heliosDeploymentRepository, times(2)).findByWorkflowRunId(23716064328L);
+    verify(workflowRunRepository, times(2)).findById(any(Long.class));
+    verify(deploymentWorkflowConfigRepository, times(2)).findByWorkflow(any(Workflow.class));
+    verify(heliosDeploymentRepository, times(2)).save(heliosDeployment);
+  }
+
+  @Test
+  void persistDurationsCachesRunsWithoutDeployment() {
+    final GitHubWorkflowJobPayload payload =
+        payloadWithoutDeployment("completed", "completed", "deploy");
+
+    when(heliosDeploymentRepository.findByWorkflowRunId(anyLong())).thenReturn(Optional.empty());
+
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+    gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    verify(heliosDeploymentRepository).findByWorkflowRunId(23716064328L);
+    verify(heliosDeploymentRepository, never()).save(any());
+    verifyNoInteractions(deploymentWorkflowConfigRepository, workflowRunRepository);
+  }
+
+  @Test
+  void persistDurationsBypassesCachedNotDeploymentForDeploymentPayload() {
+    WorkflowRun workflowRun = new WorkflowRun();
+    workflowRun.setId(23716064328L);
+    workflowRun.setWorkflow(deploymentWorkflow);
+    workflowRun.setRunStartedAt(OffsetDateTime.parse("2026-03-29T18:31:40Z"));
+    final GitHubWorkflowJobPayload initialPayload =
+        payloadWithoutDeployment("completed", "completed", "deploy");
+    final GitHubWorkflowJobPayload deploymentPayload = payload("completed", "completed", "deploy");
+
+    when(heliosDeploymentRepository.findByWorkflowRunId(anyLong()))
+        .thenReturn(Optional.empty(), Optional.of(heliosDeployment));
+    when(workflowRunRepository.findById(any(Long.class))).thenReturn(Optional.of(workflowRun));
+    when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
+        .thenReturn(Optional.of(config));
+
+    gitHubWorkflowJobTimingService.persistDurations(initialPayload);
+    gitHubWorkflowJobTimingService.persistDurations(deploymentPayload);
+
+    assertEquals(Integer.valueOf(13), heliosDeployment.getPreDeployDurationSeconds());
+    assertEquals(Integer.valueOf(13), heliosDeployment.getDeployDurationSeconds());
+    verify(heliosDeploymentRepository, times(2)).findByWorkflowRunId(23716064328L);
+    verify(workflowRunRepository).findById(any(Long.class));
+    verify(deploymentWorkflowConfigRepository).findByWorkflow(any(Workflow.class));
+    verify(heliosDeploymentRepository).save(heliosDeployment);
   }
 
   @Test
@@ -216,7 +295,7 @@ class GitHubWorkflowJobTimingServiceTest {
     workflowRun.setId(23716064328L);
     workflowRun.setWorkflow(deploymentWorkflow);
     workflowRun.setRunStartedAt(OffsetDateTime.parse("2026-03-29T18:31:40Z"));
-    GitHubWorkflowJobPayload payload = payload("in_progress", "in_progress", "build");
+    final GitHubWorkflowJobPayload payload = payload("in_progress", "in_progress", "build");
 
     when(deploymentWorkflowConfigRepository.findByWorkflow(any(Workflow.class)))
         .thenReturn(Optional.of(config));
@@ -235,6 +314,14 @@ class GitHubWorkflowJobTimingServiceTest {
 
   private GitHubWorkflowJobPayload payload(
       String action, String workflowJobStatus, String jobName) {
+    return payload(action, workflowJobStatus, jobName, deployment());
+  }
+
+  private GitHubWorkflowJobPayload payload(
+      String action,
+      String workflowJobStatus,
+      String jobName,
+      GitHubWorkflowJobPayload.Deployment deployment) {
     return new GitHubWorkflowJobPayload(
         action,
         new GitHubWorkflowJobPayload.WorkflowJob(
@@ -250,14 +337,23 @@ class GitHubWorkflowJobTimingServiceTest {
             OffsetDateTime.parse("2026-03-29T18:31:53Z"),
             OffsetDateTime.parse("2026-03-29T18:32:06Z"),
             jobName),
-        new GitHubWorkflowJobPayload.Deployment(
-            4210842007L,
-            "test",
-            "new-branch",
-            "b49e899f86b523027348c31adce8d7b41ac0cb00",
-            OffsetDateTime.parse("2026-03-29T18:31:50Z")),
+        deployment,
         new GitHubWorkflowJobPayload.Repository(
             1097747382L,
             "mert-test-org/helios-test-repo"));
+  }
+
+  private GitHubWorkflowJobPayload payloadWithoutDeployment(
+      String action, String workflowJobStatus, String jobName) {
+    return payload(action, workflowJobStatus, jobName, null);
+  }
+
+  private GitHubWorkflowJobPayload.Deployment deployment() {
+    return new GitHubWorkflowJobPayload.Deployment(
+        4210842007L,
+        "test",
+        "new-branch",
+        "b49e899f86b523027348c31adce8d7b41ac0cb00",
+        OffsetDateTime.parse("2026-03-29T18:31:50Z"));
   }
 }


### PR DESCRIPTION
### Motivation
Webhook processing slowed down after adding `workflow_job` events because GitHub sends multiple job lifecycle events for every job in every workflow run. Most of those events are unrelated to Helios deployments, but they still repeated the same repository lookups before being skipped. This change reduces repeated database work for irrelevant workflow runs while keeping the deploy-job timing path intact.

### Description
- Added a bounded Caffeine cache in `GitHubWorkflowJobTimingService` keyed by workflow run ID to remember deployment relevance outcomes.
- Cached negative relevance outcomes short-circuit repeat `workflow_job` events before repository lookups.
- Kept relevant workflow runs on the full timing persistence path so deployment timing updates still use fresh data.
- Added an early return for `queued` workflow job events without a deployment payload.
- Added explicit Caffeine dependency through the existing Spring Boot dependency management.
- Added unit coverage for queued-event short-circuiting, negative relevance caching, and relevant cache hits still persisting timing data.

### Testing Instructions
#### Prerequisites:
- Helios environment connected to a GitHub repository.
- A deployment workflow configuration with one configured deploy job.
- A GitHub workflow that includes multiple non-deploy jobs and the configured deploy job.
- Access to inspect webhook processing logs or deployment timing fields.

#### Flow:
1. Log in to Helios as a Developer.
2. Trigger a GitHub workflow run in the connected repository.
3. Confirm non-deploy `workflow_job` events do not create deployment timing updates.
4. Confirm repeated events for the same non-relevant workflow run are skipped after the first relevance resolution.
5. Confirm `queued` workflow job events without a deployment payload are ignored without changing deployment data.
6. Let the configured deploy job start and complete.
7. Confirm Helios still records the deployment ID, deploy job start time, pre-deploy duration, and deploy duration for the configured deploy job.

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices