### PR TITLE
fix: add database index for deployment workflow run ID

### DIFF
--- a/server/application-server/src/main/resources/db/migration/V49__add_helios_deployment_workflow_run_id_index.sql
+++ b/server/application-server/src/main/resources/db/migration/V49__add_helios_deployment_workflow_run_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_hd_workflow_run_id ON helios_deployment(workflow_run_id);


### PR DESCRIPTION
## Summary

Adds the database migration that creates an index on `helios_deployment.workflow_run_id`.

## Why

This isolates the staging-tested index update for release without merging the rest of `staging` into `main`.

## Validation

- Cherry-picked only `b3cb8dd3` from `staging` onto `origin/main`
- Verified the PR branch differs from `origin/main` by one file: `V49__add_helios_deployment_workflow_run_id_index.sql`
- Ran `git diff --check origin/main..HEAD`
- Confirmed `origin/main` currently has migrations through `V48`, so this `V49` migration version is available