### PR TITLE
fix(client): broadcast cross-tab logout to sync auth state and hide write/lock actions after sign-out

### DIFF
--- a/client/src/app/components/user-lock-info/user-lock-info.component.ts
+++ b/client/src/app/components/user-lock-info/user-lock-info.component.ts
@@ -23,16 +23,26 @@ export class UserLockInfoComponent implements OnInit, OnDestroy {
   private dateService = inject(DateService);
   timeNow = signal<Date>(new Date());
   private intervalId?: ReturnType<typeof setInterval>;
-  timeUntilLockExpires = computed(() =>
-    this.latestLockExpiration()?.environment?.lockWillExpireAt !== null
-      ? this.dateService.timeUntilExpire(this.timeNow(), this.latestLockExpiration()?.environment?.lockWillExpireAt)
-      : `Unlimited`
-  );
+  isLoggedIn = computed(() => this.keycloakService.isLoggedIn());
+
+  timeUntilLockExpires = computed(() => {
+    if (!this.isLoggedIn()) {
+      return '';
+    }
+
+    const lockWillExpireAt = this.latestLockExpiration()?.environment?.lockWillExpireAt;
+    if (lockWillExpireAt == null) {
+      return 'Unlimited';
+    }
+
+    return this.dateService.timeUntilExpire(this.timeNow(), lockWillExpireAt);
+  });
+
   // Returns the latest lock information for the current user
   lockQuery = injectQuery(() => ({
     ...getEnvironmentsByUserLockingOptions(),
-    refetchInterval: 10000,
-    enabled: () => !!this.keycloakService.isLoggedIn(),
+    refetchInterval: () => (this.isLoggedIn() ? 10000 : false),
+    enabled: this.isLoggedIn(),
   }));
 
   ngOnInit() {
@@ -49,6 +59,10 @@ export class UserLockInfoComponent implements OnInit, OnDestroy {
   }
 
   latestLockExpiration = computed(() => {
+    if (!this.isLoggedIn()) {
+      return null;
+    }
+
     const lock = this.lockQuery.data();
 
     // For some reason, when there is no lock

--- a/client/src/app/core/services/keycloak/keycloak.service.spec.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.spec.ts
@@ -91,14 +91,25 @@ describe('KeycloakService', () => {
     expect(clearToken).toHaveBeenCalledTimes(1);
   });
 
-  it('should clear local auth state and broadcast on auto-logout events', () => {
+  it('should clear local auth state and broadcast after max consecutive refresh attempts with auth refresh errors', async () => {
+    vi.useFakeTimers();
     const service = new KeycloakService();
     const clearToken = vi.fn();
     const localStorageSpy = vi.spyOn(window.localStorage, 'setItem');
 
-    const keycloakStub = {
+    let keycloakStub: {
+      clearToken: () => void;
+      updateToken: ReturnType<typeof vi.fn>;
+      authenticated: boolean;
+      token: string | undefined;
+      onAuthRefreshError?: () => void;
+    };
+    keycloakStub = {
       clearToken,
-      updateToken: vi.fn(),
+      updateToken: vi.fn().mockImplementation(() => {
+        keycloakStub.onAuthRefreshError?.();
+        return Promise.reject(new Error('refresh error'));
+      }),
       authenticated: false,
       token: undefined,
     };
@@ -107,12 +118,91 @@ describe('KeycloakService', () => {
     (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
 
     (service as unknown as { bindKeycloakEvents: () => void }).bindKeycloakEvents();
-    (keycloakStub as unknown as { onAuthRefreshError?: () => void }).onAuthRefreshError?.();
+    (service as unknown as { startTokenRefresh: () => void }).startTokenRefresh();
 
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(true);
+    expect(clearToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(true);
+    expect(clearToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60000);
     expect(service.isLoggedIn()).toBe(false);
     expect(clearToken).toHaveBeenCalledTimes(1);
     expect(localStorageSpy).toHaveBeenCalledWith(AUTH_SYNC_STORAGE_KEY, expect.any(String));
 
     localStorageSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('should only logout after max consecutive token refresh failures', async () => {
+    vi.useFakeTimers();
+    const service = new KeycloakService();
+    const clearToken = vi.fn();
+    const localStorageSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    const keycloakStub = {
+      clearToken,
+      updateToken: vi.fn().mockRejectedValue(new Error('network error')),
+      authenticated: true,
+      token: 'token',
+    };
+
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+    (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
+
+    (service as unknown as { startTokenRefresh: () => void }).startTokenRefresh();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(true);
+    expect(clearToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(true);
+    expect(clearToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(false);
+    expect(clearToken).toHaveBeenCalledTimes(1);
+    expect(localStorageSpy).toHaveBeenCalledWith(AUTH_SYNC_STORAGE_KEY, expect.any(String));
+
+    localStorageSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('should not double-count a refresh failure when onAuthRefreshError fires after updateToken rejection', async () => {
+    vi.useFakeTimers();
+    const service = new KeycloakService();
+    const clearToken = vi.fn();
+    const localStorageSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    const keycloakStub = {
+      clearToken,
+      updateToken: vi.fn().mockRejectedValue(new Error('network error')),
+      authenticated: true,
+      token: 'token',
+    };
+
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+    (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
+    (service as unknown as { bindKeycloakEvents: () => void }).bindKeycloakEvents();
+    (service as unknown as { startTokenRefresh: () => void }).startTokenRefresh();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    (keycloakStub as unknown as { onAuthRefreshError?: () => void }).onAuthRefreshError?.();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(true);
+    expect(clearToken).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60000);
+    expect(service.isLoggedIn()).toBe(false);
+    expect(clearToken).toHaveBeenCalledTimes(1);
+    expect(localStorageSpy).toHaveBeenCalledWith(AUTH_SYNC_STORAGE_KEY, expect.any(String));
+
+    localStorageSpy.mockRestore();
+    vi.useRealTimers();
   });
 });

--- a/client/src/app/core/services/keycloak/keycloak.service.spec.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.spec.ts
@@ -3,6 +3,7 @@ import { environment } from 'environments/environment';
 
 describe('KeycloakService', () => {
   const originalSkipLoginPage = environment.keycloak.skipLoginPage;
+  const AUTH_SYNC_STORAGE_KEY = 'helios:auth:sync';
 
   afterEach(() => {
     environment.keycloak.skipLoginPage = originalSkipLoginPage;
@@ -53,5 +54,65 @@ describe('KeycloakService', () => {
 
     expect(login).toHaveBeenCalledTimes(1);
     expect(login).toHaveBeenCalledWith();
+  });
+
+  it('should broadcast and redirect on manual logout without pre-clearing local auth state', () => {
+    const service = new KeycloakService();
+    const logout = vi.fn();
+    const localStorageSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    (service as unknown as { _keycloak: unknown })._keycloak = { logout };
+    (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
+
+    service.logout();
+
+    expect(service.isLoggedIn()).toBe(true);
+    expect(localStorageSpy).toHaveBeenCalledWith(AUTH_SYNC_STORAGE_KEY, expect.any(String));
+    expect(logout).toHaveBeenCalledWith({ redirectUri: window.location.href });
+
+    localStorageSpy.mockRestore();
+  });
+
+  it('should react to cross-tab logout via storage event', () => {
+    const service = new KeycloakService();
+    const clearToken = vi.fn();
+
+    (service as unknown as { _keycloak: unknown })._keycloak = { clearToken };
+    (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: AUTH_SYNC_STORAGE_KEY,
+        newValue: JSON.stringify({ type: 'logout', at: Date.now() }),
+      })
+    );
+
+    expect(service.isLoggedIn()).toBe(false);
+    expect(clearToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear local auth state and broadcast on auto-logout events', () => {
+    const service = new KeycloakService();
+    const clearToken = vi.fn();
+    const localStorageSpy = vi.spyOn(window.localStorage, 'setItem');
+
+    const keycloakStub = {
+      clearToken,
+      updateToken: vi.fn(),
+      authenticated: false,
+      token: undefined,
+    };
+
+    (service as unknown as { _keycloak: unknown })._keycloak = keycloakStub;
+    (service as unknown as { _isLoggedIn: { set: (value: boolean) => void } })._isLoggedIn.set(true);
+
+    (service as unknown as { bindKeycloakEvents: () => void }).bindKeycloakEvents();
+    (keycloakStub as unknown as { onAuthRefreshError?: () => void }).onAuthRefreshError?.();
+
+    expect(service.isLoggedIn()).toBe(false);
+    expect(clearToken).toHaveBeenCalledTimes(1);
+    expect(localStorageSpy).toHaveBeenCalledWith(AUTH_SYNC_STORAGE_KEY, expect.any(String));
+
+    localStorageSpy.mockRestore();
   });
 });

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -7,12 +7,16 @@ import { environment } from 'environments/environment';
 })
 export class KeycloakService {
   private static readonly AUTH_SYNC_STORAGE_KEY = 'helios:auth:sync';
+  private static readonly MAX_CONSECUTIVE_REFRESH_FAILURES = 3;
 
   private _keycloak: Keycloak | undefined;
   private tokenRefreshIntervalId: ReturnType<typeof setInterval> | undefined;
   private keycloakEventsBound = false;
   private isClearingToken = false;
   private suppressLogoutBroadcast = false;
+  private consecutiveRefreshFailures = 0;
+  // Prevent counting the same refresh attempt twice when both error paths fire.
+  private refreshErrorHandledForAttempt = false;
 
   private _isLoggedIn = signal(false);
   private _profile = signal<UserProfile | undefined>(undefined);
@@ -119,11 +123,13 @@ export class KeycloakService {
 
     this.keycloak.onAuthSuccess = async () => {
       this._isLoggedIn.set(true);
+      this.resetRefreshFailureCount();
       this.startTokenRefresh();
       await this.reloadProfile();
     };
 
     this.keycloak.onAuthRefreshSuccess = () => {
+      this.resetRefreshFailureCount();
       this._isLoggedIn.set(!!this.keycloak.authenticated);
       const profile = this._profile();
       if (profile) {
@@ -135,7 +141,7 @@ export class KeycloakService {
     };
 
     this.keycloak.onAuthRefreshError = () => {
-      this.applyLoggedOutState({ clearToken: true, broadcast: true });
+      this.handleRefreshFailureOncePerAttempt();
     };
 
     this.keycloak.onAuthLogout = () => {
@@ -153,11 +159,13 @@ export class KeycloakService {
       if (!this.isLoggedIn()) {
         return;
       }
+      this.refreshErrorHandledForAttempt = false;
       try {
         // Update the token when it will be valid for less than 1 minute.
         await this.keycloak.updateToken(60);
+        this.resetRefreshFailureCount();
       } catch {
-        this.applyLoggedOutState({ clearToken: true, broadcast: true });
+        this.handleRefreshFailureOncePerAttempt();
       }
     }, 60000);
   }
@@ -189,6 +197,7 @@ export class KeycloakService {
 
   private applyLoggedOutState(options: { clearToken?: boolean; broadcast?: boolean } = {}) {
     this.stopTokenRefresh();
+    this.resetRefreshFailureCount();
     this._isLoggedIn.set(false);
     this._profile.set(undefined);
 
@@ -202,6 +211,26 @@ export class KeycloakService {
     if (options.broadcast) {
       this.broadcastLogoutEvent();
     }
+  }
+
+  private resetRefreshFailureCount() {
+    this.consecutiveRefreshFailures = 0;
+    this.refreshErrorHandledForAttempt = false;
+  }
+
+  private handleRefreshFailure() {
+    this.consecutiveRefreshFailures += 1;
+    if (this.consecutiveRefreshFailures >= KeycloakService.MAX_CONSECUTIVE_REFRESH_FAILURES) {
+      this.applyLoggedOutState({ clearToken: true, broadcast: true });
+    }
+  }
+
+  private handleRefreshFailureOncePerAttempt() {
+    if (this.refreshErrorHandledForAttempt) {
+      return;
+    }
+    this.refreshErrorHandledForAttempt = true;
+    this.handleRefreshFailure();
   }
 
   private handleStorageEvent = (event: StorageEvent) => {
@@ -224,12 +253,16 @@ export class KeycloakService {
       return;
     }
 
-    window.localStorage.setItem(
-      KeycloakService.AUTH_SYNC_STORAGE_KEY,
-      JSON.stringify({
-        type: 'logout',
-        at: Date.now(),
-      })
-    );
+    try {
+      window.localStorage.setItem(
+        KeycloakService.AUTH_SYNC_STORAGE_KEY,
+        JSON.stringify({
+          type: 'logout',
+          at: Date.now(),
+        })
+      );
+    } catch {
+      // Ignore storage write failures so logout can continue in the current tab.
+    }
   }
 }

--- a/client/src/app/core/services/keycloak/keycloak.service.ts
+++ b/client/src/app/core/services/keycloak/keycloak.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import Keycloak from 'keycloak-js';
 import { UserProfile } from './user-profile';
 import { environment } from 'environments/environment';
@@ -6,7 +6,22 @@ import { environment } from 'environments/environment';
   providedIn: 'root',
 })
 export class KeycloakService {
+  private static readonly AUTH_SYNC_STORAGE_KEY = 'helios:auth:sync';
+
   private _keycloak: Keycloak | undefined;
+  private tokenRefreshIntervalId: ReturnType<typeof setInterval> | undefined;
+  private keycloakEventsBound = false;
+  private isClearingToken = false;
+  private suppressLogoutBroadcast = false;
+
+  private _isLoggedIn = signal(false);
+  private _profile = signal<UserProfile | undefined>(undefined);
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', this.handleStorageEvent);
+    }
+  }
 
   get keycloak() {
     if (!this._keycloak) {
@@ -15,10 +30,8 @@ export class KeycloakService {
     return this._keycloak;
   }
 
-  private _profile: UserProfile | undefined;
-
   get profile(): UserProfile | undefined {
-    return this._profile;
+    return this._profile();
   }
 
   isCurrentUser(login?: string) {
@@ -26,26 +39,24 @@ export class KeycloakService {
   }
 
   async init() {
+    this.bindKeycloakEvents();
+
     const authenticated = await this.keycloak.init({
       onLoad: 'check-sso',
     });
 
     if (!authenticated) {
+      this.applyLoggedOutState();
       return;
     }
 
-    // Regulary check if the token needs to be refreshed and refresh it if necessary
-    setInterval(() => {
-      // Update the token when will last less than 5 minutes
-      this.keycloak.updateToken(300);
-    }, 60000);
-
-    this._profile = (await this.keycloak.loadUserProfile()) as UserProfile;
-    this._profile.token = this.keycloak.token || '';
+    this._isLoggedIn.set(true);
+    this.startTokenRefresh();
+    await this.reloadProfile();
   }
 
   isLoggedIn() {
-    return this.keycloak.authenticated;
+    return this._isLoggedIn();
   }
 
   getUserId() {
@@ -90,6 +101,135 @@ export class KeycloakService {
   }
 
   logout() {
+    this.broadcastLogoutEvent();
     return this.keycloak.logout({ redirectUri: window.location.href });
+  }
+
+  private async reloadProfile() {
+    const profile = (await this.keycloak.loadUserProfile()) as UserProfile;
+    profile.token = this.keycloak.token || '';
+    this._profile.set(profile);
+  }
+
+  private bindKeycloakEvents() {
+    if (this.keycloakEventsBound) {
+      return;
+    }
+    this.keycloakEventsBound = true;
+
+    this.keycloak.onAuthSuccess = async () => {
+      this._isLoggedIn.set(true);
+      this.startTokenRefresh();
+      await this.reloadProfile();
+    };
+
+    this.keycloak.onAuthRefreshSuccess = () => {
+      this._isLoggedIn.set(!!this.keycloak.authenticated);
+      const profile = this._profile();
+      if (profile) {
+        this._profile.set({
+          ...profile,
+          token: this.keycloak.token || '',
+        });
+      }
+    };
+
+    this.keycloak.onAuthRefreshError = () => {
+      this.applyLoggedOutState({ clearToken: true, broadcast: true });
+    };
+
+    this.keycloak.onAuthLogout = () => {
+      this.applyLoggedOutState({ broadcast: !this.suppressLogoutBroadcast });
+    };
+  }
+
+  private startTokenRefresh() {
+    if (this.tokenRefreshIntervalId !== undefined) {
+      return;
+    }
+
+    // Regularly check if the token needs to be refreshed.
+    this.tokenRefreshIntervalId = setInterval(async () => {
+      if (!this.isLoggedIn()) {
+        return;
+      }
+      try {
+        // Update the token when it will be valid for less than 1 minute.
+        await this.keycloak.updateToken(60);
+      } catch {
+        this.applyLoggedOutState({ clearToken: true, broadcast: true });
+      }
+    }, 60000);
+  }
+
+  private stopTokenRefresh() {
+    if (this.tokenRefreshIntervalId !== undefined) {
+      clearInterval(this.tokenRefreshIntervalId);
+      this.tokenRefreshIntervalId = undefined;
+    }
+  }
+
+  private clearToken() {
+    if (!this._keycloak || this.isClearingToken) {
+      return;
+    }
+
+    const keycloak = this._keycloak as Keycloak & { clearToken?: () => void };
+    if (typeof keycloak.clearToken !== 'function') {
+      return;
+    }
+
+    this.isClearingToken = true;
+    try {
+      keycloak.clearToken();
+    } finally {
+      this.isClearingToken = false;
+    }
+  }
+
+  private applyLoggedOutState(options: { clearToken?: boolean; broadcast?: boolean } = {}) {
+    this.stopTokenRefresh();
+    this._isLoggedIn.set(false);
+    this._profile.set(undefined);
+
+    if (options.clearToken) {
+      const previousSuppressLogoutBroadcast = this.suppressLogoutBroadcast;
+      this.suppressLogoutBroadcast = true;
+      this.clearToken();
+      this.suppressLogoutBroadcast = previousSuppressLogoutBroadcast;
+    }
+
+    if (options.broadcast) {
+      this.broadcastLogoutEvent();
+    }
+  }
+
+  private handleStorageEvent = (event: StorageEvent) => {
+    if (event.key !== KeycloakService.AUTH_SYNC_STORAGE_KEY || !event.newValue) {
+      return;
+    }
+
+    try {
+      const authEvent = JSON.parse(event.newValue) as { type?: string };
+      if (authEvent.type === 'logout') {
+        this.applyLoggedOutState({ clearToken: true });
+      }
+    } catch {
+      // Ignore malformed storage events.
+    }
+  };
+
+  private broadcastLogoutEvent() {
+    if (typeof window === 'undefined' || !window.localStorage) {
+      return;
+    }
+
+    window.localStorage.setItem(
+      KeycloakService.AUTH_SYNC_STORAGE_KEY,
+      JSON.stringify({
+        type: 'logout',
+        at: Date.now(),
+      })
+    );
   }
 }

--- a/client/src/app/core/services/permission.service.ts
+++ b/client/src/app/core/services/permission.service.ts
@@ -14,13 +14,17 @@ export class PermissionService {
 
   permissionsQuery = injectQuery(() => ({
     ...getUserPermissionsOptions(),
-    enabled: () => !!this.repositoryService.currentRepositoryId() && !!this.keycloak.isLoggedIn(),
+    enabled: () => !!this.repositoryService.currentRepositoryId() && this.keycloak.isLoggedIn(),
   }));
 
   heliosDevelopers: string[] = environment.heliosDevelopers;
   isHeliosDeveloper = computed(() => !!this.keycloak.profile?.username && this.heliosDevelopers.includes(this.keycloak.profile.username.toLowerCase()));
 
-  hasWritePermission = computed(() => this.permissionsQuery.data()?.permission === 'WRITE' || this.permissionsQuery.data()?.permission === 'ADMIN' || this.isHeliosDeveloper());
-  isAtLeastMaintainer = computed(() => this.permissionsQuery.data()?.permission === 'ADMIN' || this.permissionsQuery.data()?.roleName === 'maintain' || this.isHeliosDeveloper());
-  isAdmin = computed(() => this.permissionsQuery.data()?.permission === 'ADMIN' || this.isHeliosDeveloper());
+  hasWritePermission = computed(
+    () => this.keycloak.isLoggedIn() && (this.permissionsQuery.data()?.permission === 'WRITE' || this.permissionsQuery.data()?.permission === 'ADMIN' || this.isHeliosDeveloper())
+  );
+  isAtLeastMaintainer = computed(
+    () => this.keycloak.isLoggedIn() && (this.permissionsQuery.data()?.permission === 'ADMIN' || this.permissionsQuery.data()?.roleName === 'maintain' || this.isHeliosDeveloper())
+  );
+  isAdmin = computed(() => this.keycloak.isLoggedIn() && (this.permissionsQuery.data()?.permission === 'ADMIN' || this.isHeliosDeveloper()));
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Helios! Before you submit your pull request, please make sure to check all tasks by putting an x in the [ ] (don't: [x ], [ x], do: [x]). Remove not applicable tasks and do not leave them unchecked -->
<!-- If your pull request is not ready for review yet, create a draft pull request! -->

### Motivation
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
When a user was logged into multiple Helios tabs, logging out in one tab did not immediately update auth state in the others.
This left write-guarded actions (e.g., deploy/lock/cancel) visible or usable in stale tabs until a refresh, which could lead to `403` responses. https://github.com/ls1intum/Helios/issues/1026 #996


### Description
<!-- Describe your changes in detail -->
This PR fixes cross-tab auth consistency and update write-action visibility in the client:
- Added cross-tab logout sync in `KeycloakService` using `localStorage (helios:auth:sync)` + `storage` event listener.
- Centralized auth lifecycle handling in `KeycloakService`:
  - reactive login state via signal
  - unified logged-out state application
  - token refresh interval start/stop management
  - logout broadcast handling for manual and auto-logout cases
- Updated permission guards in `PermissionService` so role checks (`hasWritePermission, isAtLeastMaintainer, isAdmin`) always require `isLoggedIn()`.
- Updated `UserLockInfoComponent` to stop polling and hide lock-expiration info when logged out.
- Added/updated unit tests in `keycloak.service.spec.ts` for:
  - manual logout broadcast
  - cross-tab logout handling
  - refresh-error auto-logout behavior

### Testing Instructions
<!-- Please describe in detail how reviewers can test your changes. Make sure to take all related features and views into account! -->
#### Prerequisites:
- A Helios user with write permission for at least one repository/environment
- At least one enabled `TEST` environment in that repository
- Two browser tabs opened to the same Helios instance (same account/session)

#### Flow:
1. Open Tab A and Tab B in Helios with the same logged-in account.
2. In Tab A, navigate to Environments and locate an enabled `TEST` environment where write actions are available.
3. Confirm write-related controls are visible/enabled in Tab A (e.g., Deploy/Lock where applicable).
4. In tab A, deploy a branch or PR and lock an environment. (you can additionally test the other actions) 
5. In Tab B, click Logout.
6. Return to Tab A without refreshing.
7. Verify Tab A immediately reflects logged-out state:
- write/lock-related actions are hidden/disabled by permission gating
- user lock info no longer polls/displays active lock countdown
8. Verify that there is no 403 errors in Browser > Developer Tool > Networks.

### Screenshots
<!-- Add screenshots to demonstrate the changes in the UI. Remove the section if you did not change the UI. -->

[screen-capture.webm](https://github.com/user-attachments/assets/66ba5304-39d3-47f9-b21b-d6fbd30e5228)


### Checklist
<!-- Remove tasks that are not applicable for your PR. Please only put the PR into ready for review, if all relevant tasks are checked! -->
#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally.
- [x] Screenshots have been attached.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [x] I added multiple screenshots/screencasts of my UI changes.