### PR TITLE
fix(deployment): track source branch separately from workflow branch

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/ActivityHistoryDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/ActivityHistoryDto.java
@@ -31,7 +31,9 @@ public record ActivityHistoryDto(
         heliosDeployment.getEnvironment().getName(),
         HeliosDeployment.mapHeliosStatusToDeploymentState(heliosDeployment.getStatus()),
         heliosDeployment.getSha(),
-        heliosDeployment.getBranchName(),
+        heliosDeployment.getSourceBranchName() != null
+            ? heliosDeployment.getSourceBranchName()
+            : heliosDeployment.getBranchName(),
         UserInfoDto.fromUser(heliosDeployment.getCreator()),
         null,
         heliosDeployment.getCreatedAt(),

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/DeploymentService.java
@@ -153,6 +153,7 @@ public class DeploymentService {
     heliosDeployment.setUser(authService.getUserId());
     heliosDeployment.setStatus(HeliosDeployment.Status.WAITING);
     heliosDeployment.setBranchName(this.getDeploymentWorkflowBranch(environment, deployRequest));
+    heliosDeployment.setSourceBranchName(deployRequest.branchName());
     heliosDeployment.setSha(deployRequest.commitSha());
     heliosDeployment.setCreator(authService.getUserFromGithubId());
     heliosDeployment.setPullRequest(optionalPullRequest.orElse(null));
@@ -401,8 +402,7 @@ public class DeploymentService {
 
     List<ActivityHistoryDto> heliosDeploymentDtos =
         heliosDeploymentRepository
-            .findByRepositoryIdAndBranchNameAndDeploymentIdIsNullOrderByCreatedAtDesc(
-                repositoryId, branchName)
+            .findByRepositoryIdAndSourceBranchNameOrderByCreatedAtDesc(repositoryId, branchName)
             .stream()
             .map(ActivityHistoryDto::fromHeliosDeployment)
             .toList();

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnion.java
@@ -171,20 +171,22 @@ public class LatestDeploymentUnion {
   }
 
   public String getSha() {
-    if (isRealDeployment()) {
-      return realDeployment.getSha();
-    } else if (isHeliosDeployment()) {
+    if (hasMatchingSourceHeliosDeployment() && heliosDeployment.getSha() != null) {
       return heliosDeployment.getSha();
+    } else if (isRealDeployment()) {
+      return realDeployment.getSha();
     } else {
       return null;
     }
   }
 
   public String getRef() {
-    if (isRealDeployment()) {
+    if (hasMatchingSourceHeliosDeployment()) {
+      return heliosDeployment.getSourceBranchName() != null
+          ? heliosDeployment.getSourceBranchName()
+          : heliosDeployment.getBranchName();
+    } else if (isRealDeployment()) {
       return realDeployment.getRef();
-    } else if (isHeliosDeployment()) {
-      return heliosDeployment.getBranchName();
     } else {
       return null;
     }
@@ -252,6 +254,10 @@ public class LatestDeploymentUnion {
   }
 
   private boolean hasTimingHeliosDeployment() {
+    return hasMatchingHeliosDeployment();
+  }
+
+  private boolean hasMatchingHeliosDeployment() {
     if (isHeliosDeployment()) {
       return true;
     }
@@ -263,13 +269,11 @@ public class LatestDeploymentUnion {
   }
 
   public String getPullRequestName() {
-    if (isRealDeployment()) {
+    if (hasMatchingSourceHeliosDeployment() && heliosDeployment.getPullRequest() != null) {
+      return heliosDeployment.getPullRequest().getTitle();
+    } else if (isRealDeployment()) {
       return realDeployment.getPullRequest() != null
           ? realDeployment.getPullRequest().getTitle()
-          : null;
-    } else if (isHeliosDeployment()) {
-      return heliosDeployment.getPullRequest() != null
-          ? heliosDeployment.getPullRequest().getTitle()
           : null;
     } else {
       return null;
@@ -277,13 +281,11 @@ public class LatestDeploymentUnion {
   }
 
   public Integer getPullRequestNumber() {
-    if (isRealDeployment()) {
+    if (hasMatchingSourceHeliosDeployment() && heliosDeployment.getPullRequest() != null) {
+      return heliosDeployment.getPullRequest().getNumber();
+    } else if (isRealDeployment()) {
       return realDeployment.getPullRequest() != null
           ? realDeployment.getPullRequest().getNumber()
-          : null;
-    } else if (isHeliosDeployment()) {
-      return heliosDeployment.getPullRequest() != null
-          ? heliosDeployment.getPullRequest().getNumber()
           : null;
     } else {
       return null;
@@ -292,6 +294,17 @@ public class LatestDeploymentUnion {
 
   public boolean isNone() {
     return !isRealDeployment() && !isHeliosDeployment();
+  }
+
+  private boolean hasMatchingSourceHeliosDeployment() {
+    if (isHeliosDeployment()) {
+      return true;
+    }
+    if (!isRealDeployment() || !hasHeliosDeployment()) {
+      return false;
+    }
+    return heliosDeployment.getDeploymentId() != null
+        && heliosDeployment.getDeploymentId().equals(realDeployment.getId());
   }
 
   public DeploymentType getType() {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeployment.java
@@ -56,6 +56,9 @@ public class HeliosDeployment {
   @Column(name = "branch_name")
   private String branchName;
 
+  @Column(name = "source_branch_name")
+  private String sourceBranchName;
+
   @Column(name = "build_tag")
   private String buildTag;
 

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/heliosdeployment/HeliosDeploymentRepository.java
@@ -46,6 +46,18 @@ public interface HeliosDeploymentRepository extends JpaRepository<HeliosDeployme
   List<HeliosDeployment> findByRepositoryIdAndBranchNameAndDeploymentIdIsNullOrderByCreatedAtDesc(
       @Param("repositoryId") Long repositoryId, @Param("branchName") String branchName);
 
+  @Query(
+      "SELECT hd FROM HeliosDeployment hd "
+          + "JOIN hd.environment e "
+          + "JOIN e.repository r "
+          + "WHERE r.repositoryId = :repositoryId "
+          + "AND hd.sourceBranchName = :sourceBranchName "
+          + "AND (hd.deploymentId IS NULL OR hd.branchName <> hd.sourceBranchName) "
+          + "ORDER BY hd.createdAt DESC")
+  List<HeliosDeployment> findByRepositoryIdAndSourceBranchNameOrderByCreatedAtDesc(
+      @Param("repositoryId") Long repositoryId,
+      @Param("sourceBranchName") String sourceBranchName);
+
   Optional<HeliosDeployment> findByDeploymentId(Long deploymentId);
 
   Optional<HeliosDeployment> findByWorkflowRunId(Long workflowRunId);

--- a/server/application-server/src/main/resources/db/migration/V51__add_source_branch_to_helios_deployment.sql
+++ b/server/application-server/src/main/resources/db/migration/V51__add_source_branch_to_helios_deployment.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.helios_deployment
+    ADD COLUMN source_branch_name VARCHAR(255);
+
+UPDATE public.helios_deployment
+SET source_branch_name = COALESCE(workflow_params ->> 'branch_name', branch_name)
+WHERE source_branch_name IS NULL;

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/DeploymentServiceTest.java
@@ -214,14 +214,15 @@ public class DeploymentServiceTest {
   }
 
   @Test
-  public void testDeployToEnvironment() {
-    final DeployRequest deployRequest = new DeployRequest(1L, "main", "sha");
+  public void testDeployToEnvironment() throws Exception {
+    final DeployRequest deployRequest = new DeployRequest(1L, "feature/x", "sha");
 
     Workflow wf = new Workflow();
     wf.setId(1L);
     wf.setFileNameWithExtension("deploy.yml");
 
     environment.setDeploymentWorkflow(wf);
+    environment.setDeploymentWorkflowBranch("staging");
 
     when(environmentService.getEnvironmentTypeById(1L))
         .thenReturn(Optional.of(Environment.Type.PRODUCTION));
@@ -230,6 +231,15 @@ public class DeploymentServiceTest {
     when(heliosDeploymentRepository.saveAndFlush(any())).thenAnswer(a -> a.getArgument(0));
 
     deploymentService.deployToEnvironment(deployRequest);
+
+    ArgumentCaptor<HeliosDeployment> deploymentCaptor =
+        ArgumentCaptor.forClass(HeliosDeployment.class);
+    verify(heliosDeploymentRepository).saveAndFlush(deploymentCaptor.capture());
+    HeliosDeployment capturedDeployment = deploymentCaptor.getValue();
+    assertEquals("staging", capturedDeployment.getBranchName());
+    assertEquals("feature/x", capturedDeployment.getSourceBranchName());
+    verify(gitHubService)
+        .dispatchWorkflow(eq("owner/repo"), eq("deploy.yml"), eq("staging"), any());
   }
 
   @Test
@@ -379,8 +389,7 @@ public class DeploymentServiceTest {
         .findByRepositoryRepositoryIdAndRefOrderByCreatedAtDesc(repositoryId, branchName))
         .thenReturn(List.of(deployment));
     when(heliosDeploymentRepository
-        .findByRepositoryIdAndBranchNameAndDeploymentIdIsNullOrderByCreatedAtDesc(
-            repositoryId, branchName))
+        .findByRepositoryIdAndSourceBranchNameOrderByCreatedAtDesc(repositoryId, branchName))
         .thenReturn(List.of(heliosDeployment));
 
     List<ActivityHistoryDto> result =
@@ -391,6 +400,36 @@ public class DeploymentServiceTest {
 
     assertEquals(2, result.size());
     Assertions.assertIterableEquals(List.of(heliosDto, deploymentDto), result);
+  }
+
+  @Test
+  public void testGetActivityHistoryByRepositoryIdAndSourceBranchNameForLinkedDeployment() {
+    final OffsetDateTime now = OffsetDateTime.now();
+    final Long repositoryId = 1L;
+    final String sourceBranchName = "feature/x";
+
+    heliosDeployment.setCreatedAt(now.minusMinutes(1));
+    heliosDeployment.setEnvironment(environment);
+    heliosDeployment.setDeploymentId(1L);
+    heliosDeployment.setBranchName("staging");
+    heliosDeployment.setSourceBranchName(sourceBranchName);
+    deployment.setCreatedAt(now.minusMinutes(2));
+    deployment.setRef("staging");
+
+    when(deploymentRepository
+        .findByRepositoryRepositoryIdAndRefOrderByCreatedAtDesc(repositoryId, sourceBranchName))
+        .thenReturn(List.of());
+    when(heliosDeploymentRepository
+        .findByRepositoryIdAndSourceBranchNameOrderByCreatedAtDesc(
+            repositoryId, sourceBranchName))
+        .thenReturn(List.of(heliosDeployment));
+
+    List<ActivityHistoryDto> result =
+        deploymentService.getActivityHistoryByRepositoryIdAndBranchName(
+            repositoryId, sourceBranchName);
+
+    assertEquals(1, result.size());
+    assertEquals(sourceBranchName, result.getFirst().ref());
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/deployment/LatestDeploymentUnionTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import de.tum.cit.aet.helios.heliosdeployment.HeliosDeployment;
+import de.tum.cit.aet.helios.pullrequest.PullRequest;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 
@@ -79,10 +80,80 @@ class LatestDeploymentUnionTest {
     assertEquals(WORKFLOW_STARTED_AT, union.getWorkflowStartedAt());
   }
 
+  @Test
+  void realDeploymentFallbackWithoutDeploymentIdDoesNotOverrideSourceFields() {
+    Deployment deployment = deployment(1L);
+    deployment.setRef("staging");
+    deployment.setSha("workflow-sha");
+
+    HeliosDeployment heliosDeployment = heliosDeployment(null);
+    heliosDeployment.setSourceBranchName("feature/source");
+    heliosDeployment.setSha("source-sha");
+
+    LatestDeploymentUnion union = LatestDeploymentUnion.realDeployment(deployment,
+        heliosDeployment);
+
+    assertEquals("staging", union.getRef());
+    assertEquals("workflow-sha", union.getSha());
+  }
+
+  @Test
+  void heliosDeploymentExposesSourceBranchAndSha() {
+    HeliosDeployment heliosDeployment = heliosDeployment(null);
+    heliosDeployment.setBranchName("staging");
+    heliosDeployment.setSourceBranchName("feature/source");
+    heliosDeployment.setSha("source-sha");
+
+    LatestDeploymentUnion union = LatestDeploymentUnion.heliosDeployment(heliosDeployment);
+
+    assertEquals("feature/source", union.getRef());
+    assertEquals("source-sha", union.getSha());
+  }
+
+  @Test
+  void realDeploymentWithMatchingHeliosFallbackExposesSourceBranchPrAndSha() {
+    Deployment deployment = deployment(1L);
+    deployment.setRef("staging");
+    deployment.setSha("workflow-sha");
+
+    HeliosDeployment heliosDeployment = heliosDeployment(1L);
+    heliosDeployment.setBranchName("staging");
+    heliosDeployment.setSourceBranchName("feature/source");
+    heliosDeployment.setSha("source-sha");
+    heliosDeployment.setPullRequest(pullRequest(42, "Source PR"));
+
+    LatestDeploymentUnion union = LatestDeploymentUnion.realDeployment(deployment,
+        heliosDeployment);
+
+    assertEquals("feature/source", union.getRef());
+    assertEquals("source-sha", union.getSha());
+    assertEquals("Source PR", union.getPullRequestName());
+    assertEquals(42, union.getPullRequestNumber());
+  }
+
+  @Test
+  void realDeploymentWithoutHeliosFallbackExposesGitHubRefAndSha() {
+    Deployment deployment = deployment(1L);
+    deployment.setRef("staging");
+    deployment.setSha("workflow-sha");
+
+    LatestDeploymentUnion union = LatestDeploymentUnion.realDeployment(deployment);
+
+    assertEquals("staging", union.getRef());
+    assertEquals("workflow-sha", union.getSha());
+  }
+
   private Deployment deployment(Long id) {
     Deployment deployment = new Deployment();
     deployment.setId(id);
     return deployment;
+  }
+
+  private PullRequest pullRequest(int number, String title) {
+    PullRequest pullRequest = new PullRequest();
+    pullRequest.setNumber(number);
+    pullRequest.setTitle(title);
+    return pullRequest;
   }
 
   private HeliosDeployment heliosDeployment(Long deploymentId) {


### PR DESCRIPTION
### Motivation
When a deployment workflow is configured to run from a fixed branch (e.g. `staging`) but the user selects a different source branch/PR to deploy, Helios stored only the workflow branch on the `HeliosDeployment`. As a result, the activity history was keyed on the workflow branch instead of the branch the user actually picked, and the latest deployment card surfaced the workflow branch's ref/SHA/PR rather than the deployed source's. This made it look like PRs were missing from their branch's deployment history and showed the wrong PR name/ref on environments.

### Description
- Adds a `source_branch_name` column to `helios_deployment` (Flyway `V51`) and backfills it from `workflow_params.branch_name`, falling back to `branch_name`.
- Persists the user-selected branch as `sourceBranchName` on `HeliosDeployment` when creating a deployment, while keeping `branchName` as the workflow branch.
- Switches activity-history lookup to `findByRepositoryIdAndSourceBranchNameOrderByCreatedAtDesc`, so deployments are grouped under the branch the user actually deployed (including helios deployments already linked to a real GitHub deployment when the workflow branch differs).
- Updates `LatestDeploymentUnion` to prefer the matched helios deployment's source branch, SHA, PR name and PR number when a real GitHub deployment is linked to a helios deployment, so the UI surfaces the deployed source rather than the workflow branch.
- `ActivityHistoryDto.fromHeliosDeployment` now reports `sourceBranchName` (with fallback to `branchName`).
- Adds unit tests for `DeploymentService` (capturing both branch fields on create, and source-branch-based activity history) and `LatestDeploymentUnion` (matched/unmatched fallback behavior for ref/SHA/PR).

### Testing Instructions
#### Prerequisites:
- A Helios environment whose deployment workflow runs from a fixed branch (e.g. `staging`) different from the branch you want to deploy.
- A PR open on a feature branch (e.g. `feature/x`) targeting that environment.

#### Flow:
1. Log in to Helios as a Developer.
2. Open an environment configured to deploy from `staging`.
3. Trigger a deployment selecting `feature/x` (or the PR) as the source.
4. Once the deployment completes, open the environment card and verify:
   - The latest deployment shows `feature/x` as the ref and the source PR's title/number, not `staging`.
   - The SHA shown matches the source commit.
5. Open the activity history for `feature/x` and verify the deployment appears there (previously it would only appear under `staging`).
6. Run an in-place deploy where source branch == workflow branch (`staging` → `staging`) and confirm nothing regresses: the deployment still shows up under `staging` history with the correct ref/SHA/PR.
7. Verify older deployments created before this PR still render correctly thanks to the `V51` backfill.

### Checklist
#### General
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices
