### PR TITLE
refactor: introduce statusUpdatedAt to HeliosDeployment and enforce deployment blocking logic during environment unlock

### DIFF
--- a/client/src/app/components/environments/environment-actions/environment-actions.component.html
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.html
@@ -14,7 +14,7 @@
     <p-buttongroup>
       <!-- Deploy/Cancel Button -->
       @if (deployable()) {
-        @if (isDeploymentInProgress()) {
+        @if (isDeploymentInProgress() && canUserDeploy()) {
           <p-button
             class="border-r-2"
             severity="danger"
@@ -28,7 +28,7 @@
               <span>Cancel</span>
             </div>
           </p-button>
-        } @else {
+        } @else if (!isDeploymentInProgress()) {
           <p-button class="border-r-2" (click)="onDeploy($event)" [disabled]="!canUserDeploy()" [pTooltip]="getDeployTooltip()" tooltipPosition="top">
             <div class="flex items-center">
               <i-tabler name="cloud-upload" class="w-4 h-4 mr-1.5 flex-shrink-0" />
@@ -54,7 +54,7 @@
               </div>
             </p-button>
             @if (isCurrentUserLocked()) {
-              <p-button severity="success" (click)="onExtend($event)" [disabled]="!canUnlock()" [pTooltip]="'Extend my lock expiration'" tooltipPosition="top">
+              <p-button severity="success" (click)="onExtend($event)" [disabled]="!canExtendLock()" [pTooltip]="'Extend my lock expiration'" tooltipPosition="top">
                 <i-tabler name="lock-plus" class="w-4 h-4 flex-shrink-0" />
               </p-button>
             }

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.spec.ts
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.spec.ts
@@ -99,6 +99,30 @@ describe('EnvironmentActionsComponent', () => {
     expect(component.getCancelDeploymentToolTip()).toBe('This will cancel the ongoing deployment.');
   });
 
+  it('does not block unlock for active pure GitHub deployments without a status update timestamp', () => {
+    const activeGitHubDeployment = deployment('IN_PROGRESS', {
+      type: 'GITHUB',
+    });
+    delete activeGitHubDeployment.statusUpdatedAt;
+    setEnvironment(activeGitHubDeployment);
+
+    expect(component.isDeploymentInProgress()).toBe(true);
+    expect(component.canUnlock()).toBe(true);
+    expect(component.getUnlockToolTip()).toBe('Unlock Environment');
+  });
+
+  it('blocks unlock for active Helios-backed GitHub deployments with a status update timestamp', () => {
+    setEnvironment(
+      deployment('IN_PROGRESS', {
+        type: 'GITHUB',
+      })
+    );
+
+    expect(component.isDeploymentInProgress()).toBe(true);
+    expect(component.canUnlock()).toBe(false);
+    expect(component.getUnlockToolTip()).toBe('Cancel the ongoing deployment before unlocking this environment.');
+  });
+
   it('allows the lock owner to unlock stale active deployments', () => {
     isMaintainer = false;
     currentGithubId = '1';

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.spec.ts
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.spec.ts
@@ -1,0 +1,134 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
+import { KeycloakService } from '@app/core/services/keycloak/keycloak.service';
+import { PermissionService } from '@app/core/services/permission.service';
+import { EnvironmentActionsComponent } from './environment-actions.component';
+
+describe('EnvironmentActionsComponent', () => {
+  let fixture: ComponentFixture<EnvironmentActionsComponent>;
+  let component: EnvironmentActionsComponent;
+  let currentGithubId: string;
+  let isMaintainer: boolean;
+
+  beforeEach(async () => {
+    currentGithubId = '1';
+    isMaintainer = false;
+
+    await TestBed.configureTestingModule({
+      imports: [EnvironmentActionsComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideNoopAnimations(),
+        {
+          provide: KeycloakService,
+          useValue: {
+            isLoggedIn: () => true,
+            getUserGithubId: () => currentGithubId,
+          },
+        },
+        {
+          provide: PermissionService,
+          useValue: {
+            hasWritePermission: () => true,
+            isAtLeastMaintainer: () => isMaintainer,
+          },
+        },
+      ],
+    })
+      .overrideComponent(EnvironmentActionsComponent, {
+        set: { template: '' },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(EnvironmentActionsComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  const deployment = (state: NonNullable<EnvironmentDeployment['state']>, overrides: Partial<EnvironmentDeployment> = {}): EnvironmentDeployment => ({
+    id: 1,
+    state,
+    type: 'HELIOS',
+    statusUpdatedAt: new Date().toISOString(),
+    workflowRunHtmlUrl: 'https://github.com/ls1intum/Helios/actions/runs/1',
+    ...overrides,
+  });
+
+  const environment = (latestDeployment?: EnvironmentDeployment): EnvironmentDto => ({
+    id: 1,
+    name: 'test-server-1',
+    locked: true,
+    enabled: true,
+    type: 'TEST',
+    lockedBy: {
+      id: 1,
+      login: 'test-user',
+      avatarUrl: '',
+      name: 'Test User',
+      htmlUrl: '',
+    },
+    lockedAt: new Date().toISOString(),
+    latestDeployment,
+  });
+
+  function setEnvironment(latestDeployment?: EnvironmentDeployment) {
+    fixture.componentRef.setInput('environment', environment(latestDeployment));
+    fixture.componentRef.setInput('deployable', true);
+    fixture.componentRef.setInput('canViewAllEnvironments', false);
+    fixture.componentRef.setInput('timeUntilReservationExpires', undefined);
+    fixture.detectChanges();
+  }
+
+  it.each(['WAITING', 'PENDING', 'REQUESTED', 'QUEUED', 'IN_PROGRESS'] as const)('disables unlock while deployment state is %s', state => {
+    setEnvironment(deployment(state));
+
+    expect(component.isDeploymentInProgress()).toBe(true);
+    expect(component.canUnlock()).toBe(false);
+    expect(component.getUnlockToolTip()).toBe('Cancel the ongoing deployment before unlocking this environment.');
+  });
+
+  it('keeps cancel available while an active deployment has a workflow run URL', () => {
+    setEnvironment(deployment('IN_PROGRESS'));
+
+    expect(component.canCancelDeployment()).toBe(true);
+    expect(component.getCancelDeploymentToolTip()).toBe('This will cancel the ongoing deployment.');
+  });
+
+  it('allows the lock owner to unlock stale active deployments', () => {
+    isMaintainer = false;
+    currentGithubId = '1';
+    setEnvironment(
+      deployment('IN_PROGRESS', {
+        statusUpdatedAt: new Date(Date.now() - 21 * 60 * 1000).toISOString(),
+      })
+    );
+
+    expect(component.canUnlock()).toBe(true);
+    expect(component.getUnlockToolTip()).toBe('Deployment appears stale. You can unlock this environment.');
+  });
+
+  it('allows maintainers to unlock stale active deployments on another user’s lock', () => {
+    isMaintainer = true;
+    currentGithubId = '2';
+    setEnvironment(
+      deployment('IN_PROGRESS', {
+        statusUpdatedAt: new Date(Date.now() - 21 * 60 * 1000).toISOString(),
+      })
+    );
+
+    expect(component.canUnlock()).toBe(true);
+    expect(component.getUnlockToolTip()).toBe('Deployment appears stale. You can unlock this environment.');
+  });
+
+  it('does not disable lock extension when an active deployment blocks unlock', () => {
+    setEnvironment(deployment('IN_PROGRESS'));
+
+    expect(component.canUnlock()).toBe(false);
+    expect(component.canExtendLock()).toBe(true);
+  });
+});

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.ts
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.ts
@@ -150,7 +150,7 @@ export class EnvironmentActionsComponent {
 
   readonly canUnlockStaleDeployment = computed(() => {
     const deployment = this.environment().latestDeployment;
-    if (!this.isActiveDeployment(deployment) || !deployment?.statusUpdatedAt) {
+    if (!this.isUnlockBlockingDeployment(deployment)) {
       return false;
     }
 
@@ -163,7 +163,7 @@ export class EnvironmentActionsComponent {
   });
 
   readonly activeDeploymentBlocksUnlock = computed(() => {
-    return !!this.isDeploymentInProgress() && !this.canUnlockStaleDeployment();
+    return this.isUnlockBlockingDeployment(this.environment().latestDeployment) && !this.canUnlockStaleDeployment();
   });
 
   readonly canCancelDeployment = computed(() => {
@@ -213,5 +213,9 @@ export class EnvironmentActionsComponent {
 
   private isActiveDeployment(deployment: EnvironmentDeployment | undefined): boolean {
     return !!deployment?.state && ACTIVE_DEPLOYMENT_STATES.has(deployment.state);
+  }
+
+  private isUnlockBlockingDeployment(deployment: EnvironmentDeployment | undefined): deployment is EnvironmentDeployment & { statusUpdatedAt: string } {
+    return this.isActiveDeployment(deployment) && !!deployment?.statusUpdatedAt;
   }
 }

--- a/client/src/app/components/environments/environment-actions/environment-actions.component.ts
+++ b/client/src/app/components/environments/environment-actions/environment-actions.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, input, output, computed } from '@angular/core';
 import { UserAvatarComponent } from '@app/components/user-avatar/user-avatar.component';
-import { EnvironmentDto } from '@app/core/modules/openapi';
+import { EnvironmentDeployment, EnvironmentDto } from '@app/core/modules/openapi';
 import { LockTimeComponent } from '../lock-time/lock-time.component';
 import { ButtonModule } from 'primeng/button';
 import { ButtonGroupModule } from 'primeng/buttongroup';
@@ -13,6 +13,11 @@ import { PermissionService } from '@app/core/services/permission.service';
 import { EnvironmentReviewersComponent } from '../environment-reviewers/environment-reviewers.component';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
 import { IconCheck, IconCloudUpload, IconLock, IconLockOpen, IconLockPlus, IconPencil, IconX } from 'angular-tabler-icons/icons';
+
+type DeploymentState = NonNullable<EnvironmentDeployment['state']>;
+
+const ACTIVE_DEPLOYMENT_STATES = new Set<DeploymentState>(['WAITING', 'PENDING', 'REQUESTED', 'QUEUED', 'IN_PROGRESS']);
+const STALE_DEPLOYMENT_UNLOCK_TIMEOUT_MS = 20 * 60 * 1000;
 
 @Component({
   selector: 'app-environment-actions',
@@ -77,6 +82,10 @@ export class EnvironmentActionsComponent {
   );
 
   readonly canUnlock = computed(() => {
+    if (this.activeDeploymentBlocksUnlock()) {
+      return false;
+    }
+
     if (this.hasUnlockPermissions() || this.isCurrentUserLocked()) {
       return true;
     } else if (!this.isCurrentUserLocked() && (this.timeUntilReservationExpires() ?? -1) === 0) {
@@ -85,6 +94,8 @@ export class EnvironmentActionsComponent {
       return false;
     }
   });
+
+  readonly canExtendLock = computed(() => this.isLoggedIn() && this.isCurrentUserLocked());
 
   readonly getLockTooltip = computed(() =>
     this.canUserDeploy() ? 'This will only lock the environment without any deployment.' : 'You do not have permission to lock this environment.'
@@ -98,6 +109,14 @@ export class EnvironmentActionsComponent {
   });
 
   readonly getUnlockToolTip = computed(() => {
+    if (this.canUnlockStaleDeployment()) {
+      return 'Deployment appears stale. You can unlock this environment.';
+    }
+
+    if (this.activeDeploymentBlocksUnlock()) {
+      return 'Cancel the ongoing deployment before unlocking this environment.';
+    }
+
     if (!this.canUnlock()) {
       return 'You do not have permission to unlock this environment.';
     }
@@ -126,12 +145,29 @@ export class EnvironmentActionsComponent {
   });
 
   readonly isDeploymentInProgress = computed(() => {
+    return this.isActiveDeployment(this.environment().latestDeployment);
+  });
+
+  readonly canUnlockStaleDeployment = computed(() => {
     const deployment = this.environment().latestDeployment;
-    return deployment && (deployment.state === 'IN_PROGRESS' || deployment.state === 'PENDING' || deployment.state === 'QUEUED' || deployment.state === 'REQUESTED');
+    if (!this.isActiveDeployment(deployment) || !deployment?.statusUpdatedAt) {
+      return false;
+    }
+
+    const isAllowed = this.hasUnlockPermissions() || this.isCurrentUserLocked() || (this.timeUntilReservationExpires() ?? -1) === 0;
+    if (!isAllowed) {
+      return false;
+    }
+
+    return Date.now() - new Date(deployment.statusUpdatedAt).getTime() >= STALE_DEPLOYMENT_UNLOCK_TIMEOUT_MS;
+  });
+
+  readonly activeDeploymentBlocksUnlock = computed(() => {
+    return !!this.isDeploymentInProgress() && !this.canUnlockStaleDeployment();
   });
 
   readonly canCancelDeployment = computed(() => {
-    return this.isDeploymentInProgress() && this.canUserDeploy() && this.environment().latestDeployment?.workflowRunHtmlUrl;
+    return !!(this.isDeploymentInProgress() && this.canUserDeploy() && this.environment().latestDeployment?.workflowRunHtmlUrl);
   });
 
   openExternalLink(event: MouseEvent, link?: string): void {
@@ -173,5 +209,9 @@ export class EnvironmentActionsComponent {
       return 'Cancelling deployment is not possible.';
     }
     return 'This will cancel the ongoing deployment.';
+  }
+
+  private isActiveDeployment(deployment: EnvironmentDeployment | undefined): boolean {
+    return !!deployment?.state && ACTIVE_DEPLOYMENT_STATES.has(deployment.state);
   }
 }

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -267,6 +267,10 @@ export const EnvironmentDeploymentSchema = {
       type: 'string',
       format: 'date-time',
     },
+    statusUpdatedAt: {
+      type: 'string',
+      format: 'date-time',
+    },
     deployJobStartedAt: {
       type: 'string',
       format: 'date-time',

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -88,6 +88,7 @@ export type EnvironmentDeployment = {
   pullRequestNumber?: number;
   createdAt?: string;
   updatedAt?: string;
+  statusUpdatedAt?: string;
   deployJobStartedAt?: string;
   workflowStartedAt?: string;
   type: 'GITHUB' | 'HELIOS';

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -2508,6 +2508,9 @@ components:
         updatedAt:
           type: string
           format: date-time
+        statusUpdatedAt:
+          type: string
+          format: date-time
         deployJobStartedAt:
           type: string
           format: date-time

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -230,6 +230,13 @@ public class LatestDeploymentUnion {
     }
   }
 
+  public OffsetDateTime getStatusUpdatedAt() {
+    if (hasHeliosDeployment()) {
+      return heliosDeployment.getStatusUpdatedAt();
+    }
+    return null;
+  }
+
   public OffsetDateTime getDeployJobStartedAt() {
     if (hasTimingHeliosDeployment()) {
       return heliosDeployment.getDeployJobStartedAt();

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentDto.java
@@ -90,6 +90,8 @@ public record EnvironmentDto(
     private final Integer pullRequestNumber;
     private final OffsetDateTime createdAt;
     private final OffsetDateTime updatedAt;
+    @Schema(type = "string", format = "date-time")
+    private final OffsetDateTime statusUpdatedAt;
     private final OffsetDateTime deployJobStartedAt;
     private final OffsetDateTime workflowStartedAt;
     @NonNull private final DeploymentType type;
@@ -140,6 +142,7 @@ public record EnvironmentDto(
           union.getPullRequestNumber(),
           union.getCreatedAt(),
           union.getUpdatedAt(),
+          union.getStatusUpdatedAt(),
           union.getDeployJobStartedAt(),
           union.getWorkflowStartedAt(),
           union.getType(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -56,6 +56,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EnvironmentService {
 
+  private static final long ACTIVE_DEPLOYMENT_UNLOCK_TIMEOUT_MINUTES = 20;
+  private static final String ACTIVE_DEPLOYMENT_UNLOCK_ERROR_MESSAGE =
+      "Cancel the ongoing deployment before unlocking this environment.";
+
   private final AuthService authService;
   private final EnvironmentRepository environmentRepository;
   private final EnvironmentLockHistoryRepository lockHistoryRepository;
@@ -463,11 +467,7 @@ public class EnvironmentService {
       }
     }
 
-    // 20 minutes timeout for redeployment
-    if (!canUnlock(environment, 20)) {
-      throw new DeploymentException("Deployment is still in progress, please wait.");
-    }
-
+    validateNoBlockingActiveDeployment(environment);
 
     // Publish email notification for lock unlocked
     // Publish only if the unlocker is different from the locker
@@ -777,41 +777,38 @@ public class EnvironmentService {
         .collect(Collectors.toList());
   }
 
-  // TODO: Move this to a more appropriate location
-  //  since we have the same code in two places
-  //  below method (EnvironmentService) & canRedeploy method in DeploymentService
-  private boolean canUnlock(Environment environment, long timeoutMinutes) {
-    // Fetch the most recent deployment for the environment
+  private void validateNoBlockingActiveDeployment(Environment environment) {
     Optional<HeliosDeployment> latestDeployment =
         heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment);
 
     if (latestDeployment.isEmpty()) {
-      // No prior deployments, safe to unlock
-      return true;
+      return;
     }
 
     HeliosDeployment deployment = latestDeployment.get();
 
-    if (deployment.getStatus() == HeliosDeployment.Status.FAILED
-        || deployment.getStatus() == HeliosDeployment.Status.IO_ERROR
-        || deployment.getStatus() == HeliosDeployment.Status.UNKNOWN
-        || deployment.getStatus() == HeliosDeployment.Status.CANCELLED) {
-      return true;
+    if (!isActiveDeploymentStatus(deployment.getStatus())) {
+      return;
     }
 
-    // Check if timeout has elapsed
-    if (deployment.getStatus() == HeliosDeployment.Status.IN_PROGRESS
-        || deployment.getStatus() == HeliosDeployment.Status.WAITING
-        || deployment.getStatus() == HeliosDeployment.Status.QUEUED) {
-      OffsetDateTime now = OffsetDateTime.now();
-      if (deployment.getStatusUpdatedAt().plusMinutes(timeoutMinutes).isAfter(now)) {
-        return false;
-      }
-
-      deployment.setStatus(HeliosDeployment.Status.UNKNOWN);
-      heliosDeploymentRepository.save(deployment);
+    OffsetDateTime statusUpdatedAt = deployment.getStatusUpdatedAt();
+    boolean deploymentIsStale =
+        statusUpdatedAt != null
+            && !statusUpdatedAt
+                .plusMinutes(ACTIVE_DEPLOYMENT_UNLOCK_TIMEOUT_MINUTES)
+                .isAfter(OffsetDateTime.now());
+    if (!deploymentIsStale) {
+      throw new DeploymentException(ACTIVE_DEPLOYMENT_UNLOCK_ERROR_MESSAGE);
     }
-    return true;
+
+    deployment.setStatus(HeliosDeployment.Status.UNKNOWN);
+    heliosDeploymentRepository.save(deployment);
+  }
+
+  private boolean isActiveDeploymentStatus(HeliosDeployment.Status status) {
+    return status == HeliosDeployment.Status.WAITING
+        || status == HeliosDeployment.Status.QUEUED
+        || status == HeliosDeployment.Status.IN_PROGRESS;
   }
 
   public Optional<EnvironmentReviewersDto> getEnvironmentReviewers(Long environmentId) {

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/environment/EnvironmentServiceTest.java
@@ -8,12 +8,14 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tum.cit.aet.helios.auth.AuthService;
+import de.tum.cit.aet.helios.deployment.DeploymentException;
 import de.tum.cit.aet.helios.deployment.DeploymentRepository;
 import de.tum.cit.aet.helios.environment.github.GitHubEnvironmentSyncService;
 import de.tum.cit.aet.helios.environment.protectionrules.ProtectionRuleRepository;
@@ -22,6 +24,7 @@ import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.gitreposettings.GitRepoSettingsService;
+import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeploymentRepository;
 import de.tum.cit.aet.helios.nats.NatsNotificationPublisherService;
 import de.tum.cit.aet.helios.releaseinfo.releasecandidate.ReleaseCandidateRepository;
@@ -295,6 +298,130 @@ public class EnvironmentServiceTest {
     assertNull(result.lockReservationWillExpireAt());
     verify(environmentRepository, times(1)).findById(1L);
     verify(environmentRepository, times(1)).save(any(Environment.class));
+  }
+
+  @Test
+  public void testLockOwnerCanNotUnlockWithActiveDeployment() {
+    environment.setLocked(true);
+    environment.setLockedBy(user);
+    environment.setLockedAt(OffsetDateTime.now());
+    HeliosDeployment deployment =
+        createHeliosDeployment(HeliosDeployment.Status.IN_PROGRESS, OffsetDateTime.now());
+
+    when(authService.getUserFromGithubId()).thenReturn(user);
+    when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+    when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
+        .thenReturn(Optional.of(deployment));
+
+    DeploymentException exception =
+        assertThrows(DeploymentException.class, () -> environmentService.unlockEnvironment(1L));
+
+    assertEquals(
+        "Cancel the ongoing deployment before unlocking this environment.", exception.getMessage());
+    verify(environmentRepository, never()).save(any(Environment.class));
+  }
+
+  @Test
+  public void testMaintainerCanNotUnlockWithActiveDeploymentBeforeTimeout() {
+    final User otherUser = new User();
+    otherUser.setId(2L);
+    environment.setLocked(true);
+    environment.setLockedBy(otherUser);
+    environment.setLockedAt(OffsetDateTime.now());
+    HeliosDeployment deployment =
+        createHeliosDeployment(HeliosDeployment.Status.QUEUED, OffsetDateTime.now());
+
+    when(authService.getUserFromGithubId()).thenReturn(user);
+    when(authService.isAtLeastMaintainer()).thenReturn(true);
+    when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+    when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
+        .thenReturn(Optional.of(deployment));
+
+    DeploymentException exception =
+        assertThrows(DeploymentException.class, () -> environmentService.unlockEnvironment(1L));
+
+    assertEquals(
+        "Cancel the ongoing deployment before unlocking this environment.", exception.getMessage());
+    verify(environmentRepository, never()).save(any(Environment.class));
+  }
+
+  @Test
+  public void testMaintainerCanUnlockWithStaleActiveDeployment() {
+    final User otherUser = new User();
+    otherUser.setId(2L);
+    environment.setLocked(true);
+    environment.setLockedBy(otherUser);
+    environment.setLockedAt(OffsetDateTime.now().minusMinutes(30));
+    HeliosDeployment deployment =
+        createHeliosDeployment(
+            HeliosDeployment.Status.WAITING, OffsetDateTime.now().minusMinutes(21));
+
+    when(authService.getUserFromGithubId()).thenReturn(user);
+    when(authService.isAtLeastMaintainer()).thenReturn(true);
+    when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+    when(environmentRepository.save(any(Environment.class))).thenReturn(environment);
+    when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
+        .thenReturn(Optional.of(deployment));
+
+    EnvironmentDto result = environmentService.unlockEnvironment(1L);
+
+    assertNotNull(result);
+    assertFalse(result.locked());
+    assertEquals(HeliosDeployment.Status.UNKNOWN, deployment.getStatus());
+    verify(heliosDeploymentRepository, times(1)).save(deployment);
+    verify(environmentRepository, times(1)).save(any(Environment.class));
+  }
+
+  @Test
+  public void testLockOwnerCanUnlockWithStaleActiveDeployment() {
+    environment.setLocked(true);
+    environment.setLockedBy(user);
+    environment.setLockedAt(OffsetDateTime.now().minusMinutes(30));
+    HeliosDeployment deployment =
+        createHeliosDeployment(
+            HeliosDeployment.Status.IN_PROGRESS, OffsetDateTime.now().minusMinutes(21));
+
+    when(authService.getUserFromGithubId()).thenReturn(user);
+    when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+    when(environmentRepository.save(any(Environment.class))).thenReturn(environment);
+    when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
+        .thenReturn(Optional.of(deployment));
+
+    EnvironmentDto result = environmentService.unlockEnvironment(1L);
+
+    assertNotNull(result);
+    assertFalse(result.locked());
+    assertEquals(HeliosDeployment.Status.UNKNOWN, deployment.getStatus());
+    verify(heliosDeploymentRepository, times(1)).save(deployment);
+    verify(environmentRepository, times(1)).save(any(Environment.class));
+  }
+
+  @Test
+  public void testUnlockEnvironmentWithTerminalDeployments() {
+    for (HeliosDeployment.Status status :
+        List.of(
+            HeliosDeployment.Status.DEPLOYMENT_SUCCESS,
+            HeliosDeployment.Status.FAILED,
+            HeliosDeployment.Status.IO_ERROR,
+            HeliosDeployment.Status.CANCELLED,
+            HeliosDeployment.Status.UNKNOWN)) {
+      environment.setLocked(true);
+      environment.setLockedBy(user);
+      environment.setLockedAt(OffsetDateTime.now());
+      HeliosDeployment deployment = createHeliosDeployment(status, OffsetDateTime.now());
+
+      when(authService.getUserFromGithubId()).thenReturn(user);
+      when(environmentRepository.findById(1L)).thenReturn(Optional.of(environment));
+      when(environmentRepository.save(any(Environment.class))).thenReturn(environment);
+      when(heliosDeploymentRepository.findTopByEnvironmentOrderByCreatedAtDesc(environment))
+          .thenReturn(Optional.of(deployment));
+
+      EnvironmentDto result = environmentService.unlockEnvironment(1L);
+
+      assertNotNull(result);
+      assertFalse(result.locked());
+      assertEquals(status, deployment.getStatus());
+    }
   }
 
   @Test
@@ -590,5 +717,14 @@ public class EnvironmentServiceTest {
     assertEquals(
         EnvironmentDeploymentReadinessDto.WorkflowStatus.MISSING_RUN,
         readiness.workflows().get(0).status());
+  }
+
+  private HeliosDeployment createHeliosDeployment(
+      HeliosDeployment.Status status, OffsetDateTime statusUpdatedAt) {
+    HeliosDeployment deployment = new HeliosDeployment();
+    deployment.setEnvironment(environment);
+    deployment.setStatus(status);
+    deployment.setStatusUpdatedAt(statusUpdatedAt);
+    return deployment;
   }
 }


### PR DESCRIPTION
### Motivation
When an environment has an active Helios deployment (WAITING, QUEUED, or IN_PROGRESS), users could previously try to unlock it prematurely. The server lacked a consistent check, and the frontend did not properly reflect the unlock restrictions. Additionally, stale deployments needed a recovery path for lock owners and maintainers.

Fixes #1001

### Description
- **Server**: Exposed `statusUpdatedAt` through `EnvironmentDto` and the OpenAPI schema. Replaced the original `canUnlock` logic with `validateNoBlockingActiveDeployment()`, which blocks unlock during active (non-stale) deployments. Deployments stale for 20+ minutes are marked as UNKNOWN and unlock is allowed.
- **Client**: Exposed `statusUpdatedAt` in the OpenAPI types. Added computed properties (`canUnlockStaleDeployment`, `activeDeploymentBlocksUnlock`, `canExtendLock`) to the environment actions component, decoupling lock extension from unlock permission. Updated tooltip messages to provide contextual guidance. Added unit tests covering active and stale deployment unlock scenarios.
### Testing Instructions
#### Prerequisites:
- GitHub Account with Developer permissions
- An environment with a Helios deployment capability
#### Flow:
1. Log in to Helios as a Developer
2. Lock an environment and trigger a deployment
3. While the deployment is active (WAITING / QUEUED / IN_PROGRESS), verify the Unlock button is disabled with the tooltip "Cancel the ongoing deployment before unlocking this environment."
4. Verify the Cancel button tooltip shows "Deployment is still starting" when no workflow run URL is available yet
5. Verify the Extend Lock button remains enabled even when Unlock is blocked
6. Wait 20+ minutes after the deployment status was last updated, then verify the Unlock button becomes enabled with the tooltip "Deployment appears stale. You can unlock this environment."
7. As a Maintainer, verify you can unlock an environment locked by another user after the deployment becomes stale
### Checklist
#### General
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.
#### Server
- [x] Code is performant and follows best practices