### PR TITLE
feat: implement WebSocket-based real-time updates for workflow runs with JWT authentication

### DIFF
--- a/client/src/app/components/environments/environment-list/environment-list-view.component.ts
+++ b/client/src/app/components/environments/environment-list/environment-list-view.component.ts
@@ -15,6 +15,7 @@ import {
   unlockEnvironmentMutation,
   cancelDeploymentMutation,
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { EnvironmentDeploymentWebSocketService } from '@app/core/services/environment-deployment-websocket/environment-deployment-websocket.service';
 import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 import { PermissionService } from '@app/core/services/permission.service';
 import { injectMutation, injectQuery, QueryClient } from '@tanstack/angular-query-experimental';
@@ -73,8 +74,10 @@ export class EnvironmentListViewComponent implements OnDestroy {
   private confirmationService = inject(ConfirmationService);
   private keycloakService = inject(KeycloakService);
   private permissionService = inject(PermissionService);
+  private environmentDeploymentWebSocketService = inject(EnvironmentDeploymentWebSocketService);
   private currentTime = signal(Date.now());
   private intervalId: number | undefined;
+  private webSocketCleanup: (() => void) | undefined;
   private messageService = inject(MessageService);
 
   deployDialogVisible = signal(false);
@@ -157,7 +160,10 @@ export class EnvironmentListViewComponent implements OnDestroy {
   canViewAllEnvironments = computed(() => this.isLoggedIn() && this.editable() && this.hasEditEnvironmentPermissions());
   queryFunction = computed(() => {
     const options = this.canViewAllEnvironments() ? getAllEnvironmentsOptions() : getAllEnabledEnvironmentsOptions();
-    return { ...options, refetchInterval: 3000 };
+    return {
+      ...options,
+      refetchInterval: () => (this.environmentDeploymentWebSocketService.isConnected() ? false : 60000),
+    };
   });
   queryKey = computed(() => (this.canViewAllEnvironments() ? getAllEnvironmentsQueryKey() : getAllEnabledEnvironmentsQueryKey()));
 
@@ -199,12 +205,14 @@ export class EnvironmentListViewComponent implements OnDestroy {
   }
 
   constructor() {
+    this.webSocketCleanup = this.environmentDeploymentWebSocketService.activate();
     this.intervalId = window.setInterval(() => {
       this.currentTime.set(Date.now());
     }, 1000);
   }
 
   ngOnDestroy(): void {
+    this.webSocketCleanup?.();
     if (this.intervalId !== undefined) {
       clearInterval(this.intervalId);
     }

--- a/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
+++ b/client/src/app/components/release-candidate-deployment-table/release-candidate-deployment-table.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, signal } from '@angular/core';
+import { Component, OnDestroy, computed, inject, input, signal } from '@angular/core';
 import { EnvironmentDto, getReleaseInfoByName, ReleaseInfoDetailsDto } from '@app/core/modules/openapi';
 import {
   deployToEnvironmentMutation,
@@ -6,6 +6,7 @@ import {
   getAllEnabledEnvironmentsQueryKey,
   getEnvironmentByIdQueryKey,
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { EnvironmentDeploymentWebSocketService } from '@app/core/services/environment-deployment-websocket/environment-deployment-websocket.service';
 import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
 import { PermissionService } from '@app/core/services/permission.service';
 import { injectMutation, injectQuery, QueryClient } from '@tanstack/angular-query-experimental';
@@ -46,7 +47,7 @@ import { DeployConfirmationComponent } from '@app/components/dialogs/deploy-conf
   ],
   templateUrl: './release-candidate-deployment-table.component.html',
 })
-export class ReleaseCandidateDeploymentTableComponent {
+export class ReleaseCandidateDeploymentTableComponent implements OnDestroy {
   releaseCandidate = input.required<ReleaseInfoDetailsDto>();
   queryClient = inject(QueryClient);
   selectedEnvironment = signal<EnvironmentDto | undefined>(undefined);
@@ -55,11 +56,16 @@ export class ReleaseCandidateDeploymentTableComponent {
   messageService = inject(MessageService);
   keycloakService = inject(KeycloakService);
   permissions = inject(PermissionService);
+  private environmentDeploymentWebSocketService = inject(EnvironmentDeploymentWebSocketService);
+  private webSocketCleanup = this.environmentDeploymentWebSocketService.activate();
   isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
 
   userCanDeploy = computed(() => !!(this.isLoggedIn() && this.permissions.isAdmin()));
 
-  environmentQuery = injectQuery(() => ({ ...getAllEnabledEnvironmentsOptions(), refetchInterval: 3000 }));
+  environmentQuery = injectQuery(() => ({
+    ...getAllEnabledEnvironmentsOptions(),
+    refetchInterval: () => (this.environmentDeploymentWebSocketService.isConnected() ? false : 60000),
+  }));
 
   groupedEnvironments = computed(() => {
     const environments = this.environmentQuery.data() || [];
@@ -155,5 +161,9 @@ export class ReleaseCandidateDeploymentTableComponent {
       return 'http://' + url;
     }
     return url;
+  }
+
+  ngOnDestroy(): void {
+    this.webSocketCleanup();
   }
 }

--- a/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.spec.ts
+++ b/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.spec.ts
@@ -63,11 +63,7 @@ describe('EnvironmentDeploymentWebSocketService', () => {
     expect(webSocket).toHaveBeenCalledOnce();
     const config = vi.mocked(webSocket).mock.calls[0][0];
     expect(config.url).toMatch(/\/ws\/environments$/);
-    expect(config.protocol).toEqual([
-      'helios.v1',
-      'helios.token.access-token',
-      'helios.repo.42',
-    ]);
+    expect(config.protocol).toEqual(['helios.v1', 'helios.token.access-token', 'helios.repo.42']);
 
     config.openObserver?.next(undefined);
     expect(service.isConnected()).toBe(true);

--- a/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.spec.ts
+++ b/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.spec.ts
@@ -1,0 +1,97 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { Subject } from 'rxjs';
+import { QueryClient } from '@tanstack/angular-query-experimental';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { RepositoryService } from '@app/core/services/repository.service';
+import { EnvironmentDeploymentWebSocketService } from './environment-deployment-websocket.service';
+import { EnvironmentDeploymentWsServerMessage } from './environment-deployment-websocket.types';
+import { webSocket } from 'rxjs/webSocket';
+
+vi.mock('rxjs/webSocket', () => ({
+  webSocket: vi.fn(),
+}));
+
+describe('EnvironmentDeploymentWebSocketService', () => {
+  let socketSubject: Subject<EnvironmentDeploymentWsServerMessage>;
+  let queryClient: { invalidateQueries: ReturnType<typeof vi.fn> };
+  let repositoryService: { currentRepositoryId: ReturnType<typeof signal<number | string | null>> };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    socketSubject = new Subject<EnvironmentDeploymentWsServerMessage>();
+    queryClient = { invalidateQueries: vi.fn() };
+    repositoryService = { currentRepositoryId: signal<number | string | null>(null) };
+    vi.mocked(webSocket).mockReturnValue(socketSubject as never);
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        EnvironmentDeploymentWebSocketService,
+        {
+          provide: QueryClient,
+          useValue: queryClient,
+        },
+        {
+          provide: KeycloakService,
+          useValue: {
+            keycloak: {
+              token: 'access-token',
+            },
+          },
+        },
+        {
+          provide: RepositoryService,
+          useValue: repositoryService,
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('opens the repository-scoped WebSocket with token and repository subprotocols', () => {
+    const service = TestBed.inject(EnvironmentDeploymentWebSocketService);
+
+    service.activate();
+    repositoryService.currentRepositoryId.set(42);
+    TestBed.flushEffects();
+
+    expect(webSocket).toHaveBeenCalledOnce();
+    const config = vi.mocked(webSocket).mock.calls[0][0];
+    expect(config.url).toMatch(/\/ws\/environments$/);
+    expect(config.protocol).toEqual([
+      'helios.v1',
+      'helios.token.access-token',
+      'helios.repo.42',
+    ]);
+
+    config.openObserver?.next(undefined);
+    expect(service.isConnected()).toBe(true);
+  });
+
+  it('batches environment deployment invalidations', () => {
+    TestBed.inject(EnvironmentDeploymentWebSocketService).activate();
+    repositoryService.currentRepositoryId.set(42);
+    TestBed.flushEffects();
+
+    socketSubject.next({
+      type: 'environment-deployment-invalidated',
+      repositoryId: 42,
+      environmentId: 7,
+    });
+    socketSubject.next({
+      type: 'environment-deployment-invalidated',
+      repositoryId: 42,
+      environmentId: 8,
+    });
+
+    expect(queryClient.invalidateQueries).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(100);
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(5);
+  });
+});

--- a/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.ts
+++ b/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.ts
@@ -1,0 +1,167 @@
+import { Injectable, computed, effect, inject, signal } from '@angular/core';
+import { QueryClient } from '@tanstack/angular-query-experimental';
+import {
+  getAllEnabledEnvironmentsQueryKey,
+  getAllEnvironmentsQueryKey,
+  getEnvironmentByIdQueryKey,
+  getEnvironmentsByUserLockingQueryKey,
+} from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { RepositoryService } from '@app/core/services/repository.service';
+import { environment } from 'environments/environment';
+import { Subscription, timer } from 'rxjs';
+import { retry } from 'rxjs/operators';
+import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
+import { EnvironmentDeploymentWsServerMessage } from './environment-deployment-websocket.types';
+
+const SUBPROTOCOL = 'helios.v1';
+const TOKEN_PREFIX = 'helios.token.';
+const REPO_PREFIX = 'helios.repo.';
+const INVALIDATION_DEBOUNCE_MS = 100;
+
+@Injectable({ providedIn: 'root' })
+export class EnvironmentDeploymentWebSocketService {
+  private readonly keycloak = inject(KeycloakService);
+  private readonly queryClient = inject(QueryClient);
+  private readonly repositoryService = inject(RepositoryService);
+
+  private socket$: WebSocketSubject<EnvironmentDeploymentWsServerMessage> | null = null;
+  private socketSub: Subscription | null = null;
+  private activeConsumers = signal(0);
+  private activeRepositoryId: number | null = null;
+  private connected = signal(false);
+  private pendingEnvironmentIds = new Set<number>();
+  private invalidationTimer: ReturnType<typeof setTimeout> | null = null;
+
+  readonly isConnected = computed(() => this.connected());
+
+  constructor() {
+    effect(() => {
+      const repositoryId = this.repositoryService.currentRepositoryId();
+      const activeConsumers = this.activeConsumers();
+      this.syncConnection(repositoryId, activeConsumers);
+    });
+  }
+
+  activate(): () => void {
+    this.activeConsumers.update(count => count + 1);
+    return () => {
+      this.activeConsumers.update(count => Math.max(0, count - 1));
+    };
+  }
+
+  private syncConnection(repositoryIdValue: number | string | null, activeConsumers: number): void {
+    const repositoryId = this.parseRepositoryId(repositoryIdValue);
+    const shouldConnect = activeConsumers > 0 && repositoryId !== null;
+
+    if (!shouldConnect) {
+      this.disconnect();
+      return;
+    }
+
+    if (this.socket$ && this.activeRepositoryId === repositoryId) {
+      return;
+    }
+
+    this.disconnect();
+    this.activeRepositoryId = repositoryId;
+    this.socket$ = this.openSocket(repositoryId);
+    this.socketSub = this.socket$
+      .pipe(
+        retry({
+          delay: (_, attempt) => timer(Math.min(30_000, 500 * 2 ** Math.min(attempt, 6))),
+        })
+      )
+      .subscribe({
+        next: msg => this.handleMessage(msg),
+        error: () => {
+          this.connected.set(false);
+          this.socket$ = null;
+        },
+      });
+  }
+
+  private openSocket(repositoryId: number): WebSocketSubject<EnvironmentDeploymentWsServerMessage> {
+    const token = this.keycloak.keycloak.token ?? '';
+    const protocols = [SUBPROTOCOL, `${TOKEN_PREFIX}${token}`, `${REPO_PREFIX}${repositoryId}`];
+    return webSocket<EnvironmentDeploymentWsServerMessage>({
+      url: this.buildUrl(),
+      protocol: protocols,
+      openObserver: {
+        next: () => this.connected.set(true),
+      },
+      closeObserver: {
+        next: () => this.connected.set(false),
+      },
+    });
+  }
+
+  private handleMessage(msg: EnvironmentDeploymentWsServerMessage): void {
+    if (msg.type !== 'environment-deployment-invalidated') {
+      return;
+    }
+
+    if (msg.repositoryId !== this.activeRepositoryId) {
+      return;
+    }
+
+    this.pendingEnvironmentIds.add(msg.environmentId);
+    if (this.invalidationTimer) {
+      return;
+    }
+
+    this.invalidationTimer = setTimeout(() => this.flushInvalidations(), INVALIDATION_DEBOUNCE_MS);
+  }
+
+  private flushInvalidations(): void {
+    const environmentIds = Array.from(this.pendingEnvironmentIds);
+    this.pendingEnvironmentIds.clear();
+    this.invalidationTimer = null;
+
+    for (const environmentId of environmentIds) {
+      this.queryClient.invalidateQueries({
+        queryKey: getEnvironmentByIdQueryKey({ path: { id: environmentId } }),
+      });
+    }
+
+    if (environmentIds.length === 0) {
+      return;
+    }
+
+    this.queryClient.invalidateQueries({ queryKey: getAllEnabledEnvironmentsQueryKey() });
+    this.queryClient.invalidateQueries({ queryKey: getAllEnvironmentsQueryKey() });
+    this.queryClient.invalidateQueries({ queryKey: getEnvironmentsByUserLockingQueryKey() });
+  }
+
+  private disconnect(): void {
+    if (this.invalidationTimer) {
+      clearTimeout(this.invalidationTimer);
+      this.invalidationTimer = null;
+    }
+    this.pendingEnvironmentIds.clear();
+    this.socketSub?.unsubscribe();
+    this.socketSub = null;
+    this.socket$?.complete();
+    this.socket$ = null;
+    this.activeRepositoryId = null;
+    this.connected.set(false);
+  }
+
+  private buildUrl(): string {
+    const base = environment.serverUrl;
+    const wsBase = base.startsWith('https://')
+      ? 'wss://' + base.slice('https://'.length)
+      : base.startsWith('http://')
+        ? 'ws://' + base.slice('http://'.length)
+        : base;
+    return wsBase.replace(/\/+$/, '') + '/ws/environments';
+  }
+
+  private parseRepositoryId(repositoryId: number | string | null): number | null {
+    if (repositoryId === null) {
+      return null;
+    }
+    const parsed = Number(repositoryId);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+}

--- a/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.ts
+++ b/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.service.ts
@@ -149,11 +149,7 @@ export class EnvironmentDeploymentWebSocketService {
 
   private buildUrl(): string {
     const base = environment.serverUrl;
-    const wsBase = base.startsWith('https://')
-      ? 'wss://' + base.slice('https://'.length)
-      : base.startsWith('http://')
-        ? 'ws://' + base.slice('http://'.length)
-        : base;
+    const wsBase = base.startsWith('https://') ? 'wss://' + base.slice('https://'.length) : base.startsWith('http://') ? 'ws://' + base.slice('http://'.length) : base;
     return wsBase.replace(/\/+$/, '') + '/ws/environments';
   }
 

--- a/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.types.ts
+++ b/client/src/app/core/services/environment-deployment-websocket/environment-deployment-websocket.types.ts
@@ -1,0 +1,10 @@
+export type EnvironmentDeploymentWsClientMessage = { type: 'ping' };
+
+export type EnvironmentDeploymentWsServerMessage =
+  | {
+      type: 'environment-deployment-invalidated';
+      repositoryId: number;
+      environmentId: number;
+    }
+  | { type: 'error'; code: string; message: string }
+  | { type: 'pong' };

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.spec.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.spec.ts
@@ -1,0 +1,99 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { Subject } from 'rxjs';
+import { webSocket } from 'rxjs/webSocket';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { WorkflowRunWebSocketService } from './workflow-run-websocket.service';
+import { WsServerMessage } from './workflow-run-websocket.types';
+
+vi.mock('rxjs/webSocket', () => ({
+  webSocket: vi.fn(),
+}));
+
+describe('WorkflowRunWebSocketService', () => {
+  let socketSubjects: Array<Subject<WsServerMessage>>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    socketSubjects = [];
+    vi.mocked(webSocket).mockImplementation(() => {
+      const socketSubject = new Subject<WsServerMessage>();
+      vi.spyOn(socketSubject, 'next');
+      vi.spyOn(socketSubject, 'complete');
+      socketSubjects.push(socketSubject);
+      return socketSubject as never;
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        WorkflowRunWebSocketService,
+        {
+          provide: KeycloakService,
+          useValue: {
+            keycloak: {
+              token: 'access-token',
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('opens the repository-scoped WebSocket with token and repository subprotocols', () => {
+    const subscription = TestBed.inject(WorkflowRunWebSocketService).subscribe(7, 42).subscribe();
+
+    expect(webSocket).toHaveBeenCalledOnce();
+    const config = vi.mocked(webSocket).mock.calls[0][0];
+    expect(config.url).toMatch(/\/ws\/workflow-runs$/);
+    expect(config.protocol).toEqual(['helios.v1', 'helios.token.access-token', 'helios.repo.42']);
+    expect(socketSubjects[0].next).toHaveBeenCalledWith({ type: 'subscribe', runId: 7 });
+
+    subscription.unsubscribe();
+  });
+
+  it('reconnects and resubscribes after a clean WebSocket completion', () => {
+    const subscription = TestBed.inject(WorkflowRunWebSocketService).subscribe(7, 42).subscribe();
+
+    socketSubjects[0].complete();
+    vi.advanceTimersByTime(999);
+    expect(webSocket).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    expect(webSocket).toHaveBeenCalledTimes(2);
+
+    const reconnectConfig = vi.mocked(webSocket).mock.calls[1][0];
+    reconnectConfig.openObserver?.next(undefined);
+    expect(socketSubjects[1].next).toHaveBeenCalledWith({ type: 'subscribe', runId: 7 });
+
+    subscription.unsubscribe();
+  });
+
+  it('reconnects after a WebSocket error', () => {
+    const subscription = TestBed.inject(WorkflowRunWebSocketService).subscribe(7, 42).subscribe();
+
+    socketSubjects[0].error(new Error('connection lost'));
+    vi.advanceTimersByTime(1_000);
+
+    expect(webSocket).toHaveBeenCalledTimes(2);
+
+    subscription.unsubscribe();
+  });
+
+  it('does not reconnect after manual unsubscribe disconnects the socket', () => {
+    const subscription = TestBed.inject(WorkflowRunWebSocketService).subscribe(7, 42).subscribe();
+
+    subscription.unsubscribe();
+    expect(socketSubjects[0].next).toHaveBeenCalledWith({ type: 'unsubscribe', runId: 7 });
+    expect(socketSubjects[0].complete).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(30_000);
+    expect(webSocket).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable, Subject, Subscription, timer } from 'rxjs';
+import { filter, retry } from 'rxjs/operators';
+import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
+import { environment } from 'environments/environment';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { WsClientMessage, WsServerMessage } from './workflow-run-websocket.types';
+
+const SUBPROTOCOL = 'helios.v1';
+const TOKEN_PREFIX = 'helios.token.';
+const REPO_PREFIX = 'helios.repo.';
+
+/**
+ * Shared, refcounted WebSocket connection for workflow run push updates.
+ *
+ * One socket per app, multiplexed by runId. The socket opens lazily on the first {@link subscribe}
+ * call and closes when the last subscription is torn down. Reconnect uses exponential backoff and
+ * re-emits subscribe envelopes for every active runId.
+ */
+@Injectable({ providedIn: 'root' })
+export class WorkflowRunWebSocketService {
+  private readonly keycloak = inject(KeycloakService);
+
+  private socket$: WebSocketSubject<WsServerMessage> | null = null;
+  private socketSub: Subscription | null = null;
+  private readonly incoming$ = new Subject<WsServerMessage>();
+  private readonly activeRunIds = new Map<number, number>();
+
+  /**
+   * Subscribe to push updates for a single workflow run. Multiple callers for the same runId share
+   * the same upstream subscription; the socket sends `{type:'subscribe'}` once and `{type:'unsubscribe'}`
+   * after the last caller tears down.
+   */
+  subscribe(runId: number, repositoryId: number): Observable<WsServerMessage> {
+    return new Observable<WsServerMessage>(subscriber => {
+      this.ensureConnected(repositoryId);
+      const refcount = this.activeRunIds.get(runId) ?? 0;
+      this.activeRunIds.set(runId, refcount + 1);
+      if (refcount === 0) {
+        this.send({ type: 'subscribe', runId });
+      }
+
+      const sub = this.incoming$
+        .pipe(filter(msg => 'runId' in msg && msg.runId === runId))
+        .subscribe(subscriber);
+
+      return () => {
+        sub.unsubscribe();
+        const next = (this.activeRunIds.get(runId) ?? 1) - 1;
+        if (next <= 0) {
+          this.activeRunIds.delete(runId);
+          this.send({ type: 'unsubscribe', runId });
+        } else {
+          this.activeRunIds.set(runId, next);
+        }
+        if (this.activeRunIds.size === 0) {
+          this.disconnect();
+        }
+      };
+    });
+  }
+
+  private ensureConnected(repositoryId: number): void {
+    if (this.socket$) {
+      return;
+    }
+    this.socket$ = this.openSocket(repositoryId);
+    this.socketSub = this.socket$
+      .pipe(
+        retry({
+          delay: (_, attempt) => timer(Math.min(30_000, 500 * 2 ** Math.min(attempt, 6))),
+        }),
+      )
+      .subscribe({
+        next: msg => this.incoming$.next(msg),
+        error: () => {
+          // retry already exhausted somehow; close out
+          this.socket$ = null;
+        },
+      });
+  }
+
+  private openSocket(repositoryId: number): WebSocketSubject<WsServerMessage> {
+    const token = this.keycloak.keycloak.token ?? '';
+    const protocols = [SUBPROTOCOL, `${TOKEN_PREFIX}${token}`, `${REPO_PREFIX}${repositoryId}`];
+    return webSocket<WsServerMessage>({
+      url: this.buildUrl(),
+      protocol: protocols,
+      openObserver: {
+        next: () => {
+          // On (re)connect, re-emit subscribe envelopes for every active runId.
+          for (const runId of this.activeRunIds.keys()) {
+            this.send({ type: 'subscribe', runId });
+          }
+        },
+      },
+    });
+  }
+
+  private send(msg: WsClientMessage): void {
+    this.socket$?.next(msg as unknown as WsServerMessage);
+  }
+
+  private disconnect(): void {
+    this.socketSub?.unsubscribe();
+    this.socketSub = null;
+    this.socket$?.complete();
+    this.socket$ = null;
+  }
+
+  private buildUrl(): string {
+    const base = environment.serverUrl;
+    const wsBase = base.startsWith('https://')
+      ? 'wss://' + base.slice('https://'.length)
+      : base.startsWith('http://')
+        ? 'ws://' + base.slice('http://'.length)
+        : base;
+    return wsBase.replace(/\/+$/, '') + '/ws/workflow-runs';
+  }
+}

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
@@ -72,7 +72,7 @@ export class WorkflowRunWebSocketService {
         }),
         repeat({
           delay: attempt => this.reconnectDelay(attempt),
-        }),
+        })
       )
       .subscribe({
         next: msg => this.incoming$.next(msg),

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
@@ -40,9 +40,7 @@ export class WorkflowRunWebSocketService {
         this.send({ type: 'subscribe', runId });
       }
 
-      const sub = this.incoming$
-        .pipe(filter(msg => 'runId' in msg && msg.runId === runId))
-        .subscribe(subscriber);
+      const sub = this.incoming$.pipe(filter(msg => 'runId' in msg && msg.runId === runId)).subscribe(subscriber);
 
       return () => {
         sub.unsubscribe();
@@ -69,7 +67,7 @@ export class WorkflowRunWebSocketService {
       .pipe(
         retry({
           delay: (_, attempt) => timer(Math.min(30_000, 500 * 2 ** Math.min(attempt, 6))),
-        }),
+        })
       )
       .subscribe({
         next: msg => this.incoming$.next(msg),
@@ -110,11 +108,7 @@ export class WorkflowRunWebSocketService {
 
   private buildUrl(): string {
     const base = environment.serverUrl;
-    const wsBase = base.startsWith('https://')
-      ? 'wss://' + base.slice('https://'.length)
-      : base.startsWith('http://')
-        ? 'ws://' + base.slice('http://'.length)
-        : base;
+    const wsBase = base.startsWith('https://') ? 'wss://' + base.slice('https://'.length) : base.startsWith('http://') ? 'ws://' + base.slice('http://'.length) : base;
     return wsBase.replace(/\/+$/, '') + '/ws/workflow-runs';
   }
 }

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable, Subject, Subscription, timer } from 'rxjs';
-import { filter, retry } from 'rxjs/operators';
+import { defer, Observable, Subject, Subscription, timer } from 'rxjs';
+import { filter, repeat, retry } from 'rxjs/operators';
 import { WebSocketSubject, webSocket } from 'rxjs/webSocket';
 import { environment } from 'environments/environment';
 import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
@@ -62,12 +62,17 @@ export class WorkflowRunWebSocketService {
     if (this.socket$) {
       return;
     }
-    this.socket$ = this.openSocket(repositoryId);
-    this.socketSub = this.socket$
+    this.socketSub = defer(() => {
+      this.socket$ = this.openSocket(repositoryId);
+      return this.socket$;
+    })
       .pipe(
         retry({
-          delay: (_, attempt) => timer(Math.min(30_000, 500 * 2 ** Math.min(attempt, 6))),
-        })
+          delay: (_, attempt) => this.reconnectDelay(attempt),
+        }),
+        repeat({
+          delay: attempt => this.reconnectDelay(attempt),
+        }),
       )
       .subscribe({
         next: msg => this.incoming$.next(msg),
@@ -97,6 +102,10 @@ export class WorkflowRunWebSocketService {
 
   private send(msg: WsClientMessage): void {
     this.socket$?.next(msg as unknown as WsServerMessage);
+  }
+
+  private reconnectDelay(attempt: number): Observable<number> {
+    return timer(Math.min(30_000, 500 * 2 ** Math.min(attempt, 6)));
   }
 
   private disconnect(): void {

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.types.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.types.ts
@@ -1,9 +1,6 @@
 import { WorkflowRunDto } from '@app/core/modules/openapi';
 
-export type WsClientMessage =
-  | { type: 'subscribe'; runId: number }
-  | { type: 'unsubscribe'; runId: number }
-  | { type: 'ping' };
+export type WsClientMessage = { type: 'subscribe'; runId: number } | { type: 'unsubscribe'; runId: number } | { type: 'ping' };
 
 export type WsServerMessage =
   | { type: 'workflow-run-updated'; runId: number; run: WorkflowRunDto }

--- a/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.types.ts
+++ b/client/src/app/core/services/workflow-run-websocket/workflow-run-websocket.types.ts
@@ -1,0 +1,12 @@
+import { WorkflowRunDto } from '@app/core/modules/openapi';
+
+export type WsClientMessage =
+  | { type: 'subscribe'; runId: number }
+  | { type: 'unsubscribe'; runId: number }
+  | { type: 'ping' };
+
+export type WsServerMessage =
+  | { type: 'workflow-run-updated'; runId: number; run: WorkflowRunDto }
+  | { type: 'workflow-jobs-invalidated'; runId: number }
+  | { type: 'error'; code: string; message: string; runId?: number | null }
+  | { type: 'pong' };

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, input, numberAttribute, signal } from '@angular/core';
+import { Component, computed, effect, inject, input, numberAttribute } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { WorkflowJobDto, WorkflowRunDto } from '@app/core/modules/openapi';
 import {
@@ -11,6 +11,7 @@ import {
   reRunFailedJobsMutation,
 } from '@app/core/modules/openapi/@tanstack/angular-query-experimental.gen';
 import { PermissionService } from '@app/core/services/permission.service';
+import { WorkflowRunWebSocketService } from '@app/core/services/workflow-run-websocket/workflow-run-websocket.service';
 import { WorkflowJobListComponent } from '@app/components/workflow-job-list/workflow-job-list.component';
 import { PipelineTestResultsComponent } from '@app/components/pipeline/test-results/pipeline-test-results.component';
 import { PipelineSelector } from '@app/components/pipeline/pipeline.component';
@@ -80,27 +81,12 @@ export class WorkflowRunDetailsComponent {
   protected permissions = inject(PermissionService);
   private messageService = inject(MessageService);
   private queryClient = inject(QueryClient);
+  private wsService = inject(WorkflowRunWebSocketService);
 
-  // Duration to continue polling after a user action (cancel/rerun) to ensure UI updates promptly.
-  private readonly FORCED_POLL_DURATION_MS = 2 * 60 * 1000;
-
-  // Timestamp set when a user action (cancel/rerun) is triggered.
-  private actionTriggeredAt = signal<number | null>(null);
-
-  runQuery = injectQuery(() => {
-    const actionAt = this.actionTriggeredAt();
-    return {
-      ...getWorkflowRunByIdOptions({ path: { runId: this.runId() } }),
-      refetchInterval: (query: { state?: { data?: WorkflowRunDto } }) => {
-        const data = query.state?.data;
-        const activeStatuses = ['IN_PROGRESS', 'QUEUED', 'WAITING', 'PENDING', 'REQUESTED'];
-        if (data && activeStatuses.includes(data.status)) return 5000;
-        if (actionAt !== null && Date.now() - actionAt < this.FORCED_POLL_DURATION_MS) return 5000;
-        return 0;
-      },
-      staleTime: 0,
-    };
-  });
+  runQuery = injectQuery(() => ({
+    ...getWorkflowRunByIdOptions({ path: { runId: this.runId() } }),
+    staleTime: 0,
+  }));
 
   run = computed(() => this.runQuery.data() ?? null);
 
@@ -110,21 +96,32 @@ export class WorkflowRunDetailsComponent {
     return { repositoryId: this.repositoryId(), workflowRunId: this.runId() };
   });
 
-  workflowJobsQuery = injectQuery(() => {
-    const actionAt = this.actionTriggeredAt();
-    return {
-      ...getWorkflowJobStatusOptions({ path: { runId: this.runId() } }),
-      queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.runId() } }),
-      enabled: this.permissions.hasWritePermission(),
-      refetchInterval: (query: { state?: { data?: { jobs?: WorkflowJobDto[] } } }) => {
-        const data = query.state?.data;
-        const inProgress = (data?.jobs ?? []).some(j => j.status === 'in_progress' || j.status === 'queued' || j.status === 'waiting');
-        if (inProgress) return 5000;
-        if (actionAt !== null && Date.now() - actionAt < this.FORCED_POLL_DURATION_MS) return 5000;
-        return 0;
-      },
-      staleTime: 0,
-    };
+  workflowJobsQuery = injectQuery(() => ({
+    ...getWorkflowJobStatusOptions({ path: { runId: this.runId() } }),
+    queryKey: getWorkflowJobStatusQueryKey({ path: { runId: this.runId() } }),
+    enabled: this.permissions.hasWritePermission(),
+    staleTime: 0,
+  }));
+
+  private wsEffect = effect(onCleanup => {
+    const runId = this.runId();
+    const repositoryId = this.repositoryId();
+    if (!runId || !repositoryId) return;
+
+    const sub = this.wsService.subscribe(runId, repositoryId).subscribe(msg => {
+      if (msg.type === 'workflow-run-updated') {
+        this.queryClient.setQueryData<WorkflowRunDto>(
+          getWorkflowRunByIdQueryKey({ path: { runId } }),
+          msg.run,
+        );
+      } else if (msg.type === 'workflow-jobs-invalidated') {
+        this.queryClient.invalidateQueries({
+          queryKey: getWorkflowJobStatusQueryKey({ path: { runId } }),
+        });
+      }
+    });
+
+    onCleanup(() => sub.unsubscribe());
   });
 
   jobs = computed<WorkflowJobDto[]>(() => {
@@ -168,8 +165,7 @@ export class WorkflowRunDetailsComponent {
 
   private invalidateRunQueries(): void {
     const runId = this.runId();
-    // Set the timestamp to trigger more frequent polling for a short duration to ensure UI updates promptly after user actions.
-    this.actionTriggeredAt.set(Date.now());
+    // Safety net: if the WS push races with the mutation response, this guarantees a refetch.
     this.queryClient.invalidateQueries({ queryKey: getWorkflowRunByIdQueryKey({ path: { runId } }) });
     this.queryClient.invalidateQueries({ queryKey: getWorkflowJobStatusQueryKey({ path: { runId } }) });
   }

--- a/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
+++ b/client/src/app/pages/workflow-run-details/workflow-run-details.component.ts
@@ -110,10 +110,7 @@ export class WorkflowRunDetailsComponent {
 
     const sub = this.wsService.subscribe(runId, repositoryId).subscribe(msg => {
       if (msg.type === 'workflow-run-updated') {
-        this.queryClient.setQueryData<WorkflowRunDto>(
-          getWorkflowRunByIdQueryKey({ path: { runId } }),
-          msg.run,
-        );
+        this.queryClient.setQueryData<WorkflowRunDto>(getWorkflowRunByIdQueryKey({ path: { runId } }), msg.run);
       } else if (msg.type === 'workflow-jobs-invalidated') {
         this.queryClient.invalidateQueries({
           queryKey: getWorkflowJobStatusQueryKey({ path: { runId } }),

--- a/server/application-server/build.gradle
+++ b/server/application-server/build.gradle
@@ -38,9 +38,15 @@ dependencies {
     implementation(platform("org.springframework.ai:spring-ai-bom:2.0.0-M6"))
     implementation 'org.springframework.boot:spring-boot-starter-aspectj'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+<<<<<<< HEAD
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server'
+=======
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+>>>>>>> 6cc5fff7 (feat: implement WebSocket-based real-time updates for workflow runs with JWT authentication)
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.springframework.boot:spring-boot-jackson2'

--- a/server/application-server/build.gradle
+++ b/server/application-server/build.gradle
@@ -38,15 +38,10 @@ dependencies {
     implementation(platform("org.springframework.ai:spring-ai-bom:2.0.0-M6"))
     implementation 'org.springframework.boot:spring-boot-starter-aspectj'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-<<<<<<< HEAD
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server'
-=======
-    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
->>>>>>> 6cc5fff7 (feat: implement WebSocket-based real-time updates for workflow runs with JWT authentication)
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'org.springframework.boot:spring-boot-starter-flyway'
     implementation 'org.springframework.boot:spring-boot-jackson2'

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
@@ -47,6 +47,8 @@ public class SecurityConfig {
                   /* shared‑secret filter handles these requests */
                   .requestMatchers(HttpMethod.POST, "/api/environments/status/**").permitAll()
                   .requestMatchers(HttpMethod.POST, "/api/tests/flakiness-scores").permitAll()
+                  /* WebSocket handshake auth happens in WebSocketJwtHandshakeInterceptor */
+                  .requestMatchers("/ws/**").permitAll()
                   /* other public endpoints (e.g. Swagger) */
                   .requestMatchers(
                       "/auth/**",

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketConfig.java
@@ -1,0 +1,47 @@
+package de.tum.cit.aet.helios.config;
+
+import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+  private final WorkflowRunWebSocketHandler workflowRunWebSocketHandler;
+  private final WebSocketJwtHandshakeInterceptor handshakeInterceptor;
+  private final Environment environment;
+
+  @Override
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+    registry
+        .addHandler(workflowRunWebSocketHandler, "/ws/workflow-runs")
+        .addInterceptors(handshakeInterceptor)
+        .setAllowedOrigins(allowedOrigins())
+        .setAllowedOriginPatterns(allowedOriginPatterns());
+  }
+
+  private String[] allowedOrigins() {
+    if (environment.matchesProfiles("prod")) {
+      return new String[] {"https://helios.aet.cit.tum.de"};
+    }
+    if (environment.matchesProfiles("staging")) {
+      return new String[] {"https://helios-staging.aet.cit.tum.de"};
+    }
+    return new String[0];
+  }
+
+  private String[] allowedOriginPatterns() {
+    if (environment.matchesProfiles("prod") || environment.matchesProfiles("staging")) {
+      return new String[0];
+    }
+    return new String[] {
+      "http://localhost", "http://localhost:*", "http://127.0.0.1", "http://127.0.0.1:*",
+    };
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.config;
 
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketHandler;
 import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 public class WebSocketConfig implements WebSocketConfigurer {
 
   private final WorkflowRunWebSocketHandler workflowRunWebSocketHandler;
+  private final EnvironmentDeploymentWebSocketHandler environmentDeploymentWebSocketHandler;
   private final WebSocketJwtHandshakeInterceptor handshakeInterceptor;
   private final Environment environment;
 
@@ -21,6 +23,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
   public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
     registry
         .addHandler(workflowRunWebSocketHandler, "/ws/workflow-runs")
+        .addInterceptors(handshakeInterceptor)
+        .setAllowedOrigins(allowedOrigins())
+        .setAllowedOriginPatterns(allowedOriginPatterns());
+
+    registry
+        .addHandler(environmentDeploymentWebSocketHandler, "/ws/environments")
         .addInterceptors(handshakeInterceptor)
         .setAllowedOrigins(allowedOrigins())
         .setAllowedOriginPatterns(allowedOriginPatterns());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketJwtHandshakeInterceptor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketJwtHandshakeInterceptor.java
@@ -1,6 +1,5 @@
 package de.tum.cit.aet.helios.config;
 
-import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class WebSocketJwtHandshakeInterceptor implements HandshakeInterceptor {
     for (String header : subprotocols) {
       for (String raw : header.split(",")) {
         String entry = raw.trim();
-        if (WorkflowRunWebSocketHandler.SUBPROTOCOL.equals(entry)) {
+        if ("helios.v1".equals(entry)) {
           hasMarker = true;
         } else if (entry.startsWith(TOKEN_PREFIX)) {
           token = entry.substring(TOKEN_PREFIX.length());
@@ -91,10 +90,10 @@ public class WebSocketJwtHandshakeInterceptor implements HandshakeInterceptor {
       return false;
     }
 
-    attributes.put(WorkflowRunWebSocketHandler.ATTR_USERNAME, username);
-    attributes.put(WorkflowRunWebSocketHandler.ATTR_REPOSITORY_ID, repoId);
+    attributes.put(WebSocketSessionAttributes.USERNAME, username);
+    attributes.put(WebSocketSessionAttributes.REPOSITORY_ID, repoId);
     attributes.put(
-        WorkflowRunWebSocketHandler.ATTR_IS_DEVELOPER,
+        WebSocketSessionAttributes.IS_DEVELOPER,
         heliosDevelopers != null && heliosDevelopers.contains(username));
     return true;
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketJwtHandshakeInterceptor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketJwtHandshakeInterceptor.java
@@ -1,0 +1,115 @@
+package de.tum.cit.aet.helios.config;
+
+import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+/**
+ * Authenticates a WebSocket handshake by reading a JWT and a repository id from the {@code
+ * Sec-WebSocket-Protocol} header (browsers cannot set custom headers on a WS upgrade request).
+ *
+ * <p>Expected client subprotocols:
+ *
+ * <ul>
+ *   <li>{@code helios.v1} — required marker; echoed back by the server.
+ *   <li>{@code helios.token.<jwt>} — the access token.
+ *   <li>{@code helios.repo.<id>} — the repository id this connection is scoped to.
+ * </ul>
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class WebSocketJwtHandshakeInterceptor implements HandshakeInterceptor {
+
+  private static final String TOKEN_PREFIX = "helios.token.";
+  private static final String REPO_PREFIX = "helios.repo.";
+
+  private final JwtDecoder jwtDecoder;
+
+  @Value("${helios.developers:}")
+  private Set<String> heliosDevelopers;
+
+  @Override
+  public boolean beforeHandshake(
+      ServerHttpRequest request,
+      ServerHttpResponse response,
+      WebSocketHandler wsHandler,
+      Map<String, Object> attributes) {
+
+    List<String> subprotocols = request.getHeaders().get("Sec-WebSocket-Protocol");
+    if (subprotocols == null || subprotocols.isEmpty()) {
+      reject(response, "missing Sec-WebSocket-Protocol header");
+      return false;
+    }
+
+    String token = null;
+    String repoId = null;
+    boolean hasMarker = false;
+    for (String header : subprotocols) {
+      for (String raw : header.split(",")) {
+        String entry = raw.trim();
+        if (WorkflowRunWebSocketHandler.SUBPROTOCOL.equals(entry)) {
+          hasMarker = true;
+        } else if (entry.startsWith(TOKEN_PREFIX)) {
+          token = entry.substring(TOKEN_PREFIX.length());
+        } else if (entry.startsWith(REPO_PREFIX)) {
+          repoId = entry.substring(REPO_PREFIX.length());
+        }
+      }
+    }
+
+    if (!hasMarker || token == null || token.isBlank() || repoId == null || repoId.isBlank()) {
+      reject(response, "missing required subprotocols");
+      return false;
+    }
+
+    Jwt jwt;
+    try {
+      jwt = jwtDecoder.decode(token);
+    } catch (JwtException e) {
+      log.debug("WS JWT decode failed: {}", e.getMessage());
+      reject(response, "invalid token");
+      return false;
+    }
+
+    String username = jwt.getClaim("preferred_username");
+    if (username == null || username.isBlank()) {
+      reject(response, "token missing preferred_username");
+      return false;
+    }
+
+    attributes.put(WorkflowRunWebSocketHandler.ATTR_USERNAME, username);
+    attributes.put(WorkflowRunWebSocketHandler.ATTR_REPOSITORY_ID, repoId);
+    attributes.put(
+        WorkflowRunWebSocketHandler.ATTR_IS_DEVELOPER,
+        heliosDevelopers != null && heliosDevelopers.contains(username));
+    return true;
+  }
+
+  @Override
+  public void afterHandshake(
+      ServerHttpRequest request,
+      ServerHttpResponse response,
+      WebSocketHandler wsHandler,
+      Exception exception) {
+    // no-op
+  }
+
+  private static void reject(ServerHttpResponse response, String reason) {
+    log.debug("WS handshake rejected: {}", reason);
+    response.setStatusCode(HttpStatus.UNAUTHORIZED);
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionAttributes.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionAttributes.java
@@ -1,0 +1,10 @@
+package de.tum.cit.aet.helios.config;
+
+public final class WebSocketSessionAttributes {
+
+  public static final String USERNAME = "helios.username";
+  public static final String REPOSITORY_ID = "helios.repositoryId";
+  public static final String IS_DEVELOPER = "helios.isDeveloper";
+
+  private WebSocketSessionAttributes() {}
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionRegistry.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionRegistry.java
@@ -1,0 +1,126 @@
+package de.tum.cit.aet.helios.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+
+/**
+ * Centralized registry for WebSocket sessions across all Helios handlers.
+ *
+ * <p>Owns session decoration, heartbeats, JSON serialization, and consecutive-send-failure
+ * eviction. Handlers register raw sessions on connect, use the returned decorated session for all
+ * subsequent operations, and unregister on close.
+ */
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class WebSocketSessionRegistry {
+
+  private static final int SEND_BUFFER_LIMIT = 64 * 1024;
+  private static final int SEND_TIME_LIMIT_MS = 5_000;
+  private static final int MAX_CONSECUTIVE_SEND_FAILURES = 3;
+  private static final long HEARTBEAT_INTERVAL_MS = 25_000;
+
+  private final ObjectMapper objectMapper;
+
+  private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, AtomicInteger> sendFailures = new ConcurrentHashMap<>();
+
+  /**
+   * Wrap the raw session in a {@link ConcurrentWebSocketSessionDecorator} and start tracking it.
+   * Callers must use the returned decorated session for all sends.
+   */
+  public WebSocketSession register(WebSocketSession rawSession) {
+    WebSocketSession decorated =
+        new ConcurrentWebSocketSessionDecorator(rawSession, SEND_TIME_LIMIT_MS, SEND_BUFFER_LIMIT);
+    sessions.put(rawSession.getId(), decorated);
+    sendFailures.put(rawSession.getId(), new AtomicInteger(0));
+    return decorated;
+  }
+
+  /** Look up the decorated session for a raw session id, or {@code null} if unknown. */
+  public WebSocketSession get(String sessionId) {
+    return sessions.get(sessionId);
+  }
+
+  /** Stop tracking the session. Idempotent. */
+  public void unregister(String sessionId) {
+    sessions.remove(sessionId);
+    sendFailures.remove(sessionId);
+  }
+
+  /**
+   * Serialize {@code payload} as JSON and send it. Resets the per-session failure counter on
+   * success. On failure, increments the counter and force-closes the session once it reaches
+   * {@value #MAX_CONSECUTIVE_SEND_FAILURES} so a stuck client cannot leak resources indefinitely.
+   */
+  public void send(WebSocketSession session, Object payload) {
+    String json;
+    try {
+      json = objectMapper.writeValueAsString(payload);
+    } catch (JsonProcessingException e) {
+      log.warn("Failed to serialize WS payload for session {}: {}", session.getId(), e.getMessage());
+      return;
+    }
+    try {
+      session.sendMessage(new TextMessage(json));
+      AtomicInteger failures = sendFailures.get(session.getId());
+      if (failures != null) {
+        failures.set(0);
+      }
+    } catch (IOException | IllegalStateException e) {
+      log.warn("Failed to send WS message to {}: {}", session.getId(), e.getMessage());
+      recordFailure(session);
+    }
+  }
+
+  private void recordFailure(WebSocketSession session) {
+    AtomicInteger failures = sendFailures.get(session.getId());
+    if (failures != null && failures.incrementAndGet() >= MAX_CONSECUTIVE_SEND_FAILURES) {
+      log.warn(
+          "Closing WS session {} after {} consecutive send failures",
+          session.getId(),
+          MAX_CONSECUTIVE_SEND_FAILURES);
+      closeQuietly(session, CloseStatus.PROTOCOL_ERROR);
+    }
+  }
+
+  /**
+   * Periodic ping to detect dead TCP connections. Sessions whose ping fails are force-closed; the
+   * handler's {@code afterConnectionClosed} is invoked by Spring and handles handler-specific
+   * cleanup, while {@link #unregister(String)} removes the entry from this registry.
+   */
+  @Scheduled(fixedRate = HEARTBEAT_INTERVAL_MS)
+  public void heartbeat() {
+    for (WebSocketSession session : sessions.values()) {
+      if (!session.isOpen()) {
+        continue;
+      }
+      try {
+        session.sendMessage(new PingMessage());
+      } catch (IOException | IllegalStateException e) {
+        log.debug("WS heartbeat failed for session {}: {}", session.getId(), e.getMessage());
+        closeQuietly(session, CloseStatus.SESSION_NOT_RELIABLE);
+      }
+    }
+  }
+
+  private static void closeQuietly(WebSocketSession session, CloseStatus status) {
+    try {
+      session.close(status);
+    } catch (IOException ignored) {
+      // best-effort
+    }
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionRegistry.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/WebSocketSessionRegistry.java
@@ -1,7 +1,7 @@
 package de.tum.cit.aet.helios.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,7 +70,8 @@ public class WebSocketSessionRegistry {
     try {
       json = objectMapper.writeValueAsString(payload);
     } catch (JsonProcessingException e) {
-      log.warn("Failed to serialize WS payload for session {}: {}", session.getId(), e.getMessage());
+      log.warn(
+          "Failed to serialize WS payload for session {}: {}", session.getId(), e.getMessage());
       return;
     }
     try {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -56,11 +56,8 @@ public class DeploymentService {
   private final EnvironmentRepository environmentRepository;
   private final PullRequestRepository pullRequestRepository;
   private final GitRepoRepository gitRepoRepository;
-<<<<<<< HEAD
   private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
-=======
   private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   public Optional<DeploymentDto> getDeploymentById(Long id) {
     return deploymentRepository.findById(id).map(DeploymentDto::fromDeployment);

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -10,6 +10,7 @@ import de.tum.cit.aet.helios.environment.EnvironmentLockHistory;
 import de.tum.cit.aet.helios.environment.EnvironmentLockHistoryRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentService;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.github.WorkflowDispatchResult;
@@ -55,7 +56,11 @@ public class DeploymentService {
   private final EnvironmentRepository environmentRepository;
   private final PullRequestRepository pullRequestRepository;
   private final GitRepoRepository gitRepoRepository;
+<<<<<<< HEAD
   private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
+=======
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   public Optional<DeploymentDto> getDeploymentById(Long id) {
     return deploymentRepository.findById(id).map(DeploymentDto::fromDeployment);
@@ -220,9 +225,11 @@ public class DeploymentService {
       }
 
       this.environmentService.markStatusAsChanged(environment);
+      environmentDeploymentWebSocketPublisher.publishAfterCommit(heliosDeployment);
     } catch (IOException e) {
       heliosDeployment.setStatus(HeliosDeployment.Status.IO_ERROR);
       heliosDeploymentRepository.save(heliosDeployment);
+      environmentDeploymentWebSocketPublisher.publishAfterCommit(heliosDeployment);
 
       // Pass through the detailed GitHub error message
       throw new DeploymentException(e.getMessage(), e);
@@ -442,6 +449,7 @@ public class DeploymentService {
           .ifPresent(heliosDeployment -> {
             heliosDeployment.setStatus(HeliosDeployment.Status.CANCELLED);
             heliosDeploymentRepository.save(heliosDeployment);
+            environmentDeploymentWebSocketPublisher.publishAfterCommit(heliosDeployment);
           });
 
       return "Workflow cancellation request sent successfully";

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
@@ -18,11 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrphanHeliosDeploymentRecoveryService {
 
   private final HeliosDeploymentRepository heliosDeploymentRepository;
-<<<<<<< HEAD
   private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
-=======
   private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   /**
    * Scheduled task that runs every hour and force-finalizes very old orphan Helios deployments.
@@ -97,19 +94,7 @@ public class OrphanHeliosDeploymentRecoveryService {
 
     int updatedCount = 0;
     for (HeliosDeployment deployment : stuckDeployments) {
-<<<<<<< HEAD
       markStuckHeliosDeploymentAsFailed(deployment);
-=======
-      log.warn(
-          "Marking Helios deployment {} as FAILED, stuck in {} state since {}",
-          deployment.getId(),
-          deployment.getStatus(),
-          deployment.getStatusUpdatedAt());
-
-      deployment.setStatus(HeliosDeployment.Status.FAILED);
-      heliosDeploymentRepository.save(deployment);
-      environmentDeploymentWebSocketPublisher.publishAfterCommit(deployment);
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
       updatedCount++;
     }
     return updatedCount;
@@ -124,5 +109,6 @@ public class OrphanHeliosDeploymentRecoveryService {
 
     deployment.setStatus(HeliosDeployment.Status.FAILED);
     heliosDeploymentRepository.save(deployment);
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(deployment);
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryService.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.deployment;
 
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import java.io.IOException;
@@ -17,7 +18,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class OrphanHeliosDeploymentRecoveryService {
 
   private final HeliosDeploymentRepository heliosDeploymentRepository;
+<<<<<<< HEAD
   private final HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
+=======
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   /**
    * Scheduled task that runs every hour and force-finalizes very old orphan Helios deployments.
@@ -92,7 +97,19 @@ public class OrphanHeliosDeploymentRecoveryService {
 
     int updatedCount = 0;
     for (HeliosDeployment deployment : stuckDeployments) {
+<<<<<<< HEAD
       markStuckHeliosDeploymentAsFailed(deployment);
+=======
+      log.warn(
+          "Marking Helios deployment {} as FAILED, stuck in {} state since {}",
+          deployment.getId(),
+          deployment.getStatus(),
+          deployment.getStatusUpdatedAt());
+
+      deployment.setStatus(HeliosDeployment.Status.FAILED);
+      heliosDeploymentRepository.save(deployment);
+      environmentDeploymentWebSocketPublisher.publishAfterCommit(deployment);
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
       updatedCount++;
     }
     return updatedCount;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncService.java
@@ -3,6 +3,7 @@ package de.tum.cit.aet.helios.deployment.github;
 import de.tum.cit.aet.helios.deployment.Deployment;
 import de.tum.cit.aet.helios.deployment.DeploymentRepository;
 import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
@@ -25,6 +26,7 @@ public class GitHubDeploymentSyncService {
   private final PullRequestRepository pullRequestRepository;
   private final DeploymentConverter deploymentConverter;
   private final HeliosDeploymentRepository heliosDeploymentRepository;
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   /**
    * Processes a single DeploymentSource by updating or creating a Deployment in the local
@@ -68,6 +70,7 @@ public class GitHubDeploymentSyncService {
 
     // Update Helios Deployment
     updateHeliosDeployment(deployment, environment);
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(environment);
   }
 
   private void updateHeliosDeployment(Deployment deployment, Environment environment) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentScheduler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentScheduler.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.environment;
 
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsDto;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsService;
 import de.tum.cit.aet.helios.nats.NatsNotificationPublisherService;
@@ -26,6 +27,7 @@ public class EnvironmentScheduler {
   private final UserRepository userRepository;
   private final org.springframework.core.env.Environment springEnvironment;
   private final NatsNotificationPublisherService notificationPublisherService;
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   // Every minute
   @Scheduled(fixedRate = 60000)
@@ -103,6 +105,7 @@ public class EnvironmentScheduler {
           }
 
           environmentRepository.save(environment);
+          environmentDeploymentWebSocketPublisher.publishAfterCommit(environment);
         }
       } catch (Exception e) {
         log.error("Error unlocking environment {}: {}", environment.getId(), e.getMessage());

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -12,6 +12,7 @@ import de.tum.cit.aet.helios.environment.github.GitHubEnvironmentProtectionRuleD
 import de.tum.cit.aet.helios.environment.github.GitHubEnvironmentSyncService;
 import de.tum.cit.aet.helios.environment.protectionrules.ProtectionRule;
 import de.tum.cit.aet.helios.environment.protectionrules.ProtectionRuleRepository;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -76,6 +77,7 @@ public class EnvironmentService {
   private final GitRepoRepository gitRepoRepository;
   private final GitHubService gitHubService;
   private final NatsNotificationPublisherService notificationPublisherService;
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   public Optional<EnvironmentDto> getEnvironmentById(Long id) {
     return environmentRepository.findById(id).map(EnvironmentDto::fromEnvironment);
@@ -256,6 +258,7 @@ public class EnvironmentService {
       return Optional.empty();
     }
 
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(environment);
     return Optional.of(environment);
   }
 
@@ -378,6 +381,7 @@ public class EnvironmentService {
       return Optional.empty();
     }
 
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(environment);
     return Optional.of(environment);
   }
 
@@ -504,6 +508,7 @@ public class EnvironmentService {
     }
 
     environmentRepository.save(environment);
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(environment);
 
     return EnvironmentDto.fromEnvironment(environment);
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketHandler.java
@@ -1,0 +1,167 @@
+package de.tum.cit.aet.helios.environment.ws;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.cit.aet.helios.config.WebSocketSessionAttributes;
+import de.tum.cit.aet.helios.config.WebSocketSessionRegistry;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.github.permissions.GitHubRepositoryRoleDto;
+import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.SubProtocolCapable;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class EnvironmentDeploymentWebSocketHandler extends TextWebSocketHandler
+    implements SubProtocolCapable {
+
+  public static final String SUBPROTOCOL = "helios.v1";
+
+  private final ObjectMapper objectMapper;
+  private final GitHubService gitHubService;
+  private final WebSocketSessionRegistry sessionRegistry;
+
+  private final ConcurrentHashMap<Long, Set<WebSocketSession>> sessionsByRepository =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Long> repositoryBySession = new ConcurrentHashMap<>();
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) throws IOException {
+    Long repositoryId = getRepositoryId(session);
+    if (repositoryId == null || !isAuthorized(session, repositoryId)) {
+      session.close(CloseStatus.POLICY_VIOLATION);
+      return;
+    }
+
+    WebSocketSession decorated = sessionRegistry.register(session);
+    repositoryBySession.put(session.getId(), repositoryId);
+    sessionsByRepository
+        .computeIfAbsent(repositoryId, ignored -> ConcurrentHashMap.newKeySet())
+        .add(decorated);
+
+    log.debug(
+        "Environment deployment WS connected: sessionId={}, repositoryId={}, user={}",
+        session.getId(),
+        repositoryId,
+        getUsername(session));
+  }
+
+  @Override
+  protected void handleTextMessage(WebSocketSession rawSession, TextMessage message) {
+    WebSocketSession session = sessionRegistry.get(rawSession.getId());
+    if (session == null) {
+      session = rawSession;
+    }
+    EnvironmentDeploymentWebSocketMessage parsed;
+    try {
+      parsed =
+          objectMapper.readValue(
+              message.getPayload(), EnvironmentDeploymentWebSocketMessage.class);
+    } catch (Exception e) {
+      log.warn(
+          "Environment deployment WS bad message from {}: {}", session.getId(), e.getMessage());
+      sessionRegistry.send(
+          session,
+          new EnvironmentDeploymentWebSocketMessage.Error("bad-request", "Invalid message"));
+      return;
+    }
+
+    switch (parsed) {
+      case EnvironmentDeploymentWebSocketMessage.Ping ignored ->
+          sessionRegistry.send(session, new EnvironmentDeploymentWebSocketMessage.Pong());
+      default ->
+          sessionRegistry.send(
+              session,
+              new EnvironmentDeploymentWebSocketMessage.Error(
+                  "bad-request", "Unsupported message"));
+    }
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+    sessionRegistry.unregister(session.getId());
+    Long repositoryId = repositoryBySession.remove(session.getId());
+    if (repositoryId != null) {
+      Set<WebSocketSession> repositorySessions = sessionsByRepository.get(repositoryId);
+      if (repositorySessions != null) {
+        repositorySessions.removeIf(existing -> existing.getId().equals(session.getId()));
+        if (repositorySessions.isEmpty()) {
+          sessionsByRepository.remove(repositoryId, repositorySessions);
+        }
+      }
+    }
+    log.debug("Environment deployment WS closed: sessionId={}, status={}", session.getId(), status);
+  }
+
+  public void broadcastDeploymentInvalidated(long repositoryId, long environmentId) {
+    Set<WebSocketSession> repositorySessions = sessionsByRepository.get(repositoryId);
+    if (repositorySessions == null || repositorySessions.isEmpty()) {
+      return;
+    }
+
+    EnvironmentDeploymentWebSocketMessage.EnvironmentDeploymentInvalidated payload =
+        new EnvironmentDeploymentWebSocketMessage.EnvironmentDeploymentInvalidated(
+            repositoryId, environmentId);
+    for (WebSocketSession session : repositorySessions) {
+      sessionRegistry.send(session, payload);
+    }
+  }
+
+  private boolean isAuthorized(WebSocketSession session, Long repositoryId) {
+    Boolean isDeveloper =
+        (Boolean) session.getAttributes().get(WebSocketSessionAttributes.IS_DEVELOPER);
+    if (Boolean.TRUE.equals(isDeveloper)) {
+      return true;
+    }
+
+    String username = getUsername(session);
+    if (username == null) {
+      return false;
+    }
+
+    try {
+      GitHubRepositoryRoleDto role =
+          gitHubService.getRepositoryRole(repositoryId.toString(), username);
+      return role.getPermission() != null
+          && role.getPermission() != RepoPermissionType.NONE;
+    } catch (IOException e) {
+      log.warn(
+          "Failed to resolve repo role for user {} on repo {}: {}",
+          username,
+          repositoryId,
+          e.getMessage());
+      return false;
+    }
+  }
+
+  private static Long getRepositoryId(WebSocketSession session) {
+    Object repositoryId = session.getAttributes().get(WebSocketSessionAttributes.REPOSITORY_ID);
+    if (repositoryId == null) {
+      return null;
+    }
+    try {
+      return Long.parseLong(repositoryId.toString());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  private static String getUsername(WebSocketSession session) {
+    return (String) session.getAttributes().get(WebSocketSessionAttributes.USERNAME);
+  }
+
+  @Override
+  public List<String> getSubProtocols() {
+    return List.of(SUBPROTOCOL);
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketMessage.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketMessage.java
@@ -1,0 +1,24 @@
+package de.tum.cit.aet.helios.environment.ws;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = EnvironmentDeploymentWebSocketMessage.Ping.class, name = "ping"),
+})
+public sealed interface EnvironmentDeploymentWebSocketMessage {
+
+  record Ping() implements EnvironmentDeploymentWebSocketMessage {}
+
+  @JsonTypeName("environment-deployment-invalidated")
+  record EnvironmentDeploymentInvalidated(long repositoryId, long environmentId)
+      implements EnvironmentDeploymentWebSocketMessage {}
+
+  @JsonTypeName("error")
+  record Error(String code, String message) implements EnvironmentDeploymentWebSocketMessage {}
+
+  @JsonTypeName("pong")
+  record Pong() implements EnvironmentDeploymentWebSocketMessage {}
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketPublisher.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketPublisher.java
@@ -1,0 +1,49 @@
+package de.tum.cit.aet.helios.environment.ws;
+
+import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+@RequiredArgsConstructor
+public class EnvironmentDeploymentWebSocketPublisher {
+
+  private final EnvironmentDeploymentWebSocketHandler handler;
+
+  public void publishAfterCommit(HeliosDeployment deployment) {
+    if (deployment == null) {
+      return;
+    }
+    publishAfterCommit(deployment.getEnvironment());
+  }
+
+  public void publishAfterCommit(Environment environment) {
+    if (environment == null) {
+      return;
+    }
+    GitRepository repository = environment.getRepository();
+    if (repository == null || repository.getRepositoryId() == null || environment.getId() == null) {
+      return;
+    }
+    publishAfterCommit(repository.getRepositoryId(), environment.getId());
+  }
+
+  public void publishAfterCommit(long repositoryId, long environmentId) {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.registerSynchronization(
+          new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+              handler.broadcastDeploymentInvalidated(repositoryId, environmentId);
+            }
+          });
+      return;
+    }
+
+    handler.broadcastDeploymentInvalidated(repositoryId, environmentId);
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunService.java
@@ -215,6 +215,29 @@ public class WorkflowRunService {
             "Workflow run with id %d not found".formatted(runId)));
   }
 
+  /**
+   * Returns the run scoped to the supplied repository, bypassing {@link RepositoryContext}.
+   *
+   * <p>Used by paths that don't run inside a Spring MVC request thread (e.g. WebSocket handlers),
+   * where the {@code X-Repository-Id} header has not been bound to {@code RepositoryContext}.
+   */
+  public Optional<WorkflowRunDto> findByIdForRepository(Long runId, Long repositoryId) {
+    return workflowRunRepository
+        .findByIdAndRepositoryRepositoryId(runId, repositoryId)
+        .map(WorkflowRunDto::fromWorkflowRun);
+  }
+
+  /**
+   * Returns the {@code repositoryId} that owns this run, ignoring the current
+   * {@link RepositoryContext}. Used by WebSocket subscribe authorization to look up which repo
+   * a run belongs to so we can permission-check the connecting user.
+   */
+  public Optional<Long> findOwningRepositoryId(Long runId) {
+    return workflowRunRepository
+        .findById(runId)
+        .map(run -> run.getRepository() == null ? null : run.getRepository().getRepositoryId());
+  }
+
   public void cancelWorkflowRun(Long runId) {
     executeWorkflowRunAction(runId, gitHubService::cancelWorkflowRun, "cancel", false);
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobMessageHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobMessageHandler.java
@@ -2,6 +2,7 @@ package de.tum.cit.aet.helios.workflow.github;
 
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.nats.JacksonMessageHandler;
+import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ public class GitHubWorkflowJobMessageHandler
 
   private final GitHubService gitHubService;
   private final GitHubWorkflowJobTimingService gitHubWorkflowJobTimingService;
+  private final WorkflowRunWebSocketHandler workflowRunWebSocketHandler;
 
   @Override
   protected Class<GitHubWorkflowJobPayload> getPayloadClass() {
@@ -47,5 +49,9 @@ public class GitHubWorkflowJobMessageHandler
     }
 
     gitHubWorkflowJobTimingService.persistDurations(payload);
+
+    if (payload.workflowJob() != null && payload.workflowJob().runId() != null) {
+      workflowRunWebSocketHandler.broadcastJobsInvalidated(payload.workflowJob().runId());
+    }
   }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingService.java
@@ -5,6 +5,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfig;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfigRepository;
 import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import de.tum.cit.aet.helios.workflow.Workflow;
@@ -27,6 +28,7 @@ public class GitHubWorkflowJobTimingService {
   private final DeploymentWorkflowConfigRepository deploymentWorkflowConfigRepository;
   private final HeliosDeploymentRepository heliosDeploymentRepository;
   private final WorkflowRunRepository workflowRunRepository;
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
   private final Cache<Long, RunRelevance> runRelevanceCache =
       Caffeine.newBuilder().maximumSize(10_000).expireAfterWrite(Duration.ofHours(1)).build();
 
@@ -69,7 +71,7 @@ public class GitHubWorkflowJobTimingService {
 
     if (!relevance.deployJobName().equals(job.name())) {
       if (changed) {
-        heliosDeploymentRepository.save(heliosDeployment);
+        saveAndPublish(heliosDeployment);
       }
       return;
     }
@@ -87,14 +89,14 @@ public class GitHubWorkflowJobTimingService {
         changed = true;
       }
       if (changed) {
-        heliosDeploymentRepository.save(heliosDeployment);
+        saveAndPublish(heliosDeployment);
       }
       return;
     }
 
     if (!isCompletedEvent(payload.action(), job)) {
       if (changed) {
-        heliosDeploymentRepository.save(heliosDeployment);
+        saveAndPublish(heliosDeployment);
       }
       return;
     }
@@ -106,7 +108,7 @@ public class GitHubWorkflowJobTimingService {
 
     if (job.startedAt() == null || job.completedAt() == null) {
       if (changed) {
-        heliosDeploymentRepository.save(heliosDeployment);
+        saveAndPublish(heliosDeployment);
       }
       return;
     }
@@ -127,8 +129,13 @@ public class GitHubWorkflowJobTimingService {
     changed = true;
 
     if (changed) {
-      heliosDeploymentRepository.save(heliosDeployment);
+      saveAndPublish(heliosDeployment);
     }
+  }
+
+  private void saveAndPublish(HeliosDeployment heliosDeployment) {
+    heliosDeploymentRepository.save(heliosDeployment);
+    environmentDeploymentWebSocketPublisher.publishAfterCommit(heliosDeployment);
   }
 
   private RunRelevance getCachedRelevance(Long runId) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -17,6 +17,8 @@ import de.tum.cit.aet.helios.workflow.WorkflowRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowService;
+import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
+import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
 import jakarta.transaction.Transactional;
 import java.io.IOException;
 import java.util.Collections;
@@ -44,6 +46,7 @@ public class GitHubWorkflowRunSyncService {
   private final HeliosDeploymentRepository heliosDeploymentRepository;
   private final DeploymentFailureNotificationDecider deploymentFailureNotificationDecider;
   private final NatsNotificationPublisherService notificationPublisherService;
+  private final WorkflowRunWebSocketHandler workflowRunWebSocketHandler;
   private final GitHubFacade github;
   private final GitHubClientManager clientManager;
 
@@ -167,6 +170,11 @@ public class GitHubWorkflowRunSyncService {
     }
 
     workflowRunRepository.save(result);
+
+    var dto = WorkflowRunDto.fromWorkflowRun(result);
+    var runId = result.getId();
+    workflowRunWebSocketHandler.broadcastRunUpdated(runId, dto);
+    workflowRunWebSocketHandler.broadcastJobsInvalidated(runId);
 
     return result;
   }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -1,5 +1,11 @@
 package de.tum.cit.aet.helios.workflow.github;
 
+<<<<<<< HEAD
+=======
+import static de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment.mapWorkflowRunStatus;
+
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 import de.tum.cit.aet.helios.github.GitHubClientManager;
 import de.tum.cit.aet.helios.github.GitHubFacade;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -47,6 +53,7 @@ public class GitHubWorkflowRunSyncService {
   private final DeploymentFailureNotificationDecider deploymentFailureNotificationDecider;
   private final NatsNotificationPublisherService notificationPublisherService;
   private final WorkflowRunWebSocketHandler workflowRunWebSocketHandler;
+  private final EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
   private final GitHubFacade github;
   private final GitHubClientManager clientManager;
 
@@ -323,6 +330,7 @@ public class GitHubWorkflowRunSyncService {
                       heliosDeployment.getId(),
                       mappedStatus);
                   heliosDeploymentRepository.save(heliosDeployment);
+                  environmentDeploymentWebSocketPublisher.publishAfterCommit(heliosDeployment);
                 }
               } catch (IOException e) {
                 e.printStackTrace();

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowRunSyncService.java
@@ -1,11 +1,6 @@
 package de.tum.cit.aet.helios.workflow.github;
 
-<<<<<<< HEAD
-=======
-import static de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment.mapWorkflowRunStatus;
-
 import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 import de.tum.cit.aet.helios.github.GitHubClientManager;
 import de.tum.cit.aet.helios.github.GitHubFacade;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -21,9 +16,9 @@ import de.tum.cit.aet.helios.workflow.GitHubWorkflowContext;
 import de.tum.cit.aet.helios.workflow.Workflow;
 import de.tum.cit.aet.helios.workflow.WorkflowRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRun;
+import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowService;
-import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
 import de.tum.cit.aet.helios.workflow.ws.WorkflowRunWebSocketHandler;
 import jakarta.transaction.Transactional;
 import java.io.IOException;

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
@@ -109,13 +110,7 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
   }
 
   private void handleUnsubscribe(WebSocketSession session, long runId) {
-    Set<WebSocketSession> subs = subscribersByRun.get(runId);
-    if (subs != null) {
-      subs.remove(session);
-      if (subs.isEmpty()) {
-        subscribersByRun.remove(runId, subs);
-      }
-    }
+    removeSubscriber(runId, session.getId());
     Set<Long> runs = runsBySession.get(session.getId());
     if (runs != null) {
       runs.remove(runId);
@@ -128,16 +123,21 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     Set<Long> runs = runsBySession.remove(session.getId());
     if (runs != null) {
       for (Long runId : runs) {
-        Set<WebSocketSession> subs = subscribersByRun.get(runId);
-        if (subs != null) {
-          subs.remove(session);
-          if (subs.isEmpty()) {
-            subscribersByRun.remove(runId, subs);
-          }
-        }
+        removeSubscriber(runId, session.getId());
       }
     }
     log.debug("WS closed: sessionId={}, status={}", session.getId(), status);
+  }
+
+  private void removeSubscriber(long runId, String sessionId) {
+    Set<WebSocketSession> subs = subscribersByRun.get(runId);
+    if (subs == null) {
+      return;
+    }
+    subs.removeIf(existing -> existing.getId().equals(sessionId));
+    if (subs.isEmpty()) {
+      subscribersByRun.remove(runId, subs);
+    }
   }
 
   /**
@@ -164,13 +164,22 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
    * {@value #JOBS_INVALIDATION_INTERVAL_MS} ms to avoid excessive GitHub API calls.
    */
   public void broadcastJobsInvalidated(long runId) {
-    long now = System.currentTimeMillis();
-    Long prev = lastJobsBroadcastAt.put(runId, now);
-    if (prev != null && now - prev < JOBS_INVALIDATION_INTERVAL_MS) {
-      return;
-    }
     Set<WebSocketSession> subs = subscribersByRun.get(runId);
     if (subs == null || subs.isEmpty()) {
+      return;
+    }
+    long now = System.currentTimeMillis();
+    AtomicBoolean shouldBroadcast = new AtomicBoolean(false);
+    lastJobsBroadcastAt.compute(
+        runId,
+        (key, prev) -> {
+          if (prev != null && now - prev < JOBS_INVALIDATION_INTERVAL_MS) {
+            return prev;
+          }
+          shouldBroadcast.set(true);
+          return now;
+        });
+    if (!shouldBroadcast.get()) {
       return;
     }
     WsServerMessage.WorkflowJobsInvalidated payload =

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
@@ -1,6 +1,8 @@
 package de.tum.cit.aet.helios.workflow.ws;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.cit.aet.helios.config.WebSocketSessionAttributes;
+import de.tum.cit.aet.helios.config.WebSocketSessionRegistry;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.github.permissions.GitHubRepositoryRoleDto;
 import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
@@ -13,14 +15,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
-import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.SubProtocolCapable;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
-import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 @Log4j2
@@ -33,40 +32,39 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
   public static final String SUBPROTOCOL = "helios.v1";
 
   /** Handshake attribute key for the authenticated GitHub username. */
-  public static final String ATTR_USERNAME = "helios.username";
+  public static final String ATTR_USERNAME = WebSocketSessionAttributes.USERNAME;
 
   /** Handshake attribute key for the repository id supplied at handshake. */
-  public static final String ATTR_REPOSITORY_ID = "helios.repositoryId";
+  public static final String ATTR_REPOSITORY_ID = WebSocketSessionAttributes.REPOSITORY_ID;
 
   /** Handshake attribute key marking a developer that bypasses per-repo permission checks. */
-  public static final String ATTR_IS_DEVELOPER = "helios.isDeveloper";
+  public static final String ATTR_IS_DEVELOPER = WebSocketSessionAttributes.IS_DEVELOPER;
 
-  private static final int SEND_BUFFER_LIMIT = 64 * 1024;
-  private static final int SEND_TIME_LIMIT_MS = 5_000;
   private static final long JOBS_INVALIDATION_INTERVAL_MS = 10_000;
 
   private final ObjectMapper objectMapper;
   private final WorkflowRunService workflowRunService;
   private final GitHubService gitHubService;
+  private final WebSocketSessionRegistry sessionRegistry;
 
   private final ConcurrentHashMap<Long, Set<WebSocketSession>> subscribersByRun =
       new ConcurrentHashMap<>();
   private final ConcurrentHashMap<String, Set<Long>> runsBySession = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
   private final ConcurrentHashMap<Long, Long> lastJobsBroadcastAt = new ConcurrentHashMap<>();
 
   @Override
   public void afterConnectionEstablished(WebSocketSession session) {
-    WebSocketSession decorated =
-        new ConcurrentWebSocketSessionDecorator(session, SEND_TIME_LIMIT_MS, SEND_BUFFER_LIMIT);
-    sessions.put(session.getId(), decorated);
+    sessionRegistry.register(session);
     runsBySession.put(session.getId(), ConcurrentHashMap.newKeySet());
     log.debug("WS connected: sessionId={}, user={}", session.getId(), getUsername(session));
   }
 
   @Override
   protected void handleTextMessage(WebSocketSession rawSession, TextMessage message) {
-    WebSocketSession session = sessions.getOrDefault(rawSession.getId(), rawSession);
+    WebSocketSession session = sessionRegistry.get(rawSession.getId());
+    if (session == null) {
+      session = rawSession;
+    }
     WsClientMessage parsed;
     try {
       parsed = objectMapper.readValue(message.getPayload(), WsClientMessage.class);
@@ -79,7 +77,7 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     switch (parsed) {
       case WsClientMessage.Subscribe sub -> handleSubscribe(session, sub.runId());
       case WsClientMessage.Unsubscribe unsub -> handleUnsubscribe(session, unsub.runId());
-      case WsClientMessage.Ping ignored -> send(session, new WsServerMessage.Pong());
+      case WsClientMessage.Ping ignored -> sessionRegistry.send(session, new WsServerMessage.Pong());
     }
   }
 
@@ -99,10 +97,12 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     subscribersByRun.computeIfAbsent(runId, k -> ConcurrentHashMap.newKeySet()).add(session);
     runsBySession.computeIfAbsent(session.getId(), k -> ConcurrentHashMap.newKeySet()).add(runId);
 
+    final WebSocketSession target = session;
     workflowRunService
         .findByIdForRepository(runId, owningRepoId)
-        .ifPresent(dto -> send(session, new WsServerMessage.WorkflowRunUpdated(runId, dto)));
-    send(session, new WsServerMessage.WorkflowJobsInvalidated(runId));
+        .ifPresent(
+            dto -> sessionRegistry.send(target, new WsServerMessage.WorkflowRunUpdated(runId, dto)));
+    sessionRegistry.send(session, new WsServerMessage.WorkflowJobsInvalidated(runId));
   }
 
   private void handleUnsubscribe(WebSocketSession session, long runId) {
@@ -121,7 +121,7 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
 
   @Override
   public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
-    sessions.remove(session.getId());
+    sessionRegistry.unregister(session.getId());
     Set<Long> runs = runsBySession.remove(session.getId());
     if (runs != null) {
       for (Long runId : runs) {
@@ -149,7 +149,7 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     WsServerMessage.WorkflowRunUpdated payload =
         new WsServerMessage.WorkflowRunUpdated(runId, run);
     for (WebSocketSession s : subs) {
-      send(s, payload);
+      sessionRegistry.send(s, payload);
     }
   }
 
@@ -173,26 +173,7 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     WsServerMessage.WorkflowJobsInvalidated payload =
         new WsServerMessage.WorkflowJobsInvalidated(runId);
     for (WebSocketSession s : subs) {
-      send(s, payload);
-    }
-  }
-
-  @Scheduled(fixedRate = 25_000)
-  public void heartbeat() {
-    for (WebSocketSession session : sessions.values()) {
-      if (!session.isOpen()) {
-        continue;
-      }
-      try {
-        session.sendMessage(new PingMessage());
-      } catch (IOException | IllegalStateException e) {
-        log.debug("Heartbeat failed for session {}: {}", session.getId(), e.getMessage());
-        try {
-          session.close(CloseStatus.SESSION_NOT_RELIABLE);
-        } catch (IOException ignored) {
-          // best-effort close
-        }
-      }
+      sessionRegistry.send(s, payload);
     }
   }
 
@@ -224,17 +205,8 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     }
   }
 
-  private void send(WebSocketSession session, WsServerMessage payload) {
-    try {
-      String json = objectMapper.writeValueAsString(payload);
-      session.sendMessage(new TextMessage(json));
-    } catch (IOException | IllegalStateException e) {
-      log.warn("Failed to send WS message to {}: {}", session.getId(), e.getMessage());
-    }
-  }
-
   private void sendError(WebSocketSession session, String code, String message, Long runId) {
-    send(session, new WsServerMessage.Error(code, message, runId));
+    sessionRegistry.send(session, new WsServerMessage.Error(code, message, runId));
   }
 
   private static String getUsername(WebSocketSession session) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
@@ -77,7 +77,8 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     switch (parsed) {
       case WsClientMessage.Subscribe sub -> handleSubscribe(session, sub.runId());
       case WsClientMessage.Unsubscribe unsub -> handleUnsubscribe(session, unsub.runId());
-      case WsClientMessage.Ping ignored -> sessionRegistry.send(session, new WsServerMessage.Pong());
+      case WsClientMessage.Ping ignored ->
+          sessionRegistry.send(session, new WsServerMessage.Pong());
     }
   }
 
@@ -101,7 +102,9 @@ public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
     workflowRunService
         .findByIdForRepository(runId, owningRepoId)
         .ifPresent(
-            dto -> sessionRegistry.send(target, new WsServerMessage.WorkflowRunUpdated(runId, dto)));
+            dto ->
+                sessionRegistry.send(
+                    target, new WsServerMessage.WorkflowRunUpdated(runId, dto)));
     sessionRegistry.send(session, new WsServerMessage.WorkflowJobsInvalidated(runId));
   }
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandler.java
@@ -1,0 +1,248 @@
+package de.tum.cit.aet.helios.workflow.ws;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.github.permissions.GitHubRepositoryRoleDto;
+import de.tum.cit.aet.helios.github.permissions.RepoPermissionType;
+import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
+import de.tum.cit.aet.helios.workflow.WorkflowRunService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.PingMessage;
+import org.springframework.web.socket.SubProtocolCapable;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.ConcurrentWebSocketSessionDecorator;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Log4j2
+@Component
+@RequiredArgsConstructor
+public class WorkflowRunWebSocketHandler extends TextWebSocketHandler
+    implements SubProtocolCapable {
+
+  /** Subprotocol the server selects and echoes back; clients must include this. */
+  public static final String SUBPROTOCOL = "helios.v1";
+
+  /** Handshake attribute key for the authenticated GitHub username. */
+  public static final String ATTR_USERNAME = "helios.username";
+
+  /** Handshake attribute key for the repository id supplied at handshake. */
+  public static final String ATTR_REPOSITORY_ID = "helios.repositoryId";
+
+  /** Handshake attribute key marking a developer that bypasses per-repo permission checks. */
+  public static final String ATTR_IS_DEVELOPER = "helios.isDeveloper";
+
+  private static final int SEND_BUFFER_LIMIT = 64 * 1024;
+  private static final int SEND_TIME_LIMIT_MS = 5_000;
+  private static final long JOBS_INVALIDATION_INTERVAL_MS = 10_000;
+
+  private final ObjectMapper objectMapper;
+  private final WorkflowRunService workflowRunService;
+  private final GitHubService gitHubService;
+
+  private final ConcurrentHashMap<Long, Set<WebSocketSession>> subscribersByRun =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Set<Long>> runsBySession = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Long, Long> lastJobsBroadcastAt = new ConcurrentHashMap<>();
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) {
+    WebSocketSession decorated =
+        new ConcurrentWebSocketSessionDecorator(session, SEND_TIME_LIMIT_MS, SEND_BUFFER_LIMIT);
+    sessions.put(session.getId(), decorated);
+    runsBySession.put(session.getId(), ConcurrentHashMap.newKeySet());
+    log.debug("WS connected: sessionId={}, user={}", session.getId(), getUsername(session));
+  }
+
+  @Override
+  protected void handleTextMessage(WebSocketSession rawSession, TextMessage message) {
+    WebSocketSession session = sessions.getOrDefault(rawSession.getId(), rawSession);
+    WsClientMessage parsed;
+    try {
+      parsed = objectMapper.readValue(message.getPayload(), WsClientMessage.class);
+    } catch (Exception e) {
+      log.warn("WS bad message from session {}: {}", session.getId(), e.getMessage());
+      sendError(session, "bad-request", "Invalid message", null);
+      return;
+    }
+
+    switch (parsed) {
+      case WsClientMessage.Subscribe sub -> handleSubscribe(session, sub.runId());
+      case WsClientMessage.Unsubscribe unsub -> handleUnsubscribe(session, unsub.runId());
+      case WsClientMessage.Ping ignored -> send(session, new WsServerMessage.Pong());
+    }
+  }
+
+  private void handleSubscribe(WebSocketSession session, long runId) {
+    Optional<Long> owningRepoOpt = workflowRunService.findOwningRepositoryId(runId);
+    if (owningRepoOpt.isEmpty() || owningRepoOpt.get() == null) {
+      sendError(session, "not-found", "Workflow run not found", runId);
+      return;
+    }
+    Long owningRepoId = owningRepoOpt.get();
+
+    if (!isAuthorized(session, owningRepoId)) {
+      sendError(session, "forbidden", "Not allowed to subscribe to this run", runId);
+      return;
+    }
+
+    subscribersByRun.computeIfAbsent(runId, k -> ConcurrentHashMap.newKeySet()).add(session);
+    runsBySession.computeIfAbsent(session.getId(), k -> ConcurrentHashMap.newKeySet()).add(runId);
+
+    workflowRunService
+        .findByIdForRepository(runId, owningRepoId)
+        .ifPresent(dto -> send(session, new WsServerMessage.WorkflowRunUpdated(runId, dto)));
+    send(session, new WsServerMessage.WorkflowJobsInvalidated(runId));
+  }
+
+  private void handleUnsubscribe(WebSocketSession session, long runId) {
+    Set<WebSocketSession> subs = subscribersByRun.get(runId);
+    if (subs != null) {
+      subs.remove(session);
+      if (subs.isEmpty()) {
+        subscribersByRun.remove(runId, subs);
+      }
+    }
+    Set<Long> runs = runsBySession.get(session.getId());
+    if (runs != null) {
+      runs.remove(runId);
+    }
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+    sessions.remove(session.getId());
+    Set<Long> runs = runsBySession.remove(session.getId());
+    if (runs != null) {
+      for (Long runId : runs) {
+        Set<WebSocketSession> subs = subscribersByRun.get(runId);
+        if (subs != null) {
+          subs.remove(session);
+          if (subs.isEmpty()) {
+            subscribersByRun.remove(runId, subs);
+          }
+        }
+      }
+    }
+    log.debug("WS closed: sessionId={}, status={}", session.getId(), status);
+  }
+
+  /**
+   * Broadcast an update for a single run to every subscribed session. Called by
+   * {@code GitHubWorkflowRunSyncService} after persisting a workflow run update.
+   */
+  public void broadcastRunUpdated(long runId, WorkflowRunDto run) {
+    Set<WebSocketSession> subs = subscribersByRun.get(runId);
+    if (subs == null || subs.isEmpty()) {
+      return;
+    }
+    WsServerMessage.WorkflowRunUpdated payload =
+        new WsServerMessage.WorkflowRunUpdated(runId, run);
+    for (WebSocketSession s : subs) {
+      send(s, payload);
+    }
+  }
+
+  /**
+   * Notify subscribed clients that workflow jobs for {@code runId} have changed; clients refetch
+   * via the existing REST endpoint.
+   *
+   * <p>Rate-limited: at most one broadcast per runId every
+   * {@value #JOBS_INVALIDATION_INTERVAL_MS} ms to avoid excessive GitHub API calls.
+   */
+  public void broadcastJobsInvalidated(long runId) {
+    long now = System.currentTimeMillis();
+    Long prev = lastJobsBroadcastAt.put(runId, now);
+    if (prev != null && now - prev < JOBS_INVALIDATION_INTERVAL_MS) {
+      return;
+    }
+    Set<WebSocketSession> subs = subscribersByRun.get(runId);
+    if (subs == null || subs.isEmpty()) {
+      return;
+    }
+    WsServerMessage.WorkflowJobsInvalidated payload =
+        new WsServerMessage.WorkflowJobsInvalidated(runId);
+    for (WebSocketSession s : subs) {
+      send(s, payload);
+    }
+  }
+
+  @Scheduled(fixedRate = 25_000)
+  public void heartbeat() {
+    for (WebSocketSession session : sessions.values()) {
+      if (!session.isOpen()) {
+        continue;
+      }
+      try {
+        session.sendMessage(new PingMessage());
+      } catch (IOException | IllegalStateException e) {
+        log.debug("Heartbeat failed for session {}: {}", session.getId(), e.getMessage());
+        try {
+          session.close(CloseStatus.SESSION_NOT_RELIABLE);
+        } catch (IOException ignored) {
+          // best-effort close
+        }
+      }
+    }
+  }
+
+  private boolean isAuthorized(WebSocketSession session, Long owningRepositoryId) {
+    Object connectedRepo = session.getAttributes().get(ATTR_REPOSITORY_ID);
+    if (connectedRepo == null || !owningRepositoryId.toString().equals(connectedRepo.toString())) {
+      return false;
+    }
+    Boolean isDeveloper = (Boolean) session.getAttributes().get(ATTR_IS_DEVELOPER);
+    if (Boolean.TRUE.equals(isDeveloper)) {
+      return true;
+    }
+    String username = (String) session.getAttributes().get(ATTR_USERNAME);
+    if (username == null) {
+      return false;
+    }
+    try {
+      GitHubRepositoryRoleDto role =
+          gitHubService.getRepositoryRole(owningRepositoryId.toString(), username);
+      return role.getPermission() != null
+          && role.getPermission() != RepoPermissionType.NONE;
+    } catch (IOException e) {
+      log.warn(
+          "Failed to resolve repo role for user {} on repo {}: {}",
+          username,
+          owningRepositoryId,
+          e.getMessage());
+      return false;
+    }
+  }
+
+  private void send(WebSocketSession session, WsServerMessage payload) {
+    try {
+      String json = objectMapper.writeValueAsString(payload);
+      session.sendMessage(new TextMessage(json));
+    } catch (IOException | IllegalStateException e) {
+      log.warn("Failed to send WS message to {}: {}", session.getId(), e.getMessage());
+    }
+  }
+
+  private void sendError(WebSocketSession session, String code, String message, Long runId) {
+    send(session, new WsServerMessage.Error(code, message, runId));
+  }
+
+  private static String getUsername(WebSocketSession session) {
+    return (String) session.getAttributes().get(ATTR_USERNAME);
+  }
+
+  @Override
+  public List<String> getSubProtocols() {
+    return List.of(SUBPROTOCOL);
+  }
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WsClientMessage.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WsClientMessage.java
@@ -1,0 +1,18 @@
+package de.tum.cit.aet.helios.workflow.ws;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = WsClientMessage.Subscribe.class, name = "subscribe"),
+  @JsonSubTypes.Type(value = WsClientMessage.Unsubscribe.class, name = "unsubscribe"),
+  @JsonSubTypes.Type(value = WsClientMessage.Ping.class, name = "ping"),
+})
+public sealed interface WsClientMessage {
+  record Subscribe(long runId) implements WsClientMessage {}
+
+  record Unsubscribe(long runId) implements WsClientMessage {}
+
+  record Ping() implements WsClientMessage {}
+}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WsServerMessage.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/ws/WsServerMessage.java
@@ -1,0 +1,26 @@
+package de.tum.cit.aet.helios.workflow.ws;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import de.tum.cit.aet.helios.workflow.WorkflowRunDto;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public sealed interface WsServerMessage {
+
+  @JsonTypeName("workflow-run-updated")
+  record WorkflowRunUpdated(long runId, WorkflowRunDto run) implements WsServerMessage {}
+
+  /**
+   * Tells the client that workflow jobs for {@code runId} have changed. The client refetches via
+   * the existing REST endpoint — jobs are not persisted server-side, so we don't include them in
+   * the push payload.
+   */
+  @JsonTypeName("workflow-jobs-invalidated")
+  record WorkflowJobsInvalidated(long runId) implements WsServerMessage {}
+
+  @JsonTypeName("error")
+  record Error(String code, String message, Long runId) implements WsServerMessage {}
+
+  @JsonTypeName("pong")
+  record Pong() implements WsServerMessage {}
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
@@ -20,7 +20,11 @@ import de.tum.cit.aet.helios.environment.EnvironmentLockHistory;
 import de.tum.cit.aet.helios.environment.EnvironmentLockHistoryRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentService;
+<<<<<<< HEAD
 import de.tum.cit.aet.helios.filters.RepositoryContext;
+=======
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.github.WorkflowDispatchResult;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -61,7 +65,11 @@ public class DeploymentServiceTest {
   @Mock private BranchService branchService;
   @Mock private PullRequestRepository pullRequestRepository;
   @Mock private GitRepoRepository gitRepoRepository;
+<<<<<<< HEAD
   @Mock private HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
+=======
+  @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   private Deployment deployment;
   private GitRepository gitRepository;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
@@ -20,11 +20,8 @@ import de.tum.cit.aet.helios.environment.EnvironmentLockHistory;
 import de.tum.cit.aet.helios.environment.EnvironmentLockHistoryRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentRepository;
 import de.tum.cit.aet.helios.environment.EnvironmentService;
-<<<<<<< HEAD
-import de.tum.cit.aet.helios.filters.RepositoryContext;
-=======
 import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
+import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.github.WorkflowDispatchResult;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -65,11 +62,8 @@ public class DeploymentServiceTest {
   @Mock private BranchService branchService;
   @Mock private PullRequestRepository pullRequestRepository;
   @Mock private GitRepoRepository gitRepoRepository;
-<<<<<<< HEAD
   @Mock private HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
-=======
   @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 
   private Deployment deployment;
   private GitRepository gitRepository;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
@@ -10,12 +10,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-<<<<<<< HEAD
 import de.tum.cit.aet.helios.environment.Environment;
-import de.tum.cit.aet.helios.gitrepo.GitRepository;
-=======
 import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
->>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import java.io.IOException;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/OrphanHeliosDeploymentRecoveryServiceTest.java
@@ -10,8 +10,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+<<<<<<< HEAD
 import de.tum.cit.aet.helios.environment.Environment;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
+=======
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
+>>>>>>> efabc71d (feat: implement WebSocket infrastructure for real-time environment deployment status updates)
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import java.io.IOException;
@@ -28,6 +32,8 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
 
   @Mock
   private HeliosDeploymentRepository heliosDeploymentRepository;
+  @Mock
+  private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   @Mock
   private HeliosDeploymentWorkflowRunSyncService heliosDeploymentWorkflowRunSyncService;
@@ -59,6 +65,8 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
         .findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
             any(OffsetDateTime.class));
     verify(heliosDeploymentRepository, times(2)).save(any(HeliosDeployment.class));
+    verify(environmentDeploymentWebSocketPublisher, times(2))
+        .publishAfterCommit(any(HeliosDeployment.class));
     assertEquals(HeliosDeployment.Status.FAILED, stuck1.getStatus());
     assertEquals(HeliosDeployment.Status.FAILED, stuck2.getStatus());
     assertEquals(HeliosDeployment.Status.QUEUED, notStuck.getStatus());
@@ -165,6 +173,8 @@ class OrphanHeliosDeploymentRecoveryServiceTest {
         .findStuckDeploymentsWithoutDeploymentIdAndWorkflowRunIdIsNull(
             any(OffsetDateTime.class));
     verify(heliosDeploymentRepository, never()).save(any(HeliosDeployment.class));
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(HeliosDeployment.class));
   }
 
   private HeliosDeployment createStuckHeliosDeployment(Long id, HeliosDeployment.Status status) {

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/github/GitHubDeploymentSyncServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.helios.deployment.Deployment;
 import de.tum.cit.aet.helios.deployment.DeploymentRepository;
 import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
@@ -29,6 +30,7 @@ class GitHubDeploymentSyncServiceTest {
   @Mock private PullRequestRepository pullRequestRepository;
   @Mock private DeploymentConverter deploymentConverter;
   @Mock private HeliosDeploymentRepository heliosDeploymentRepository;
+  @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   @InjectMocks private GitHubDeploymentSyncService gitHubDeploymentSyncService;
 
@@ -72,5 +74,6 @@ class GitHubDeploymentSyncServiceTest {
     assertEquals(HeliosDeployment.Status.IN_PROGRESS, heliosDeployment.getStatus());
     assertEquals(deploymentUpdatedAt, heliosDeployment.getUpdatedAt());
     verify(heliosDeploymentRepository).save(heliosDeployment);
+    verify(environmentDeploymentWebSocketPublisher).publishAfterCommit(environment);
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentSchedulerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentSchedulerTest.java
@@ -1,0 +1,109 @@
+package de.tum.cit.aet.helios.environment;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
+import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsService;
+import de.tum.cit.aet.helios.nats.NatsNotificationPublisherService;
+import de.tum.cit.aet.helios.user.User;
+import de.tum.cit.aet.helios.user.UserRepository;
+import de.tum.cit.aet.helios.user.github.GitHubUserConverter;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EnvironmentSchedulerTest {
+
+  @Mock private EnvironmentRepository environmentRepository;
+  @Mock private GitRepoSettingsService gitRepoSettingsService;
+  @Mock private EnvironmentLockHistoryRepository lockHistoryRepository;
+  @Mock private GitHubUserConverter userConverter;
+  @Mock private UserRepository userRepository;
+  @Mock private org.springframework.core.env.Environment springEnvironment;
+  @Mock private NatsNotificationPublisherService notificationPublisherService;
+  @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
+
+  @InjectMocks private EnvironmentScheduler environmentScheduler;
+
+  private Environment environment;
+  private EnvironmentLockHistory lockHistory;
+  private User lockedBy;
+
+  @BeforeEach
+  void setUp() {
+    GitRepository repository = new GitRepository();
+    repository.setRepositoryId(42L);
+    repository.setNameWithOwner("owner/repo");
+
+    lockedBy = new User();
+    lockedBy.setId(1L);
+    lockedBy.setLogin("locked-user");
+
+    environment = new Environment();
+    environment.setId(7L);
+    environment.setName("test-env");
+    environment.setRepository(repository);
+    environment.setLocked(true);
+    environment.setLockedBy(lockedBy);
+    environment.setLockedAt(OffsetDateTime.now().minusMinutes(10));
+    environment.setLockExpirationThreshold(5L);
+
+    lockHistory = new EnvironmentLockHistory();
+    lockHistory.setEnvironment(environment);
+    lockHistory.setLockedBy(lockedBy);
+    lockHistory.setLockedAt(environment.getLockedAt());
+  }
+
+  @Test
+  void unlockExpiredEnvironmentsPublishesInvalidationAfterAutoUnlock() {
+    User expirationUser = new User();
+    expirationUser.setId(-2L);
+
+    when(springEnvironment.matchesProfiles("openapi")).thenReturn(false);
+    when(environmentRepository.findByLockedTrue()).thenReturn(List.of(environment));
+    when(lockHistoryRepository.findCurrentLockForEnabledEnvironment(7L))
+        .thenReturn(Optional.of(lockHistory));
+    when(userRepository.findById(-2L)).thenReturn(Optional.of(expirationUser));
+
+    environmentScheduler.unlockExpiredEnvironments();
+
+    verify(environmentRepository).save(environment);
+    verify(environmentDeploymentWebSocketPublisher).publishAfterCommit(environment);
+  }
+
+  @Test
+  void unlockExpiredEnvironmentsDoesNotPublishForNonExpiredLock() {
+    environment.setLockedAt(OffsetDateTime.now());
+
+    when(springEnvironment.matchesProfiles("openapi")).thenReturn(false);
+    when(environmentRepository.findByLockedTrue()).thenReturn(List.of(environment));
+
+    environmentScheduler.unlockExpiredEnvironments();
+
+    verify(environmentRepository, never()).save(any(Environment.class));
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
+  }
+
+  @Test
+  void unlockExpiredEnvironmentsDoesNotPublishWhenOpenApiProfileIsActive() {
+    when(springEnvironment.matchesProfiles("openapi")).thenReturn(true);
+
+    environmentScheduler.unlockExpiredEnvironments();
+
+    verify(environmentRepository, never()).findByLockedTrue();
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
@@ -19,6 +19,7 @@ import de.tum.cit.aet.helios.deployment.DeploymentException;
 import de.tum.cit.aet.helios.deployment.DeploymentRepository;
 import de.tum.cit.aet.helios.environment.github.GitHubEnvironmentSyncService;
 import de.tum.cit.aet.helios.environment.protectionrules.ProtectionRuleRepository;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.filters.RepositoryContext;
 import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
@@ -64,6 +65,7 @@ public class EnvironmentServiceTest {
   @Mock private GitHubEnvironmentSyncService environmentSyncService;
   @Mock private GitRepoRepository gitRepoRepository;
   @Mock private GitHubService gitHubService;
+  @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   @InjectMocks private EnvironmentService environmentService;
 
@@ -149,6 +151,7 @@ public class EnvironmentServiceTest {
     assertTrue(result.get().isLocked());
     verify(environmentRepository, times(1)).findById(1L);
     verify(environmentRepository, times(1)).save(any(Environment.class));
+    verify(environmentDeploymentWebSocketPublisher, times(1)).publishAfterCommit(environment);
   }
 
   @Test
@@ -167,6 +170,8 @@ public class EnvironmentServiceTest {
     // Should not modify lockedAt
     assertTrue(result.get().getLockedAt().isEqual(environment.getLockedAt()));
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -188,6 +193,8 @@ public class EnvironmentServiceTest {
 
     assertTrue(exception.getMessage().contains("Environment is locked by another user"));
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -220,6 +227,7 @@ public class EnvironmentServiceTest {
             .isAfter(dateTimeNow.plusMinutes(lockReservationExpirationThreshold)));
     verify(environmentRepository, times(1)).findById(1L);
     verify(environmentRepository, times(1)).save(any(Environment.class));
+    verify(environmentDeploymentWebSocketPublisher, times(1)).publishAfterCommit(environment);
   }
 
   @Test
@@ -236,6 +244,8 @@ public class EnvironmentServiceTest {
 
     assertEquals("Environment is not locked. Cannot extend lock.", exception.getMessage());
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -254,6 +264,8 @@ public class EnvironmentServiceTest {
 
     assertEquals("Only TEST environments can have their locks extended", exception.getMessage());
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -272,6 +284,8 @@ public class EnvironmentServiceTest {
 
     assertEquals("Environment is disabled", exception.getMessage());
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -295,6 +309,7 @@ public class EnvironmentServiceTest {
     assertNull(result.lockReservationWillExpireAt());
     verify(environmentRepository, times(1)).findById(1L);
     verify(environmentRepository, times(1)).save(any(Environment.class));
+    verify(environmentDeploymentWebSocketPublisher, times(1)).publishAfterCommit(environment);
   }
 
   @Test
@@ -435,6 +450,8 @@ public class EnvironmentServiceTest {
 
     assertEquals("Environment is not locked", exception.getMessage());
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test
@@ -459,6 +476,7 @@ public class EnvironmentServiceTest {
     assertNull(result.lockReservationWillExpireAt());
     verify(environmentRepository, times(1)).findById(1L);
     verify(environmentRepository, times(1)).save(any(Environment.class));
+    verify(environmentDeploymentWebSocketPublisher, times(1)).publishAfterCommit(environment);
   }
 
   @Test
@@ -482,6 +500,8 @@ public class EnvironmentServiceTest {
     assertTrue(
         exception.getMessage().contains("You do not have permission to unlock this environment"));
     verify(environmentRepository, times(1)).findById(1L);
+    verify(environmentDeploymentWebSocketPublisher, never())
+        .publishAfterCommit(any(Environment.class));
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketPublisherTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/ws/EnvironmentDeploymentWebSocketPublisherTest.java
@@ -1,0 +1,51 @@
+package de.tum.cit.aet.helios.environment.ws;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class EnvironmentDeploymentWebSocketPublisherTest {
+
+  @Mock private EnvironmentDeploymentWebSocketHandler handler;
+
+  @InjectMocks private EnvironmentDeploymentWebSocketPublisher publisher;
+
+  @AfterEach
+  void tearDown() {
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  @Test
+  void publishAfterCommitBroadcastsImmediatelyWithoutTransaction() {
+    publisher.publishAfterCommit(42L, 7L);
+
+    verify(handler).broadcastDeploymentInvalidated(42L, 7L);
+  }
+
+  @Test
+  void publishAfterCommitWaitsForTransactionCommit() {
+    TransactionSynchronizationManager.initSynchronization();
+
+    publisher.publishAfterCommit(42L, 7L);
+
+    verify(handler, never()).broadcastDeploymentInvalidated(42L, 7L);
+
+    for (TransactionSynchronization synchronization :
+        TransactionSynchronizationManager.getSynchronizations()) {
+      synchronization.afterCommit();
+    }
+
+    verify(handler).broadcastDeploymentInvalidated(42L, 7L);
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/github/GitHubWorkflowJobTimingServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfig;
 import de.tum.cit.aet.helios.deployment.DeploymentWorkflowConfigRepository;
 import de.tum.cit.aet.helios.environment.Environment;
+import de.tum.cit.aet.helios.environment.ws.EnvironmentDeploymentWebSocketPublisher;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import de.tum.cit.aet.helios.workflow.Workflow;
@@ -35,6 +36,7 @@ class GitHubWorkflowJobTimingServiceTest {
   @Mock private DeploymentWorkflowConfigRepository deploymentWorkflowConfigRepository;
   @Mock private HeliosDeploymentRepository heliosDeploymentRepository;
   @Mock private WorkflowRunRepository workflowRunRepository;
+  @Mock private EnvironmentDeploymentWebSocketPublisher environmentDeploymentWebSocketPublisher;
 
   @InjectMocks private GitHubWorkflowJobTimingService gitHubWorkflowJobTimingService;
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandlerTest.java
@@ -1,0 +1,125 @@
+package de.tum.cit.aet.helios.workflow.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.tum.cit.aet.helios.config.WebSocketSessionRegistry;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.workflow.WorkflowRunService;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+
+@ExtendWith(MockitoExtension.class)
+class WorkflowRunWebSocketHandlerTest {
+
+  private static final long RUN_ID = 42L;
+
+  @Mock private WorkflowRunService workflowRunService;
+  @Mock private GitHubService gitHubService;
+  @Mock private WebSocketSessionRegistry sessionRegistry;
+
+  private WorkflowRunWebSocketHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler =
+        new WorkflowRunWebSocketHandler(
+            new ObjectMapper(), workflowRunService, gitHubService, sessionRegistry);
+  }
+
+  @Test
+  void afterConnectionClosedRemovesDecoratedSessionById() {
+    WebSocketSession rawSession = session("session-1");
+    WebSocketSession decoratedSession = session("session-1");
+
+    subscribersByRun().put(RUN_ID, ConcurrentHashMap.newKeySet());
+    subscribersByRun().get(RUN_ID).add(decoratedSession);
+    runsBySession().put("session-1", ConcurrentHashMap.newKeySet());
+    runsBySession().get("session-1").add(RUN_ID);
+
+    handler.afterConnectionClosed(rawSession, CloseStatus.NORMAL);
+
+    verify(sessionRegistry).unregister("session-1");
+    assertFalse(runsBySession().containsKey("session-1"));
+    assertFalse(subscribersByRun().containsKey(RUN_ID));
+  }
+
+  @Test
+  void broadcastJobsInvalidatedKeepsThrottleTimestampForSuppressedEvent() {
+    WebSocketSession session = session("session-1");
+    subscribersByRun().put(RUN_ID, ConcurrentHashMap.newKeySet());
+    subscribersByRun().get(RUN_ID).add(session);
+    lastJobsBroadcastAt().put(RUN_ID, System.currentTimeMillis());
+
+    Long previousTimestamp = lastJobsBroadcastAt().get(RUN_ID);
+
+    handler.broadcastJobsInvalidated(RUN_ID);
+
+    assertEquals(previousTimestamp, lastJobsBroadcastAt().get(RUN_ID));
+    verify(sessionRegistry, never()).send(eq(session), any(WsServerMessage.class));
+  }
+
+  @Test
+  void broadcastJobsInvalidatedSendsAndAdvancesTimestampAfterThrottleWindow() {
+    WebSocketSession session = session("session-1");
+    subscribersByRun().put(RUN_ID, ConcurrentHashMap.newKeySet());
+    subscribersByRun().get(RUN_ID).add(session);
+    lastJobsBroadcastAt().put(RUN_ID, System.currentTimeMillis() - 11_000);
+
+    Long previousTimestamp = lastJobsBroadcastAt().get(RUN_ID);
+
+    handler.broadcastJobsInvalidated(RUN_ID);
+
+    verify(sessionRegistry).send(session, new WsServerMessage.WorkflowJobsInvalidated(RUN_ID));
+    assertTrue(lastJobsBroadcastAt().get(RUN_ID) > previousTimestamp);
+  }
+
+  @Test
+  void broadcastJobsInvalidatedDoesNotThrottleRunsWithoutSubscribers() {
+    handler.broadcastJobsInvalidated(RUN_ID);
+
+    assertNull(lastJobsBroadcastAt().get(RUN_ID));
+    verify(sessionRegistry, never()).send(any(WebSocketSession.class), any(WsServerMessage.class));
+  }
+
+  private static WebSocketSession session(String id) {
+    WebSocketSession session = mock(WebSocketSession.class);
+    lenient().when(session.getId()).thenReturn(id);
+    return session;
+  }
+
+  @SuppressWarnings("unchecked")
+  private ConcurrentHashMap<Long, Set<WebSocketSession>> subscribersByRun() {
+    return (ConcurrentHashMap<Long, Set<WebSocketSession>>)
+        ReflectionTestUtils.getField(handler, "subscribersByRun");
+  }
+
+  @SuppressWarnings("unchecked")
+  private ConcurrentHashMap<String, Set<Long>> runsBySession() {
+    return (ConcurrentHashMap<String, Set<Long>>)
+        ReflectionTestUtils.getField(handler, "runsBySession");
+  }
+
+  @SuppressWarnings("unchecked")
+  private ConcurrentHashMap<Long, Long> lastJobsBroadcastAt() {
+    return (ConcurrentHashMap<Long, Long>)
+        ReflectionTestUtils.getField(handler, "lastJobsBroadcastAt");
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandlerTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/ws/WorkflowRunWebSocketHandlerTest.java
@@ -46,7 +46,7 @@ class WorkflowRunWebSocketHandlerTest {
 
   @Test
   void afterConnectionClosedRemovesDecoratedSessionById() {
-    WebSocketSession rawSession = session("session-1");
+    final WebSocketSession rawSession = session("session-1");
     WebSocketSession decoratedSession = session("session-1");
 
     subscribersByRun().put(RUN_ID, ConcurrentHashMap.newKeySet());


### PR DESCRIPTION
### Motivation
Workflow run detail pages currently rely on polling/refetching, so users can miss status and job changes until the client refreshes data. This change adds authenticated WebSocket push updates so workflow run details stay current while a run progresses.

### Description
- Added a `/ws/workflow-runs` WebSocket endpoint for workflow run subscriptions.
- Authenticated WebSocket handshakes with JWT subprotocols and repository scoping.
- Added authorization checks so clients can only subscribe to runs owned by the connected repository unless they are configured Helios developers.
- Broadcast workflow run updates after persisted GitHub workflow run syncs.
- Broadcast workflow job invalidation events when workflow job webhook messages arrive, with rate limiting to avoid excessive refetches.
- Added a shared Angular WebSocket service with lazy connection handling, subscription refcounting, reconnect backoff, and automatic resubscription.
- Updated the workflow run details page to apply pushed run updates and invalidate workflow job queries in real time.

### Testing Instructions
#### Prerequisites:
- Developer account with access to a Helios repository.
- A repository with GitHub workflow runs and GitHub webhook/NATS processing configured.
- A workflow run details page that can be opened in Helios.

#### Flow:
1. Log in to Helios as a Developer.
2. Navigate to a repository and open an active workflow run details page.
3. Trigger or re-run a GitHub workflow for the same repository.
4. Keep the workflow run details page open while the workflow progresses.
5. Verify that run status, conclusion, timestamps, and duration update without manually refreshing the page.
6. If the user has write permission, verify that workflow job information refreshes when jobs start, complete, or change state.
7. Navigate away from the workflow run details page and back again, then verify updates still arrive after the page reconnects.

### Checklist
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I documented the TypeScript code using JSDoc style.