### PR TITLE
perf: fetch deployment workflows directly

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRepository.java
@@ -4,6 +4,8 @@ import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.workflow.Workflow.Label;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,4 +20,12 @@ public interface WorkflowRepository extends JpaRepository<Workflow, Long> {
 
   Workflow findFirstByLabelAndRepositoryRepositoryIdOrderByCreatedAtDesc(
       Label label, Long repositoryId);
+
+  @Query(
+      "SELECT DISTINCT e.deploymentWorkflow FROM Environment e "
+          + "WHERE e.enabled = true "
+          + "AND e.repository.repositoryId = :repositoryId "
+          + "AND e.deploymentWorkflow IS NOT NULL")
+  List<Workflow> findDeploymentWorkflowsForEnabledEnvironmentsByRepositoryId(
+      @Param("repositoryId") Long repositoryId);
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowService.java
@@ -1,6 +1,5 @@
 package de.tum.cit.aet.helios.workflow;
 
-import de.tum.cit.aet.helios.environment.EnvironmentService;
 import jakarta.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class WorkflowService {
   private final WorkflowRepository workflowRepository;
-  private final EnvironmentService environmentService;
 
   public Optional<WorkflowDto> getWorkflowById(Long id) {
     return workflowRepository.findById(id).map(WorkflowDto::fromWorkflow);
@@ -49,15 +47,8 @@ public class WorkflowService {
   }
 
   public List<Workflow> getDeploymentWorkflowsForAllEnv(Long repositoryId) {
-    return environmentService.getAllEnabledEnvironments().stream()
-        .filter(env -> env.repository().id().equals(repositoryId))
-        .filter(env -> env.deploymentWorkflow() != null)
-        .map(env -> env.deploymentWorkflow().id())
-        .distinct()
-        .map(workflowId -> workflowRepository.findById(workflowId))
-        .filter(Optional::isPresent)
-        .map(Optional::get)
-        .collect(Collectors.toList());
+    return workflowRepository.findDeploymentWorkflowsForEnabledEnvironmentsByRepositoryId(
+        repositoryId);
   }
 
   public List<Workflow> getTestWorkflows(Long repositoryId) {


### PR DESCRIPTION
## Summary
- Fetch deployment workflows for enabled environments directly from the workflow repository
- Avoid building environment DTOs and computing deployment duration estimates during workflow run processing

## Verification
- `cd server && JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :application-server:compileJava`