### PR TITLE
refactor: replace granular log line tone toggles with a consolidated log level filter component

### DIFF
--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
@@ -177,7 +177,7 @@
                     <div class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-color">
                       <span class="font-semibold uppercase text-primary-700 dark:text-primary-100">Job</span>
                       <span aria-hidden="true">·</span>
-                      <span>{{ getStepLogCountLabel(groupView.group.files.length) }}</span>
+                      <span>{{ getStepLogCountLabel(getStepFileViewsForGroup(groupView.group.name).length) }}</span>
 
                       @if (groupView.group.jobName && groupView.group.jobName !== groupView.group.name) {
                         <span aria-hidden="true">·</span>
@@ -193,7 +193,7 @@
 
               <p-accordion-content>
                 <div class="space-y-2">
-                  @for (fileView of getFileViewsForGroup(groupView.group.name); track fileView.file.path) {
+                  @for (fileView of getStepFileViewsForGroup(groupView.group.name); track fileView.file.path) {
                     <button
                       class="flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition"
                       [ngClass]="
@@ -235,6 +235,32 @@
                         </span>
                       </span>
                     </button>
+                  }
+                  @if (getNonStepFileViewsForGroup(groupView.group.name).length > 0) {
+                    <p-divider class="my-1" />
+                    <div class="px-2 py-1 text-xs font-semibold uppercase text-muted-color">Other logs</div>
+                    @for (fileView of getNonStepFileViewsForGroup(groupView.group.name); track fileView.file.path) {
+                      <button
+                        class="flex w-full items-center gap-3 rounded-lg border px-3 py-2 text-left transition"
+                        [ngClass]="
+                          activeFilePath() === fileView.file.path
+                            ? 'border-primary bg-primary-50 text-primary-900 shadow-sm dark:bg-primary-400/15 dark:text-primary-50'
+                            : 'border-surface-200 bg-surface-0 dark:border-surface-700 dark:bg-surface-900'
+                        "
+                        type="button"
+                        (click)="selectFile(fileView.file.path)"
+                      >
+                        <span class="inline-flex size-6 shrink-0 items-center justify-center rounded-md bg-surface-100 text-surface-500 dark:bg-surface-800 dark:text-surface-300">
+                          <i-tabler name="file-text" class="!size-4"></i-tabler>
+                        </span>
+                        <span class="min-w-0 flex-1">
+                          <span class="block truncate text-sm font-medium">{{ getStepDisplayName(fileView.file) }}</span>
+                          <span class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-color">
+                            <span class="font-semibold uppercase">Log</span>
+                          </span>
+                        </span>
+                      </button>
+                    }
                   }
                 </div>
               </p-accordion-content>

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
@@ -278,19 +278,18 @@
           <p-divider class="my-4" />
 
           <div [class]="logViewClasses.container">
-            <div [class]="logViewClasses.toolbar">
-              @for (filterOption of lineFilterOptions; track filterOption.tone) {
-                <button
-                  type="button"
-                  class="rounded-full border px-2 py-1 transition"
-                  [class]="getLineToneFilterClass(filterOption.tone)"
-                  [attr.aria-pressed]="isLineToneEnabled(filterOption.tone)"
-                  (click)="toggleLineTone(filterOption.tone)"
-                >
-                  {{ filterOption.label }}
-                </button>
-              }
-            </div>
+            @if (hasFilterableContent()) {
+              <div [class]="logViewClasses.toolbar">
+                <p-selectButton
+                  [options]="logLevelFilterOptions"
+                  [ngModel]="logLevelFilter()"
+                  (ngModelChange)="logLevelFilter.set($event)"
+                  optionLabel="label"
+                  optionValue="value"
+                  size="small"
+                />
+              </div>
+            }
             <div [class]="logViewClasses.content">
               @if (selectedFileView.rows.length === 0) {
                 <div [class]="logViewClasses.emptyState">No log lines match the selected filters.</div>

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
@@ -41,7 +41,7 @@
       <p-card class="border border-surface-200 shadow-sm dark:border-surface-700">
         <div class="mb-4 flex items-center gap-2">
           <i-tabler name="folder" class="!size-5 text-primary" />
-          <span class="font-semibold">Preparing log groups</span>
+          <span class="font-semibold">Preparing jobs and steps</span>
         </div>
 
         <div class="space-y-3">
@@ -142,9 +142,9 @@
           <div class="flex w-full items-center justify-between gap-3">
             <div class="flex items-center gap-2">
               <i-tabler name="folder" class="!size-5 text-primary" />
-              <span class="font-semibold">Log Files</span>
+              <span class="font-semibold">Jobs & Steps</span>
             </div>
-            <p-tag severity="secondary" [rounded]="true" [value]="groupViews().length + ' groups'" />
+            <p-tag severity="secondary" [rounded]="true" [value]="getJobCountLabel(groupViews().length)" />
           </div>
         </ng-template>
 
@@ -173,13 +173,21 @@
                   }
 
                   <div class="min-w-0 flex-1">
-                    <div class="truncate font-medium">{{ groupView.group.name }}</div>
-                    @if (groupView.group.jobName && groupView.group.jobName !== groupView.group.name) {
-                      <div class="truncate text-xs text-muted-color">{{ groupView.group.jobName }}</div>
-                    }
-                  </div>
+                    <div class="truncate font-medium">{{ getJobDisplayName(groupView.group) }}</div>
+                    <div class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-color">
+                      <span class="font-semibold uppercase text-primary-700 dark:text-primary-100">Job</span>
+                      <span aria-hidden="true">·</span>
+                      <span>{{ getStepLogCountLabel(groupView.group.files.length) }}</span>
 
-                  <p-tag severity="secondary" [rounded]="true" [value]="groupView.group.files.length + ' files'" />
+                      @if (groupView.group.jobName && groupView.group.jobName !== groupView.group.name) {
+                        <span aria-hidden="true">·</span>
+                        <span class="min-w-0 truncate">Log group: {{ groupView.group.name }}</span>
+                      } @else if (!groupView.group.jobName) {
+                        <span aria-hidden="true">·</span>
+                        <span>Unmatched log group</span>
+                      }
+                    </div>
+                  </div>
                 </div>
               </p-accordion-header>
 
@@ -210,14 +218,25 @@
                           <i-tabler name="file-text" class="!size-4"></i-tabler>
                         </span>
                       }
-                      <span class="min-w-0 flex-1 truncate text-sm">{{ fileView.file.displayName }}</span>
-                      @if (getStepDuration(fileView.file.stepStartedAt, fileView.file.stepCompletedAt); as stepDuration) {
-                        @if (stepDuration) {
-                          <span class="shrink-0 rounded-full bg-surface-100 px-2 py-0.5 text-xs text-surface-700 dark:bg-surface-800 dark:text-surface-300">
-                            {{ stepDuration }}
-                          </span>
-                        }
-                      }
+                      <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-medium">{{ getStepDisplayName(fileView.file) }}</span>
+                        <span class="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-color">
+                          <span class="font-semibold uppercase">{{ getStepLabel(fileView.file) }}</span>
+                          @if (getStepDuration(fileView.file.stepStartedAt, fileView.file.stepCompletedAt); as stepDuration) {
+                            @if (stepDuration) {
+                              <span aria-hidden="true">·</span>
+                              <span>{{ stepDuration }}</span>
+                            }
+                          }
+                          @if (fileView.file.stepName && fileView.file.displayName && fileView.file.stepName !== fileView.file.displayName) {
+                            <span aria-hidden="true">·</span>
+                            <span class="min-w-0 truncate">Log file: {{ fileView.file.displayName }}</span>
+                          } @else if (!fileView.file.stepName) {
+                            <span aria-hidden="true">·</span>
+                            <span>Unmatched log file</span>
+                          }
+                        </span>
+                      </span>
                     </button>
                   }
                 </div>
