### PR TITLE
fix: add database index for deployment workflow run ID

### DIFF
--- a/server/application-server/src/main/resources/db/migration/V49__add_helios_deployment_workflow_run_id_index.sql
+++ b/server/application-server/src/main/resources/db/migration/V49__add_helios_deployment_workflow_run_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_hd_workflow_run_id ON helios_deployment(workflow_run_id);


### PR DESCRIPTION
### Motivation
Every `workflow_job` webhook event triggers a `findByWorkflowRunId()` query in `GitHubWorkflowJobTimingService.resolveRelevance()`. The `helios_deployment.workflow_run_id` column had no index — its FK constraint was dropped in V42 without creating a standalone index. This meant every lookup performed a full sequential scan on the `helios_deployment` table. For deployment workflow runs, `resolveRelevance()` re-runs on every `workflow_job` event (the Caffeine cache stores only the classification, not the entities), multiplying the cost per run. As the table grows, this creates a growing bottleneck that blocks all downstream webhook processing.

Fixes #1032 
### Description
- Added a B-tree index on `helios_deployment(workflow_run_id)` via Flyway migration V49
### Testing Instructions
#### Prerequisites:
- Access to the Helios database
- A repository with at least one deployment workflow triggered through Helios
#### Flow:
1. Deploy the migration. Verify it applied cleanly in the `flyway_schema_history` table.
2. Run `EXPLAIN SELECT * FROM helios_deployment WHERE workflow_run_id = <some_id>;` — confirm the plan uses an Index Scan on `idx_hd_workflow_run_id` instead of a Seq Scan.
3. Trigger a deployment and observe that workflow_job webhooks are processed without delays. Monitor NATS consumer message backlog and ensure it drains quickly.
### Checklist
#### General
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.
#### Server
- [x] Code is performant and follows best practices.