### PR TITLE
fix(security): resolve 5 CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/deployment-helios-fail-deployment.yml
+++ b/.github/workflows/deployment-helios-fail-deployment.yml
@@ -19,6 +19,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 concurrency: ${{ github.event.inputs.environment_name }}
 
 env:

--- a/.github/workflows/deployment-helios-fail-pre-deployment.yml
+++ b/.github/workflows/deployment-helios-fail-pre-deployment.yml
@@ -19,6 +19,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 concurrency: ${{ github.event.inputs.environment_name }}
 
 env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,14 +37,14 @@ jobs:
           uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
           with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-            coverage-reports: client/coverage/lcov.info
+            coverage-reports: client/coverage/client/lcov.info
           if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
         - name: Upload Client Test Coverage Report
           if: success() || failure()
           uses: actions/upload-artifact@v7
           with:
               name: Coverage Report Client Tests
-              path: client/coverage/lcov-report
+              path: client/coverage/client/lcov-report
     server-tests:
         runs-on: ubuntu-latest
         timeout-minutes: 60

--- a/server/notification/src/main/java/de/tum/cit/aet/notification/service/EmailTemplateService.java
+++ b/server/notification/src/main/java/de/tum/cit/aet/notification/service/EmailTemplateService.java
@@ -88,6 +88,14 @@ public class EmailTemplateService {
    * @return the template content
    */
   private String getTemplateContent(String templateName) {
+    // Reject anything but a plain template name before it reaches the classpath
+    // lookup below. templateName can originate from a request path variable
+    // (see EmailTestController), so allowing '/', '\\' or '..' would permit
+    // path traversal to other classpath resources.
+    if (templateName == null || !templateName.matches("[A-Za-z0-9_-]+")) {
+      throw new IllegalArgumentException("Invalid email template name: " + templateName);
+    }
+
     // Check if template is in cache
     if (templateCache.containsKey(templateName)) {
       return templateCache.get(templateName);


### PR DESCRIPTION
## Summary

Clears all 5 open alerts on [code scanning](https://github.com/ls1intum/Helios/security/code-scanning). These are **current** findings (CodeQL re-scanned `staging` on 2026-05-27 after default setup was re-enabled), not stale.

### #36 — HIGH · `java/path-injection` (real)
`EmailTestController` exposes `POST /api/test/email-templates/{templateName}` and the `@PathVariable templateName` flowed **unsanitized** into:
```java
resourceLoader.getResource("classpath:email-templates/" + templateName + ".html");
```
The controller has no `@Profile` / auth annotation, so an attacker reaching `/api/test/**` could pass `../` to traverse to other classpath resources. **Fix:** validate `templateName` against `[A-Za-z0-9_-]+` before the lookup. All real template names (`welcome`, `lock-expired`, `lock-released`, `deployment-failure`) satisfy it.

> Follow-up worth considering separately: whether `/api/test/**` on the notification service should be exposed/secured at all.

### #32–#35 — MEDIUM · `actions/missing-workflow-permissions`
Two mock-deployment workflows added after the earlier permissions cleanup lacked a `permissions:` block:
- `.github/workflows/deployment-helios-fail-deployment.yml`
- `.github/workflows/deployment-helios-fail-pre-deployment.yml`

**Fix:** added top-level `permissions: contents: read` (they make no GitHub API writes), matching `deployment-helios.yml`.

### Verification
- ✅ `./gradlew :notification:compileJava` passes.
- The alerts auto-resolve once CodeQL re-scans `staging` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)