@@ -250,19 +269,41 @@
 
         @if (selectedFileView(); as selectedFileView) {
           <div class="min-w-0">
-            <div class="text-sm uppercase tracking-wide text-muted-color">{{ selectedFileView.selectedFile.groupView.group.name }}</div>
-            <h3 class="mt-1 min-w-0 truncate text-xl font-semibold">{{ selectedFileView.selectedFile.file.displayName }}</h3>
-            <div class="truncate text-sm text-muted-color">{{ selectedFileView.selectedFile.file.path }}</div>
-            @if (selectedStep(); as selectedStep) {
-              <div class="mt-3 flex flex-wrap gap-2">
-                <span [class]="selectedFileView.selectedFile.outcome.badgeClass">
-                  {{ 'GitHub step: ' + (selectedStep.name || 'Step ' + (selectedStep.number ?? '?')) }}
-                </span>
-                <span [class]="selectedFileView.selectedFile.outcome.badgeClass">
-                  {{ selectedFileView.selectedFile.outcome.label }}
-                </span>
+            <div class="grid gap-4 md:grid-cols-2">
+              <div class="min-w-0 border-l-4 border-primary-300 pl-3 dark:border-primary-500">
+                <div class="text-xs font-semibold uppercase text-muted-color">Job</div>
+                <h3 class="mt-1 min-w-0 truncate text-lg font-semibold">
+                  {{ getJobDisplayName(selectedFileView.selectedFile.groupView.group) }}
+                </h3>
+                @if (
+                  selectedFileView.selectedFile.groupView.group.jobName &&
+                  selectedFileView.selectedFile.groupView.group.jobName !== selectedFileView.selectedFile.groupView.group.name
+                ) {
+                  <div class="truncate text-sm text-muted-color">Log group: {{ selectedFileView.selectedFile.groupView.group.name }}</div>
+                } @else if (!selectedFileView.selectedFile.groupView.group.jobName) {
+                  <div class="truncate text-sm text-muted-color">Unmatched log group</div>
+                }
+                <div class="mt-2 flex flex-wrap gap-2">
+                  <span [class]="selectedFileView.selectedFile.groupView.outcome.badgeClass">
+                    {{ selectedFileView.selectedFile.groupView.outcome.label }}
+                  </span>
+                </div>
               </div>
-            }
+
+              <div class="min-w-0 border-l-4 border-surface-300 pl-3 dark:border-surface-600">
+                <div class="text-xs font-semibold uppercase text-muted-color">{{ getStepLabel(selectedFileView.selectedFile.file) }}</div>
+                <h3 class="mt-1 min-w-0 truncate text-lg font-semibold">
+                  {{ getStepDisplayName(selectedFileView.selectedFile.file) }}
+                </h3>
+                <div class="truncate text-sm text-muted-color">{{ selectedFileView.selectedFile.file.path }}</div>
+                <div class="mt-2 flex flex-wrap gap-2">
+                  <span [class]="selectedFileView.selectedFile.outcome.badgeClass">
+                    {{ selectedFileView.selectedFile.outcome.label }}
+                  </span>
+                </div>
+              </div>
+            </div>
+
             @if (selectedFileView.lineStats.errorCount > 0 || selectedFileView.lineStats.warningCount > 0) {
               <div class="mt-3 flex flex-wrap gap-2">
                 @if (selectedFileView.lineStats.errorCount > 0) {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.html
@@ -231,9 +231,6 @@
                           @if (fileView.file.stepName && fileView.file.displayName && fileView.file.stepName !== fileView.file.displayName) {
                             <span aria-hidden="true">·</span>
                             <span class="min-w-0 truncate">Log file: {{ fileView.file.displayName }}</span>
-                          } @else if (!fileView.file.stepName) {
-                            <span aria-hidden="true">·</span>
-                            <span>Unmatched log file</span>
                           }
                         </span>
                       </span>

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
@@ -285,7 +285,7 @@ describe('Integration Test Workflow Run Logs Page', () => {
 
     expect(component.selectedStep()).toBeNull();
     expect(fixture.nativeElement.textContent).toContain('Unmatched log group');
-    expect(fixture.nativeElement.textContent).toContain('Unmatched log file');
+    expect(fixture.nativeElement.textContent).not.toContain('Unmatched log file');
     expect(fixture.nativeElement.textContent).not.toContain('GitHub step:');
   });
 

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
@@ -177,12 +177,35 @@ describe('Integration Test Workflow Run Logs Page', () => {
     ).toBe('/usr/bin/git status');
   });
 
-  it('should toggle line tone filters', () => {
-    expect(component.isLineToneEnabled('error')).toBe(true);
-    component.toggleLineTone('error');
-    expect(component.isLineToneEnabled('error')).toBe(false);
-    component.toggleLineTone('error');
-    expect(component.isLineToneEnabled('error')).toBe(true);
+  it('should switch log level filter and affect visible rows', () => {
+    expect(component.logLevelFilter()).toBe('all');
+
+    component.logLevelFilter.set('errors');
+    expect(component.selectedFileView()?.rows.every(row => row.type === 'group' || row.line.tone === 'error')).toBe(true);
+
+    component.logLevelFilter.set('warnings');
+    expect(component.selectedFileView()?.rows.every(row => row.type === 'group' || row.line.tone === 'warning' || row.line.tone === 'error')).toBe(true);
+
+    component.logLevelFilter.set('all');
+    const allRowCount = component.selectedFileView()?.rows.length ?? 0;
+    expect(allRowCount).toBeGreaterThan(0);
+    expect(allRowCount).toBe(component.selectedFileView()?.totalRowCount);
+  });
+
+  it('should show filter toolbar when the selected file has errors or warnings', () => {
+    expect(component.hasFilterableContent()).toBe(true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('p-selectbutton')).toBeTruthy();
+  });
+
+  it('should hide filter toolbar when the selected file has no errors or warnings', async () => {
+    component.selectFile('deploy/system.txt');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.hasFilterableContent()).toBe(false);
+    expect(fixture.nativeElement.querySelector('p-selectbutton')).toBeFalsy();
   });
 
   it('should keep log groups collapsed by default and toggle them on demand', () => {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.spec.ts
@@ -241,10 +241,14 @@ describe('Integration Test Workflow Run Logs Page', () => {
     });
   });
 
-  it('should expose the selected file step metadata without rendering the step panel', () => {
+  it('should expose the selected file job and step metadata', () => {
     expect(component.selectedStep()?.name).toBe('Checkout');
-    expect(fixture.nativeElement.textContent).toContain('GitHub step: Checkout');
-    expect(fixture.nativeElement.textContent).not.toContain('GitHub Steps');
+    expect(fixture.nativeElement.textContent).toContain('Jobs & Steps');
+    expect(fixture.nativeElement.textContent).toContain('Job');
+    expect(fixture.nativeElement.textContent).toContain('Step');
+    expect(fixture.nativeElement.textContent).not.toContain('Step 1');
+    expect(fixture.nativeElement.textContent).toContain('Checkout');
+    expect(fixture.nativeElement.textContent).not.toContain('GitHub step:');
   });
 
   it('should derive file status from the matched GitHub step number', () => {
@@ -280,6 +284,8 @@ describe('Integration Test Workflow Run Logs Page', () => {
     fixture.detectChanges();
 
     expect(component.selectedStep()).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Unmatched log group');
+    expect(fixture.nativeElement.textContent).toContain('Unmatched log file');
     expect(fixture.nativeElement.textContent).not.toContain('GitHub step:');
   });
 

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
@@ -52,7 +52,22 @@ import type { LogLevelFilter, WorkflowRunLogLineTone } from './workflow-run-logs
 
 @Component({
   selector: 'app-workflow-run-logs',
-  imports: [CommonModule, FormsModule, PageHeadingComponent, AccordionModule, Button, CardModule, Divider, MessageModule, Panel, SelectButton, SkeletonModule, TagModule, Toolbar, TablerIconComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    PageHeadingComponent,
+    AccordionModule,
+    Button,
+    CardModule,
+    Divider,
+    MessageModule,
+    Panel,
+    SelectButton,
+    SkeletonModule,
+    TagModule,
+    Toolbar,
+    TablerIconComponent,
+  ],
   providers: [
     provideTablerIcons({
       IconArrowLeft,
@@ -191,6 +206,7 @@ export class WorkflowRunLogsComponent {
 
   selectFile(path: string) {
     this.selectedFilePath.set(path);
+    this.logLevelFilter.set('all');
 
     const selectedEntry = this.groupedFiles().find(entry => entry.file.path === path);
     if (!selectedEntry) {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule, Location } from '@angular/common';
 import { Component, computed, effect, inject, input, numberAttribute, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
 import { getWorkflowRunLogsQueryKey, getWorkflowRunLogsOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { getWorkflowRunLogs } from '@app/core/modules/openapi/sdk.gen';
@@ -27,19 +28,18 @@ import { CardModule } from 'primeng/card';
 import { Divider } from 'primeng/divider';
 import { MessageModule } from 'primeng/message';
 import { Panel } from 'primeng/panel';
+import { SelectButton } from 'primeng/selectbutton';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TagModule } from 'primeng/tag';
 import { Toolbar } from 'primeng/toolbar';
 import {
-  ALL_LOG_LINE_TONES,
-  LOG_LINE_FILTER_OPTIONS,
+  LOG_LEVEL_FILTER_OPTIONS,
   LOG_VIEW_CLASSES,
   buildFileViews,
   buildGroupViews,
   getAutoExpandedLogGroupIds,
   buildSelectedFileView,
   getLineTone,
-  getLineToneFilterClass,
   getLineToneBadgeClass,
   getLineToneRowClass,
   getLineToneTextClass,
@@ -48,11 +48,11 @@ import {
   getRenderedLineContent,
   getWorkflowRunOutcome,
 } from './workflow-run-logs.utils';
-import type { WorkflowRunLogLineTone } from './workflow-run-logs.utils';
+import type { LogLevelFilter, WorkflowRunLogLineTone } from './workflow-run-logs.utils';
 
 @Component({
   selector: 'app-workflow-run-logs',
-  imports: [CommonModule, PageHeadingComponent, AccordionModule, Button, CardModule, Divider, MessageModule, Panel, SkeletonModule, TagModule, Toolbar, TablerIconComponent],
+  imports: [CommonModule, FormsModule, PageHeadingComponent, AccordionModule, Button, CardModule, Divider, MessageModule, Panel, SelectButton, SkeletonModule, TagModule, Toolbar, TablerIconComponent],
   providers: [
     provideTablerIcons({
       IconArrowLeft,
@@ -84,8 +84,8 @@ export class WorkflowRunLogsComponent {
   expandedLogGroupIds = signal<Record<string, boolean>>({});
   selectedFilePath = signal<string | null>(null);
   refreshedLogs = signal<WorkflowRunLogsResponse | null>(null);
-  enabledLineTones = signal<WorkflowRunLogLineTone[]>([...ALL_LOG_LINE_TONES]);
-  readonly lineFilterOptions = LOG_LINE_FILTER_OPTIONS;
+  logLevelFilter = signal<LogLevelFilter>('all');
+  readonly logLevelFilterOptions = LOG_LEVEL_FILTER_OPTIONS;
   readonly logViewClasses = LOG_VIEW_CLASSES;
   readonly getWorkflowRunOutcome = getWorkflowRunOutcome;
   readonly getLineTone = getLineTone;
@@ -150,7 +150,12 @@ export class WorkflowRunLogsComponent {
 
     return selectedFile.groupView.group.steps.find(step => step.number === selectedFile.file.stepNumber && step.name === selectedFile.file.stepName) ?? null;
   });
-  selectedFileView = computed(() => buildSelectedFileView(this.selectedFile(), new Set(this.enabledLineTones()), this.expandedLogGroupIds()));
+  selectedFileView = computed(() => buildSelectedFileView(this.selectedFile(), this.logLevelFilter(), this.expandedLogGroupIds()));
+  hasFilterableContent = computed(() => {
+    const view = this.selectedFileView();
+    if (!view) return false;
+    return view.lineStats.errorCount > 0 || view.lineStats.warningCount > 0;
+  });
 
   constructor() {
     effect(() => {
@@ -209,16 +214,6 @@ export class WorkflowRunLogsComponent {
     this.logsQuery.refetch();
   }
 
-  toggleLineTone(tone: WorkflowRunLogLineTone) {
-    this.enabledLineTones.update(enabledLineTones =>
-      enabledLineTones.includes(tone) ? enabledLineTones.filter(enabledTone => enabledTone !== tone) : [...enabledLineTones, tone]
-    );
-  }
-
-  isLineToneEnabled(tone: WorkflowRunLogLineTone): boolean {
-    return this.enabledLineTones().includes(tone);
-  }
-
   toggleLogGroup(groupId: string) {
     this.expandedLogGroupIds.update(expandedLogGroupIds => ({
       ...expandedLogGroupIds,
@@ -246,10 +241,6 @@ export class WorkflowRunLogsComponent {
         newWindow.opener = null;
       }
     }
-  }
-
-  getLineToneFilterClass(tone: WorkflowRunLogLineTone): string {
-    return getLineToneFilterClass(tone, this.isLineToneEnabled(tone));
   }
 
   getLineToneBadgeClass(tone: Extract<WorkflowRunLogLineTone, 'warning' | 'error'>): string {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
@@ -283,6 +283,18 @@ export class WorkflowRunLogsComponent {
     return this.groupedFilesByGroup()[groupName] ?? [];
   }
 
+  isStepFile(file: WorkflowRunLogFileDto): boolean {
+    return file.stepNumber != null;
+  }
+
+  getStepFileViewsForGroup(groupName: string) {
+    return this.getFileViewsForGroup(groupName).filter(fv => this.isStepFile(fv.file));
+  }
+
+  getNonStepFileViewsForGroup(groupName: string) {
+    return this.getFileViewsForGroup(groupName).filter(fv => !this.isStepFile(fv.file));
+  }
+
   getJobDisplayName(group: WorkflowRunLogGroupDto): string {
     return group.jobName || group.name;
   }

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { PageHeadingComponent } from '@app/components/page-heading/page-heading.component';
 import { getWorkflowRunLogsQueryKey, getWorkflowRunLogsOptions } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { getWorkflowRunLogs } from '@app/core/modules/openapi/sdk.gen';
-import type { WorkflowRunLogsResponse } from '@app/core/modules/openapi/types.gen';
+import type { WorkflowRunLogFileDto, WorkflowRunLogGroupDto, WorkflowRunLogsResponse } from '@app/core/modules/openapi/types.gen';
 import { injectMutation, injectQuery, QueryClient } from '@tanstack/angular-query-experimental';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import {
@@ -281,6 +281,26 @@ export class WorkflowRunLogsComponent {
 
   getFileViewsForGroup(groupName: string) {
     return this.groupedFilesByGroup()[groupName] ?? [];
+  }
+
+  getJobDisplayName(group: WorkflowRunLogGroupDto): string {
+    return group.jobName || group.name;
+  }
+
+  getStepDisplayName(file: WorkflowRunLogFileDto): string {
+    return file.stepName || file.displayName;
+  }
+
+  getStepLabel(file: WorkflowRunLogFileDto): string {
+    return file.stepName ? 'Step' : 'Log';
+  }
+
+  getStepLogCountLabel(count: number): string {
+    return `${count} ${count === 1 ? 'step log' : 'step logs'}`;
+  }
+
+  getJobCountLabel(count: number): string {
+    return `${count} ${count === 1 ? 'job' : 'jobs'}`;
   }
 
   getStepDuration(startTime: string | undefined, endTime: string | undefined): string {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.parser.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.parser.ts
@@ -164,7 +164,19 @@ export function buildVisibleLogRows(
     const isExpanded = expandAllGroups || !showGroups || expandedLogGroupIds[entry.id] === true;
     const childLevel = showGroups ? level + 1 : level;
 
-    if (showGroups) {
+    if (!showGroups) {
+      // Groups hidden — just inline children when expanded
+      if (isExpanded) {
+        rows.push(...buildVisibleLogRows(entry.entries, enabledLineTones, expandedLogGroupIds, childLevel, expandAllGroups));
+      }
+      continue;
+    }
+
+    // Compute child rows first so we can skip groups with no matching content
+    const childRows = isExpanded ? buildVisibleLogRows(entry.entries, enabledLineTones, expandedLogGroupIds, childLevel, expandAllGroups) : [];
+    const hasMatchingContent = childRows.length > 0 || groupHasMatchingLines(entry, enabledLineTones);
+
+    if (hasMatchingContent) {
       rows.push({
         type: 'group',
         level,
@@ -172,10 +184,7 @@ export function buildVisibleLogRows(
         line: entry.headerLine,
         title: entry.title,
       });
-    }
-
-    if (isExpanded) {
-      rows.push(...buildVisibleLogRows(entry.entries, enabledLineTones, expandedLogGroupIds, childLevel, expandAllGroups));
+      rows.push(...childRows);
     }
   }
 
@@ -203,6 +212,18 @@ export function collectGroupIdsContainingTone(
   }
 
   return containsTone;
+}
+
+function groupHasMatchingLines(group: Extract<WorkflowRunLogEntry, { type: 'group' }>, enabledLineTones: ReadonlySet<WorkflowRunLogLineTone>): boolean {
+  for (const entry of group.entries) {
+    if (entry.type === 'line' && enabledLineTones.has(entry.line.tone)) {
+      return true;
+    }
+    if (entry.type === 'group' && groupHasMatchingLines(entry, enabledLineTones)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function isGroupEndLine(content: string): boolean {

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.utils.spec.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.utils.spec.ts
@@ -4,8 +4,8 @@ import {
   LOG_VIEW_CLASSES,
   buildFileViews,
   buildGroupViews,
+  getEnabledTonesForLevel,
   getLineToneBadgeClass,
-  getLineToneFilterClass,
   getLineToneRowClass,
   getLineToneTextClass,
   getLogGroupRowClass,
@@ -80,29 +80,37 @@ describe('workflow-run-logs utils', () => {
     });
   });
 
-  it('keeps purple group filters in light mode and switches away from purple in dark mode', () => {
-    const filterClass = getLineToneFilterClass('group', true);
-
-    expect(filterClass).toContain('border-violet-200');
-    expect(filterClass).toContain('bg-violet-50');
-    expect(filterClass).toContain('dark:border-violet-500');
-    expect(filterClass).toContain('dark:bg-violet-900/30');
+  it('returns all five tones for the "all" log level filter', () => {
+    const tones = getEnabledTonesForLevel('all');
+    expect(tones).toContain('default');
+    expect(tones).toContain('command');
+    expect(tones).toContain('group');
+    expect(tones).toContain('warning');
+    expect(tones).toContain('error');
+    expect(tones.size).toBe(5);
   });
 
-  it('uses a higher-contrast blue for command filters in dark mode', () => {
-    const filterClass = getLineToneFilterClass('command', true);
+  it('returns only warning, error, and group tones for the "warnings" log level filter', () => {
+    const tones = getEnabledTonesForLevel('warnings');
+    expect(tones).toContain('warning');
+    expect(tones).toContain('error');
+    expect(tones).toContain('group');
+    expect(tones).not.toContain('default');
+    expect(tones).not.toContain('command');
+    expect(tones.size).toBe(3);
+  });
 
-    expect(filterClass).toContain('border-primary-200');
-    expect(filterClass).toContain('bg-primary-50');
-    expect(filterClass).toContain('dark:border-primary-500');
-    expect(filterClass).toContain('dark:bg-primary-900/30');
+  it('returns only error and group tones for the "errors" log level filter', () => {
+    const tones = getEnabledTonesForLevel('errors');
+    expect(tones).toContain('error');
+    expect(tones).toContain('group');
+    expect(tones).not.toContain('default');
+    expect(tones).not.toContain('command');
+    expect(tones).not.toContain('warning');
+    expect(tones.size).toBe(2);
   });
 
   it('uses the same orange and red families as the rest of the app for warnings and errors', () => {
-    expect(getLineToneFilterClass('warning', true)).toContain('orange');
-    expect(getLineToneFilterClass('warning', true)).not.toContain('amber');
-    expect(getLineToneFilterClass('error', true)).toContain('red');
-    expect(getLineToneFilterClass('error', true)).not.toContain('rose');
     expect(getLineToneBadgeClass('warning')).toContain('bg-orange-50');
     expect(getLineToneBadgeClass('error')).toContain('bg-red-100');
     expect(getLineToneRowClass('warning')).toContain('border-l-orange-500');
@@ -119,11 +127,8 @@ describe('workflow-run-logs utils', () => {
     expect(getLineToneTextClass('default')).toContain('text-surface-900');
   });
 
-  it('keeps the grouped rows on the same purple family as the group filter', () => {
-    const groupFilterClass = getLineToneFilterClass('group', true);
+  it('keeps the grouped rows on the same purple family', () => {
     const groupRowClass = getLogGroupRowClass();
-
-    expect(groupFilterClass).toContain('violet');
     expect(groupRowClass).toContain('violet');
   });
 

--- a/client/src/app/pages/workflow-run-logs/workflow-run-logs.utils.ts
+++ b/client/src/app/pages/workflow-run-logs/workflow-run-logs.utils.ts
@@ -14,6 +14,8 @@ import {
 export type { WorkflowRunLogLineTone } from './workflow-run-logs.parser';
 export { getLineTone, getRenderedLineContent } from './workflow-run-logs.parser';
 
+export type LogLevelFilter = 'all' | 'warnings' | 'errors';
+
 export type WorkflowRunLogFileView = {
   groupView: WorkflowRunLogGroupView;
   file: WorkflowRunLogFileDto;
@@ -31,16 +33,27 @@ type SelectedWorkflowRunLogFileView = {
 const BADGE_BASE_CLASS = 'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-semibold';
 
 export const ALL_LOG_LINE_TONES: WorkflowRunLogLineTone[] = ['default', 'command', 'group', 'warning', 'error'];
-export const LOG_LINE_FILTER_OPTIONS = [
-  { tone: 'default', label: 'Default' },
-  { tone: 'command', label: 'Commands' },
-  { tone: 'warning', label: 'Warnings' },
-  { tone: 'error', label: 'Errors' },
-] as const satisfies ReadonlyArray<{ tone: WorkflowRunLogLineTone; label: string }>;
+
+export const LOG_LEVEL_FILTER_OPTIONS: { label: string; value: LogLevelFilter }[] = [
+  { label: 'All Logs', value: 'all' },
+  { label: 'Warnings & Errors', value: 'warnings' },
+  { label: 'Errors Only', value: 'errors' },
+];
 
 const ALL_LOG_LINE_TONE_SET: ReadonlySet<WorkflowRunLogLineTone> = new Set(ALL_LOG_LINE_TONES);
-const DISABLED_LINE_TONE_FILTER_CLASS =
-  'border-surface-300 bg-surface-0 text-surface-500 hover:border-surface-400 hover:bg-surface-100 hover:text-surface-700 dark:border-surface-700 dark:bg-surface-900 dark:text-surface-400 dark:hover:border-surface-600 dark:hover:bg-surface-800 dark:hover:text-surface-200';
+const WARNINGS_AND_ERRORS_TONE_SET: ReadonlySet<WorkflowRunLogLineTone> = new Set<WorkflowRunLogLineTone>(['warning', 'error', 'group']);
+const ERRORS_ONLY_TONE_SET: ReadonlySet<WorkflowRunLogLineTone> = new Set<WorkflowRunLogLineTone>(['error', 'group']);
+
+export function getEnabledTonesForLevel(level: LogLevelFilter): ReadonlySet<WorkflowRunLogLineTone> {
+  switch (level) {
+    case 'warnings':
+      return WARNINGS_AND_ERRORS_TONE_SET;
+    case 'errors':
+      return ERRORS_ONLY_TONE_SET;
+    default:
+      return ALL_LOG_LINE_TONE_SET;
+  }
+}
 const LOG_LINE_TONE_STYLES: Record<
   WorkflowRunLogLineTone,
   {
@@ -200,7 +213,7 @@ export function buildGroupViews(groups: WorkflowRunLogGroupDto[]): WorkflowRunLo
 
 export function buildSelectedFileView(
   selectedFile: WorkflowRunLogFileView | null,
-  enabledLineTones: ReadonlySet<WorkflowRunLogLineTone>,
+  logLevelFilter: LogLevelFilter,
   expandedLogGroupIds: Readonly<Record<string, boolean>>
 ): SelectedWorkflowRunLogFileView | null {
   if (!selectedFile) {
@@ -210,11 +223,12 @@ export function buildSelectedFileView(
   const lines = buildLogLines(selectedFile.file.content);
   const entries = buildLogEntries(lines);
   const allRows = buildVisibleLogRows(entries, ALL_LOG_LINE_TONE_SET, expandedLogGroupIds, 0, true);
+  const enabledTones = getEnabledTonesForLevel(logLevelFilter);
 
   return {
     selectedFile,
     lineStats: getLineStats(lines),
-    rows: buildVisibleLogRows(entries, enabledLineTones, expandedLogGroupIds),
+    rows: buildVisibleLogRows(entries, enabledTones, expandedLogGroupIds),
     totalRowCount: allRows.length,
   };
 }
@@ -240,10 +254,6 @@ export function getAutoExpandedLogGroupIds(content: string, tone: Extract<Workfl
   collectGroupIdsContainingTone(entries, tone, expandedGroupIds);
 
   return Object.fromEntries(Array.from(expandedGroupIds, groupId => [groupId, true]));
-}
-
-export function getLineToneFilterClass(tone: WorkflowRunLogLineTone, isEnabled: boolean): string {
-  return isEnabled ? LOG_LINE_TONE_STYLES[tone].filterClass : DISABLED_LINE_TONE_FILTER_CLASS;
 }
 
 export function getLineToneRowClass(tone: WorkflowRunLogLineTone): string {


### PR DESCRIPTION
### Motivation

Workflow run logs currently expose several low-level line tone toggles, which makes filtering harder to scan and can leave empty group rows visible when filters hide their children. Reviewers need a simpler way to focus on warnings and errors while keeping grouped log context readable.

Fixes #985 

### Description

- Replaced individual log line tone toggles with a single log level select button.
- Added filter modes for all logs, warnings and errors, and errors only.
- Hide the filter toolbar when the selected log file has no warnings or errors.
- Preserve matching log groups while filtering and skip groups without matching child content.
- Updated workflow run log component and utility tests for the new filtering behavior.

### Testing Instructions

#### Prerequisites:
- GitHub Account without having any additional access-rights (e.g. admin, owner)
- A repository in Helios with completed workflow runs
- At least one workflow run log file containing warnings or errors

#### Flow:
1. Log in to Helios as a Developer.
2. Open a repository with completed workflow runs.
3. Navigate to a workflow run logs page.
4. Select a log file that contains warnings or errors.
5. Verify the log level filter is shown above the log output.
6. Switch between `All Logs`, `Warnings & Errors`, and `Errors Only`.
7. Verify each filter shows only the expected log lines while preserving relevant group rows.
8. Select a log file without warnings or errors and verify the filter toolbar is hidden.

### Screenshots

https://github.com/user-attachments/assets/578b5188-0475-4cbe-94b6-808850016164


### Checklist

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.