### PR TITLE
chore: standardize on Node 24.15.0 across all images

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Angular app
-FROM node:24 AS build
+FROM node:24.15.0 AS build
 
 # Set the working directory
 WORKDIR /app

--- a/client/Dockerfile.dev
+++ b/client/Dockerfile.dev
@@ -1,11 +1,12 @@
-FROM alpine:3.23
+# Node pinned to 24.15.0 to match client/.nvmrc and the production Dockerfile.
+FROM node:24.15.0-alpine
 
 # Create app directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-# Install app dependencies and pnpm (pinned to the repo's package manager)
-RUN apk add --no-cache git nodejs npm && npm install -g pnpm@11.2.2
+# node:alpine already ships node + npm; add git, then pnpm (pinned to the repo's package manager)
+RUN apk add --no-cache git && npm install -g pnpm@11.2.2
 
 # Copy manifest, lockfile, and pnpm settings, then install
 COPY package.json pnpm-lock.yaml .npmrc pnpm-workspace.yaml /usr/src/app/

--- a/keycloakify/Dockerfile
+++ b/keycloakify/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Angular app
-FROM node:24 AS build
+FROM node:24.15.0 AS build
 
 # Set the working directory
 WORKDIR /app

--- a/keycloakify/package.json
+++ b/keycloakify/package.json
@@ -59,7 +59,7 @@
     "vite": "7.3.2"
   },
   "engines": {
-    "node": "^18.0.0 || >=20.0.0"
+    "node": ">=24.0.0"
   },
   "packageManager": "pnpm@11.2.2"
 }


### PR DESCRIPTION
## Summary

Makes the Node version **uniform and exact-pinned** everywhere, matching `client/.nvmrc` (`24.15.0`), which already drives all CI via `node-version-file`. The repo was already on Node 24 everywhere, but versions had drifted (24.15.0 vs floating `node:24` vs Alpine's 24.14.1) and the keycloakify `engines` range still allowed Node 18/20.

| Source | Before | After |
|---|---|---|
| `client/Dockerfile` | `node:24` | `node:24.15.0` |
| `keycloakify/Dockerfile` | `node:24` | `node:24.15.0` |
| `client/Dockerfile.dev` | `alpine:3.23` + `apk add nodejs npm` (drifting; was 24.14.1) | `node:24.15.0-alpine` |
| `keycloakify` `engines.node` | `^18.0.0 \|\| >=20.0.0` | `>=24.0.0` |

`client/.nvmrc` and all GitHub Actions workflows were already on `24.15.0` — no change needed there.

### Notes
- The dev image now uses the official `node:alpine` base (ships node + npm), so only `git` is installed via `apk` before pnpm.
- `engines` uses `>=24.0.0` rather than an exact pin: pinning a runtime-compat declaration to one patch would wrongly reject valid 24.x runtimes.

### Verification
- ✅ Built `client/Dockerfile.dev`: image runs **Node v24.15.0**, pnpm 11.2.2, and `pnpm install --frozen-lockfile` succeeds.
- The other two are same-family base-image patch bumps (`node:24` → `node:24.15.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)