### PR TITLE
feat(cleanup): confirm orphan-branch runs against GitHub before deleting

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/WorkflowRunRepository.java
@@ -298,23 +298,57 @@ public interface WorkflowRunRepository
                         @Param("tps") String testProcessingStatus);
 
   /**
-   * IDs (up to {@code limit}) of workflow runs whose {@code head_branch} no
-   * longer exists in the {@code branch} table for the same repository,
-   * older than the grace window, and not referenced by any deployment row.
+   * Distinct repository ids that currently have at least one orphan-branch
+   * candidate (see {@link #findOrphanBranchRunCandidatesForRepo}). The caller
+   * iterates these so it can fetch each repo's live branch set from GitHub once
+   * and confirm candidates against it.
    *
-   * <p>Used to preview which runs the orphan-branch sweep would remove in
-   * dry-run mode. The matching batched {@code DELETE} query lives in
-   * {@link #purgeOrphanBranchRunsBatch(int, int)}.
-   *
-   * <p>Runs with a {@code NULL head_branch} (tag pushes, scheduled and
-   * {@code workflow_dispatch} runs) are excluded — they have no branch
-   * identity to compare against and the keep-N policy in
-   * {@link #purgeObsoleteRuns} already handles their retention.
+   * <p>Runs with a {@code NULL repository_id} are excluded — their branch can't
+   * be confirmed against any GitHub repo, so they are never swept.
    */
   @Query(value = """
-      SELECT wr.id
+      SELECT DISTINCT wr.repository_id
       FROM workflow_run wr
       WHERE wr.created_at < now() - (:graceDays * interval '1 day')
+        AND wr.head_branch IS NOT NULL
+        AND wr.repository_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM branch b
+          WHERE b.repository_id = wr.repository_id
+            AND b.name          = wr.head_branch
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM helios_deployment hd
+          WHERE hd.workflow_run_id = wr.id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM deployment d
+          WHERE d.workflow_run_id = wr.id
+        )
+      """, nativeQuery = true)
+  List<Long> findRepositoriesWithOrphanCandidates(@Param("graceDays") int graceDays);
+
+  /**
+   * Candidate orphan-branch runs (up to {@code limit}) for a single repository:
+   * runs whose {@code head_branch} is absent from the {@code branch} table,
+   * older than the grace window, and not referenced by a {@code deployment} or
+   * {@code helios_deployment} row.
+   *
+   * <p>These are <em>candidates</em>, not confirmed deletions. The caller
+   * re-checks each candidate's {@code headBranch} against GitHub's live branch
+   * list before deleting, so a branch that merely went missing from our local
+   * {@code branch} table (a sync gap) is healed via a targeted re-sync instead
+   * of being swept.
+   *
+   * <p>Runs with a {@code NULL head_branch} are excluded — they have no branch
+   * identity; the keep-N policy in {@link #purgeObsoleteRuns} handles them.
+   */
+  @Query(value = """
+      SELECT wr.id          AS "id",
+             wr.head_branch AS "headBranch"
+      FROM workflow_run wr
+      WHERE wr.repository_id = :repositoryId
+        AND wr.created_at < now() - (:graceDays * interval '1 day')
         AND wr.head_branch IS NOT NULL
         AND NOT EXISTS (
           SELECT 1 FROM branch b
@@ -331,22 +365,23 @@ public interface WorkflowRunRepository
         )
       LIMIT :limit
       """, nativeQuery = true)
-  List<Long> previewOrphanBranchRunIds(@Param("graceDays") int graceDays,
-                                       @Param("limit") int limit);
+  List<OrphanBranchRunCandidate> findOrphanBranchRunCandidatesForRepo(
+      @Param("repositoryId") long repositoryId,
+      @Param("graceDays") int graceDays,
+      @Param("limit") int limit);
 
   /**
-   * Total number of workflow runs the orphan-branch sweep would delete for the
-   * given grace window. Uses the exact same predicate as
-   * {@link #previewOrphanBranchRunIds(int, int)} and
-   * {@link #purgeOrphanBranchRunsBatch(int, int)} but without a {@code LIMIT},
-   * so dry-run mode can report the true backlog size rather than a single
-   * batch's worth.
+   * Total number of workflow runs the orphan-branch sweep would consider for the
+   * given grace window, <em>before</em> the per-run GitHub confirmation. Same
+   * predicate as {@link #findOrphanBranchRunCandidatesForRepo} (minus the
+   * per-repo filter / limit), so dry-run mode can log the backlog size.
    */
   @Query(value = """
       SELECT count(*)
       FROM workflow_run wr
       WHERE wr.created_at < now() - (:graceDays * interval '1 day')
         AND wr.head_branch IS NOT NULL
+        AND wr.repository_id IS NOT NULL
         AND NOT EXISTS (
           SELECT 1 FROM branch b
           WHERE b.repository_id = wr.repository_id
@@ -364,55 +399,12 @@ public interface WorkflowRunRepository
   long countOrphanBranchRunIds(@Param("graceDays") int graceDays);
 
   /**
-   * Deletes up to {@code batchSize} workflow runs whose {@code head_branch}
-   * no longer exists in the {@code branch} table, are older than the grace
-   * window, and are not referenced by any deployment. Cascades through
-   * {@code test_suite}, {@code test_case}, {@code test_failure_analysis},
-   * {@code workflow_run_pull_requests}, and {@code issue_workflow_runs}
-   * via existing FK constraints.
-   *
-   * <p>Bounded by {@code batchSize} so the caller can loop and split the
-   * work into multiple short transactions; this avoids long-held locks and
-   * unbounded WAL growth on a backlog that may exceed tens of thousands of
-   * rows.
-   *
-   * <p>Note: {@code helios_deployment.workflow_run_id} was intentionally
-   * de-FK'd in {@code V42} because that column is populated at dispatch
-   * time, before the workflow_run row arrives via webhook sync. The
-   * {@code NOT EXISTS} guard here remains correct because the orphan sweep
-   * only targets workflow_runs that already exist and are older than the
-   * grace window.
-   *
-   * @return number of {@code workflow_run} rows deleted in this batch (not
-   *     including cascaded child rows). Callers loop until the return is
-   *     less than {@code batchSize}.
+   * Lightweight projection of an orphan-branch sweep candidate: the run id (to
+   * delete by) and its head branch (to confirm against GitHub).
    */
-  @Modifying
-  @Transactional
-  @Query(value = """
-      DELETE FROM workflow_run
-      WHERE id IN (
-        SELECT wr.id
-        FROM workflow_run wr
-        WHERE wr.created_at < now() - (:graceDays * interval '1 day')
-          AND wr.head_branch IS NOT NULL
-          AND NOT EXISTS (
-            SELECT 1 FROM branch b
-            WHERE b.repository_id = wr.repository_id
-              AND b.name          = wr.head_branch
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM helios_deployment hd
-            WHERE hd.workflow_run_id = wr.id
-          )
-          AND NOT EXISTS (
-            SELECT 1 FROM deployment d
-            WHERE d.workflow_run_id = wr.id
-          )
-        LIMIT :batchSize
-      )
-      """, nativeQuery = true)
-  int purgeOrphanBranchRunsBatch(@Param("graceDays") int graceDays,
-                                 @Param("batchSize") int batchSize);
+  interface OrphanBranchRunCandidate {
+    Long getId();
 
+    String getHeadBranch();
+  }
 }

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunCleanupTask.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunCleanupTask.java
@@ -1,9 +1,20 @@
 package de.tum.cit.aet.helios.workflow.cleanup;
 
+import de.tum.cit.aet.helios.branch.github.GitHubBranchSyncService;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHRepository;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -24,6 +35,9 @@ public class WorkflowRunCleanupTask {
 
   private final WorkflowRunRepository repo;
   private final WorkflowRunCleanupProps props;
+  private final GitHubService gitHubService;
+  private final GitHubBranchSyncService branchSyncService;
+  private final GitRepoRepository gitRepoRepository;
 
   /**
    * This method is called when the application is ready. It logs the current mode of operation
@@ -96,27 +110,30 @@ public class WorkflowRunCleanupTask {
 
 
   /**
-   * Sweeps workflow runs whose {@code head_branch} no longer exists in the
-   * {@code branch} table — typically feature branches deleted after a PR
-   * merged. The keep-N policy in {@link #purge()} cannot detect these,
-   * so they would otherwise accumulate indefinitely.
+   * Sweeps workflow runs whose {@code head_branch} no longer exists — typically
+   * feature branches deleted after a PR merged. The keep-N policy in
+   * {@link #purge()} cannot detect these, so they would otherwise accumulate.
    *
-   * <p>Runs daily at 03:30, after the test-failure cleanup at 03:00 and
-   * well clear of the keep-N sweep at 01:00 — this avoids two concurrent
-   * DELETEs against {@code workflow_run} on the scheduler's shared
-   * thread pool. Honours the same {@link WorkflowRunCleanupProps#isDryRun()}
-   * flag. Runs younger than {@code graceDays} are skipped to avoid races
-   * with branch-sync state. Runs with a {@code NULL head_branch} (tag
-   * pushes, scheduled, {@code workflow_dispatch}) are skipped because they
-   * have no branch identity. Runs still referenced by a
-   * {@code helios_deployment} or {@code deployment} row are skipped to
-   * preserve the deployment → build audit link.
+   * <p>Runs daily at 03:30, well clear of the keep-N sweep at 01:00. Honours the
+   * same {@link WorkflowRunCleanupProps#isDryRun()} flag. Runs younger than
+   * {@code graceDays}, with a {@code NULL head_branch} (tag/scheduled/dispatch),
+   * with a {@code NULL repository_id}, or still referenced by a
+   * {@code helios_deployment}/{@code deployment} row are never swept.
    *
-   * <p>Deletes in batches of {@link WorkflowRunCleanupProps.OrphanBranches#getBatchSize()}
-   * so a multi-tens-of-thousands backlog doesn't run as one transaction
-   * that would hold locks and grow WAL for tens of minutes. Each batch is
-   * its own short transaction (opened by the {@code @Modifying} repository
-   * method); the outer loop is intentionally non-transactional.
+   * <p><b>GitHub confirmation:</b> the DB only yields <em>candidates</em>
+   * (branches absent from our local {@code branch} table). Before deleting, each
+   * candidate's branch is confirmed against GitHub's live branch list for that
+   * repo (one cheap listing per repo). If the branch still exists on GitHub, the
+   * run is <em>not</em> deleted — instead the branch is re-synced (a targeted
+   * single-branch sync) to heal the local table, since its absence was a sync
+   * gap rather than a real deletion. This guarantees a run is only deleted once
+   * GitHub itself confirms its branch is gone. If GitHub can't be reached for a
+   * repo, that repo is skipped for the run (fail-safe: nothing deleted).
+   *
+   * <p>Confirmed orphans are deleted by id in batches of
+   * {@link WorkflowRunCleanupProps.OrphanBranches#getBatchSize()} (cascading to
+   * {@code test_suite}/{@code test_case}/junction rows via FK constraints); each
+   * batch is its own short transaction and the outer loop is non-transactional.
    */
   @Scheduled(cron = "${cleanup.workflow-run.orphan-branches.cron:0 30 3 * * *}")
   public void purgeOrphanBranchRuns() {
@@ -136,27 +153,138 @@ public class WorkflowRunCleanupTask {
       return;
     }
 
-    log.info("Orphan-branch cleanup started (graceDays={}, batchSize={}, dryRun={}).",
-        graceDays, batchSize, props.isDryRun());
-
-    int totalDeleted = 0;
     if (props.isDryRun()) {
       long total = repo.countOrphanBranchRunIds(graceDays);
-      List<Long> sample = repo.previewOrphanBranchRunIds(graceDays, batchSize);
       log.info(
-          "DRY-RUN: Orphan-branch cleanup graceDays={}  →  {} rows would be deleted "
-              + "(showing first {} id(s): {}).",
-          graceDays, total, sample.size(), sample);
-    } else {
-      while (true) {
-        int deleted = repo.purgeOrphanBranchRunsBatch(graceDays, batchSize);
-        totalDeleted += deleted;
-        if (deleted < batchSize) {
-          break;
-        }
-      }
+          "DRY-RUN: Orphan-branch cleanup graceDays={}  →  {} candidate rows (pre-GitHub-"
+              + "confirmation; actual deletions exclude branches still present on GitHub).",
+          graceDays, total);
+      return;
     }
 
-    log.info("Orphan-branch cleanup finished.  Total rows deleted: {}", totalDeleted);
+    log.info("Orphan-branch cleanup started (graceDays={}, batchSize={}).", graceDays, batchSize);
+
+    int totalDeleted = 0;
+    int totalHealed = 0;
+    for (Long repositoryId : repo.findRepositoriesWithOrphanCandidates(graceDays)) {
+      Set<String> liveBranches = fetchLiveBranches(repositoryId);
+      if (liveBranches == null) {
+        // Couldn't confirm this repo against GitHub — skip it this run (fail-safe).
+        continue;
+      }
+      int[] counts = sweepRepository(repositoryId, graceDays, batchSize, liveBranches);
+      totalDeleted += counts[0];
+      totalHealed += counts[1];
+    }
+
+    log.info(
+        "Orphan-branch cleanup finished.  Rows deleted: {}, branches re-synced (sync gaps): {}.",
+        totalDeleted, totalHealed);
+  }
+
+  /**
+   * Sweeps a single repository's orphan candidates, confirming each against the
+   * already-fetched {@code liveBranches} set.
+   *
+   * @return {@code [rowsDeleted, branchesHealed]}
+   */
+  private int[] sweepRepository(
+      long repositoryId, int graceDays, int batchSize, Set<String> liveBranches) {
+    int deleted = 0;
+    int healed = 0;
+    // Heal each gap branch at most once per run (guards against re-processing).
+    Set<String> healedBranches = new HashSet<>();
+
+    while (true) {
+      List<WorkflowRunRepository.OrphanBranchRunCandidate> candidates =
+          repo.findOrphanBranchRunCandidatesForRepo(repositoryId, graceDays, batchSize);
+      if (candidates.isEmpty()) {
+        break;
+      }
+
+      List<Long> confirmedOrphanIds = new ArrayList<>();
+      boolean healedThisBatch = false;
+      for (WorkflowRunRepository.OrphanBranchRunCandidate candidate : candidates) {
+        if (liveBranches.contains(candidate.getHeadBranch())) {
+          // The branch still exists on GitHub but is missing from our table:
+          // a sync gap. Re-sync it instead of deleting the run.
+          if (healedBranches.add(candidate.getHeadBranch())
+              && healBranch(repositoryId, candidate.getHeadBranch())) {
+            healed++;
+            healedThisBatch = true;
+          }
+        } else {
+          confirmedOrphanIds.add(candidate.getId());
+        }
+      }
+
+      if (!confirmedOrphanIds.isEmpty()) {
+        repo.deleteAllByIdInBatch(confirmedOrphanIds);
+        deleted += confirmedOrphanIds.size();
+      }
+
+      // Stop when a batch produced neither a deletion nor a fresh heal: the
+      // remaining candidates are gap branches already handled (or heals that
+      // failed), so another pass cannot make progress.
+      if (confirmedOrphanIds.isEmpty() && !healedThisBatch) {
+        break;
+      }
+    }
+    return new int[] {deleted, healed};
+  }
+
+  /**
+   * Fetches the live branch names for a repository from GitHub (one cheap
+   * listing, no per-branch calls).
+   *
+   * @return the set of live branch names, or {@code null} if the repository
+   *     can't be resolved or GitHub can't be reached (caller skips the repo).
+   */
+  private Set<String> fetchLiveBranches(long repositoryId) {
+    Optional<GitRepository> repository = gitRepoRepository.findByRepositoryId(repositoryId);
+    if (repository.isEmpty()) {
+      log.warn("Orphan-branch cleanup: no repository row for repositoryId={}; skipping.",
+          repositoryId);
+      return null;
+    }
+    String nameWithOwner = repository.get().getNameWithOwner();
+    try {
+      GHRepository ghRepository = gitHubService.getRepository(nameWithOwner);
+      Set<String> names = new HashSet<>(ghRepository.getBranches().keySet());
+      log.info("Orphan-branch cleanup: {} live branches fetched for {}.", names.size(),
+          nameWithOwner);
+      return names;
+    } catch (IOException | RuntimeException e) {
+      log.warn("Orphan-branch cleanup: failed to fetch live branches for {}; skipping repo this "
+          + "run (nothing deleted). Cause: {}", nameWithOwner, e.toString());
+      return null;
+    }
+  }
+
+  /**
+   * Targeted single-branch re-sync to heal a branch that exists on GitHub but
+   * went missing from the local {@code branch} table.
+   *
+   * @return {@code true} if the branch was re-synced; {@code false} on failure
+   *     (the run is then left in place rather than deleted).
+   */
+  private boolean healBranch(long repositoryId, String branchName) {
+    Optional<GitRepository> repository = gitRepoRepository.findByRepositoryId(repositoryId);
+    if (repository.isEmpty()) {
+      return false;
+    }
+    String nameWithOwner = repository.get().getNameWithOwner();
+    try {
+      GHRepository ghRepository = gitHubService.getRepository(nameWithOwner);
+      GHBranch ghBranch = ghRepository.getBranch(branchName);
+      branchSyncService.processBranch(ghBranch);
+      log.info("Orphan-branch cleanup: branch '{}' still exists on {} but was missing locally — "
+          + "re-synced it instead of deleting its runs.", branchName, nameWithOwner);
+      return true;
+    } catch (IOException | RuntimeException e) {
+      log.warn("Orphan-branch cleanup: failed to re-sync branch '{}' on {}; leaving its runs in "
+          + "place. Cause: {}", branchName, nameWithOwner, e.toString());
+      return false;
+    }
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunCleanupTaskTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunCleanupTaskTest.java
@@ -1,148 +1,195 @@
 package de.tum.cit.aet.helios.workflow.cleanup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import de.tum.cit.aet.helios.branch.github.GitHubBranchSyncService;
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
+import de.tum.cit.aet.helios.workflow.WorkflowRunRepository.OrphanBranchRunCandidate;
+import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-import org.mockito.Mockito;
+import org.kohsuke.github.GHBranch;
+import org.kohsuke.github.GHRepository;
 
 class WorkflowRunCleanupTaskTest {
 
-  private static final int BATCH_SIZE = 5000;
+  private static final int GRACE = 7;
+  private static final int BATCH = 5000;
+  private static final long REPO_ID = 1L;
+  private static final String REPO = "ls1intum/Helios";
 
   @Test
-  void purgeOrphanBranchRunsDeletesInBatchesUntilDrained() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    // First two batches return a full batch → loop continues; third returns a
-    // short batch → loop terminates with 5000 + 5000 + 273 = 10 273 total.
-    when(repo.purgeOrphanBranchRunsBatch(7, BATCH_SIZE))
-        .thenReturn(BATCH_SIZE)
-        .thenReturn(BATCH_SIZE)
-        .thenReturn(273);
+  void deletesRunsWhoseBranchGitHubConfirmsAreGone() throws Exception {
+    Fixture f = new Fixture();
+    f.liveBranches("main"); // GitHub: only 'main' still exists
+    f.candidatesForRepo(candidate(100L, "feature-gone"));
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ false, /* enabled */ true, 7);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    verify(repo, times(3)).purgeOrphanBranchRunsBatch(7, BATCH_SIZE);
-    verifyNoMoreInteractions(repo);
+    verify(f.repo).deleteAllByIdInBatch(List.of(100L));
+    verify(f.branchSync, never()).processBranch(any());
   }
 
   @Test
-  void purgeOrphanBranchRunsStopsAfterShortFirstBatch() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    when(repo.purgeOrphanBranchRunsBatch(7, BATCH_SIZE)).thenReturn(42);
+  void healsBranchStillOnGitHubInsteadOfDeleting() throws Exception {
+    Fixture f = new Fixture();
+    f.liveBranches("main", "feature-live"); // branch still exists on GitHub
+    GHBranch ghBranch = mock(GHBranch.class);
+    when(f.ghRepo.getBranch("feature-live")).thenReturn(ghBranch);
+    f.candidatesForRepo(candidate(100L, "feature-live"));
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ false, /* enabled */ true, 7);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    verify(repo).purgeOrphanBranchRunsBatch(7, BATCH_SIZE);
-    verifyNoMoreInteractions(repo);
+    verify(f.branchSync).processBranch(ghBranch); // re-synced
+    verify(f.repo, never()).deleteAllByIdInBatch(any()); // not deleted
   }
 
   @Test
-  void purgeOrphanBranchRunsStopsImmediatelyWhenBacklogIsEmpty() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    when(repo.purgeOrphanBranchRunsBatch(7, BATCH_SIZE)).thenReturn(0);
+  void deletesGoneBranchButHealsLiveOneInSameBatch() throws Exception {
+    Fixture f = new Fixture();
+    f.liveBranches("main", "feature-live");
+    GHBranch ghBranch = mock(GHBranch.class);
+    when(f.ghRepo.getBranch("feature-live")).thenReturn(ghBranch);
+    f.candidatesForRepo(candidate(100L, "feature-gone"), candidate(101L, "feature-live"));
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ false, /* enabled */ true, 7);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    verify(repo).purgeOrphanBranchRunsBatch(7, BATCH_SIZE);
-    verifyNoMoreInteractions(repo);
+    verify(f.repo).deleteAllByIdInBatch(List.of(100L)); // gone branch swept
+    verify(f.branchSync).processBranch(ghBranch); // live branch healed, 101 kept
   }
 
   @Test
-  void purgeOrphanBranchRunsPreviewsOnlyInDryRunMode() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    // Dry-run reports the true backlog via count(*) and a capped id sample.
-    when(repo.countOrphanBranchRunIds(14)).thenReturn(12_345L);
-    when(repo.previewOrphanBranchRunIds(14, BATCH_SIZE)).thenReturn(List.of(1L, 2L, 3L));
+  void skipsRepoWhenGitHubCannotBeReached() throws Exception {
+    Fixture f = new Fixture();
+    when(f.repo.findRepositoriesWithOrphanCandidates(GRACE)).thenReturn(List.of(REPO_ID));
+    GitRepository gitRepo = mock(GitRepository.class);
+    when(gitRepo.getNameWithOwner()).thenReturn(REPO);
+    when(f.gitRepoRepo.findByRepositoryId(REPO_ID)).thenReturn(Optional.of(gitRepo));
+    when(f.gitHub.getRepository(REPO)).thenThrow(new IOException("github down"));
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ true, /* enabled */ true, 14);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    verify(repo).countOrphanBranchRunIds(14);
-    verify(repo).previewOrphanBranchRunIds(14, BATCH_SIZE);
-    verify(repo, never()).purgeOrphanBranchRunsBatch(anyInt(), anyInt());
-    verifyNoMoreInteractions(repo);
+    // Fail-safe: never deletes or heals, never even queries candidates for the repo.
+    verify(f.repo, never()).deleteAllByIdInBatch(any());
+    verify(f.branchSync, never()).processBranch(any());
+    verify(f.repo, never()).findOrphanBranchRunCandidatesForRepo(anyLong(), anyInt(), anyInt());
   }
 
   @Test
-  void purgeOrphanBranchRunsSkipsInvalidBatchSize() {
-    WorkflowRunCleanupProps props = new WorkflowRunCleanupProps();
-    props.setDryRun(false);
-    WorkflowRunCleanupProps.OrphanBranches orphan = new WorkflowRunCleanupProps.OrphanBranches();
-    orphan.setEnabled(true);
-    orphan.setGraceDays(7);
-    orphan.setBatchSize(0); // invalid: before the guard this looped forever (LIMIT 0 deletes 0)
-    props.setOrphanBranches(orphan);
+  void dryRunOnlyCountsNoDeleteNoHeal() {
+    Fixture f = new Fixture();
+    f.dryRun = true;
+    when(f.repo.countOrphanBranchRunIds(GRACE)).thenReturn(42L);
 
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    WorkflowRunCleanupTask task = new WorkflowRunCleanupTask(repo, props);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    // Skipped before issuing any query — and the test terminates instead of hanging.
-    verifyNoMoreInteractions(repo);
+    verify(f.repo).countOrphanBranchRunIds(GRACE);
+    verify(f.repo, never()).deleteAllByIdInBatch(any());
+    verify(f.branchSync, never()).processBranch(any());
+    verifyNoInteractions(f.gitHub);
   }
 
   @Test
-  void purgeOrphanBranchRunsShortCircuitsWhenDisabled() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
+  void shortCircuitsWhenDisabled() {
+    Fixture f = new Fixture();
+    f.enabled = false;
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ false, /* enabled */ false, 7);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    verifyNoMoreInteractions(repo);
+    verifyNoInteractions(f.repo, f.gitHub, f.branchSync, f.gitRepoRepo);
   }
 
   @Test
-  void purgeOrphanBranchRunsPropagatesGraceDaysToRepository() {
-    WorkflowRunRepository repo = Mockito.mock(WorkflowRunRepository.class);
-    when(repo.purgeOrphanBranchRunsBatch(30, BATCH_SIZE)).thenReturn(0);
+  void skipsInvalidBatchSize() {
+    Fixture f = new Fixture();
+    f.batchSize = 0; // invalid: before the guard this could loop forever
 
-    WorkflowRunCleanupTask task = createTask(repo, /* dryRun */ false, /* enabled */ true, 30);
+    f.task().purgeOrphanBranchRuns();
 
-    task.purgeOrphanBranchRuns();
-
-    InOrder inOrder = Mockito.inOrder(repo);
-    inOrder.verify(repo).purgeOrphanBranchRunsBatch(30, BATCH_SIZE);
-    inOrder.verifyNoMoreInteractions();
+    verifyNoInteractions(f.repo, f.gitHub, f.branchSync, f.gitRepoRepo);
   }
 
   @Test
   void orphanBranchesDefaultsAreSafe() {
-    // Defaults must keep the sweep off until an operator explicitly enables
-    // it — otherwise the first scheduled tick after deploy would wipe the
-    // historical backlog.
+    // Defaults must keep the sweep off until an operator explicitly enables it.
     WorkflowRunCleanupProps.OrphanBranches defaults = new WorkflowRunCleanupProps.OrphanBranches();
-    assertEquals(false, defaults.isEnabled());
+    assertFalse(defaults.isEnabled());
     assertEquals(7, defaults.getGraceDays());
     assertEquals(5000, defaults.getBatchSize());
   }
 
-  private WorkflowRunCleanupTask createTask(
-      WorkflowRunRepository repo, boolean dryRun, boolean enabled, int graceDays) {
-    WorkflowRunCleanupProps props = new WorkflowRunCleanupProps();
-    props.setDryRun(dryRun);
-    WorkflowRunCleanupProps.OrphanBranches orphan = new WorkflowRunCleanupProps.OrphanBranches();
-    orphan.setEnabled(enabled);
-    orphan.setGraceDays(graceDays);
-    orphan.setBatchSize(BATCH_SIZE);
-    props.setOrphanBranches(orphan);
-    return new WorkflowRunCleanupTask(repo, props);
+  private static OrphanBranchRunCandidate candidate(long id, String headBranch) {
+    return new OrphanBranchRunCandidate() {
+      @Override
+      public Long getId() {
+        return id;
+      }
+
+      @Override
+      public String getHeadBranch() {
+        return headBranch;
+      }
+    };
+  }
+
+  /** Wires the task's collaborators as bare mocks; tests stub only what they need. */
+  private static final class Fixture {
+    final WorkflowRunRepository repo = mock(WorkflowRunRepository.class);
+    final GitHubService gitHub = mock(GitHubService.class);
+    final GitHubBranchSyncService branchSync = mock(GitHubBranchSyncService.class);
+    final GitRepoRepository gitRepoRepo = mock(GitRepoRepository.class);
+    final GHRepository ghRepo = mock(GHRepository.class);
+
+    boolean enabled = true;
+    boolean dryRun = false;
+    int graceDays = GRACE;
+    int batchSize = BATCH;
+
+    WorkflowRunCleanupTask task() {
+      WorkflowRunCleanupProps props = new WorkflowRunCleanupProps();
+      props.setDryRun(dryRun);
+      WorkflowRunCleanupProps.OrphanBranches orphan = new WorkflowRunCleanupProps.OrphanBranches();
+      orphan.setEnabled(enabled);
+      orphan.setGraceDays(graceDays);
+      orphan.setBatchSize(batchSize);
+      props.setOrphanBranches(orphan);
+      return new WorkflowRunCleanupTask(repo, props, gitHub, branchSync, gitRepoRepo);
+    }
+
+    /** Repo has candidates, resolves to {@link #REPO}; GitHub returns the given branches. */
+    void liveBranches(String... names) throws IOException {
+      when(repo.findRepositoriesWithOrphanCandidates(graceDays)).thenReturn(List.of(REPO_ID));
+      GitRepository gitRepo = mock(GitRepository.class);
+      when(gitRepo.getNameWithOwner()).thenReturn(REPO);
+      when(gitRepoRepo.findByRepositoryId(REPO_ID)).thenReturn(Optional.of(gitRepo));
+      when(gitHub.getRepository(REPO)).thenReturn(ghRepo);
+      Map<String, GHBranch> branches = new HashMap<>();
+      for (String name : names) {
+        branches.put(name, mock(GHBranch.class));
+      }
+      when(ghRepo.getBranches()).thenReturn(branches);
+    }
+
+    /** First candidate query returns the given candidates, then drains to empty. */
+    void candidatesForRepo(OrphanBranchRunCandidate... candidates) {
+      when(repo.findOrphanBranchRunCandidatesForRepo(REPO_ID, graceDays, batchSize))
+          .thenReturn(List.of(candidates))
+          .thenReturn(List.of());
+    }
   }
 }

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunOrphanSweepIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunOrphanSweepIntegrationTest.java
@@ -57,6 +57,9 @@ class WorkflowRunOrphanSweepIntegrationTest {
   // orphan branch, but referenced by a deployment → keep
   private static final long ORPHAN_WITH_DEPLOYMENT = 104L;
 
+  private static final long REPOSITORY_ID = 1L;
+  private static final String DELETED_BRANCH = "deleted-feature";
+
   @Autowired private WorkflowRunRepository repo;
   @Autowired private DataSource dataSource;
   private JdbcTemplate jdbc;
@@ -78,11 +81,11 @@ class WorkflowRunOrphanSweepIntegrationTest {
         "INSERT INTO branch (repository_id, name, ahead_by, behind_by, is_default, protection) "
             + "VALUES (1, 'main', 0, 0, true, false)");
 
-    insertRun(ORPHAN_OLD, "deleted-feature", "30 days");
+    insertRun(ORPHAN_OLD, DELETED_BRANCH, "30 days");
     insertRun(LIVE_BRANCH, "main", "30 days");
-    insertRun(ORPHAN_YOUNG, "deleted-feature", "1 day");
+    insertRun(ORPHAN_YOUNG, DELETED_BRANCH, "1 day");
     insertRun(NULL_BRANCH, null, "30 days");
-    insertRun(ORPHAN_WITH_DEPLOYMENT, "deleted-feature", "30 days");
+    insertRun(ORPHAN_WITH_DEPLOYMENT, DELETED_BRANCH, "30 days");
 
     // A deployment references the orphan run → the sweep must preserve it.
     jdbc.update(
@@ -116,15 +119,25 @@ class WorkflowRunOrphanSweepIntegrationTest {
   }
 
   @Test
-  void previewReturnsOnlyTheDeletableOrphan() {
-    assertThat(repo.previewOrphanBranchRunIds(GRACE_DAYS, BATCH_SIZE)).containsExactly(ORPHAN_OLD);
+  void candidateQueriesReturnOnlyTheDeletableOrphan() {
+    // Only repo 1 has a candidate, and within it only the old, branch-deleted,
+    // non-deployment-referenced run — the live/young/null/deployment runs are excluded.
+    assertThat(repo.findRepositoriesWithOrphanCandidates(GRACE_DAYS))
+        .containsExactly(REPOSITORY_ID);
+
+    var candidates =
+        repo.findOrphanBranchRunCandidatesForRepo(REPOSITORY_ID, GRACE_DAYS, BATCH_SIZE);
+    assertThat(candidates).hasSize(1);
+    assertThat(candidates.get(0).getId()).isEqualTo(ORPHAN_OLD);
+    assertThat(candidates.get(0).getHeadBranch()).isEqualTo(DELETED_BRANCH);
   }
 
   @Test
-  void purgeDeletesOnlyTheOrphanAndCascadesItsChildren() {
-    int deleted = repo.purgeOrphanBranchRunsBatch(GRACE_DAYS, BATCH_SIZE);
+  void deletingAConfirmedOrphanCascadesToItsChildren() {
+    // The task confirms candidates against GitHub, then deletes by id; here we
+    // exercise that delete-by-id path and assert the FK cascade.
+    repo.deleteAllByIdInBatch(List.of(ORPHAN_OLD));
 
-    assertThat(deleted).isEqualTo(1);
     assertThat(remainingRunIds())
         .containsExactlyInAnyOrder(LIVE_BRANCH, ORPHAN_YOUNG, NULL_BRANCH, ORPHAN_WITH_DEPLOYMENT);
     // ON DELETE CASCADE removed the orphan's test suite and case.
@@ -133,9 +146,8 @@ class WorkflowRunOrphanSweepIntegrationTest {
   }
 
   @Test
-  void purgeRespectsBatchSizeLimit() {
-    // batchSize 2 must delete at most 2 rows even though only one is eligible here.
-    assertThat(repo.purgeOrphanBranchRunsBatch(GRACE_DAYS, 2)).isEqualTo(1);
+  void candidateQueryRespectsTheLimit() {
+    assertThat(repo.findOrphanBranchRunCandidatesForRepo(REPOSITORY_ID, GRACE_DAYS, 1)).hasSize(1);
   }
 
   private List<Long> remainingRunIds() {

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunOrphanSweepIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/cleanup/WorkflowRunOrphanSweepIntegrationTest.java
@@ -133,7 +133,7 @@ class WorkflowRunOrphanSweepIntegrationTest {
   }
 
   @Test
-  void deletingAConfirmedOrphanCascadesToItsChildren() {
+  void deletingConfirmedOrphanCascadesToItsChildren() {
     // The task confirms candidates against GitHub, then deletes by id; here we
     // exercise that delete-by-id path and assert the FK cascade.
     repo.deleteAllByIdInBatch(List.of(ORPHAN_OLD));


### PR DESCRIPTION
## Summary

Hardens the orphan-branch sweep (shipped in #1050) against the one realistic over-deletion path: the local `branch` table not being a complete mirror of live branches. Now a run is only deleted **once GitHub itself confirms its branch is gone**, and a branch that merely went missing locally (a sync gap) is **healed** instead of swept.

## Why
The sweep deletes a run when its `head_branch` is absent from the `branch` table. That trusts an invariant maintained by a separate sync pipeline (webhook-driven branch deletes; full-prune reconciliation is commented out). A live branch missing from the table → its runs look orphaned → irreversible incorrect delete. This closes that gap.

## How (per repo that has candidates)
1. **DB yields candidates only** — branch absent from the local table, older than grace, non-null branch + repo, not referenced by `deployment`/`helios_deployment`.
2. **Cheap GitHub confirmation** — fetch the repo's live branch names once (`getBranches().keySet()`; one listing, no per-branch calls). If GitHub can't be reached, **skip that repo this run** (fail-safe: nothing deleted).
3. **Classify each candidate:**
   - branch still on GitHub → **sync gap** → re-sync that **single** branch (targeted full sync) to heal the table; **do not delete**.
   - branch genuinely gone → **confirmed orphan** → delete by id (cascades to `test_suite`/`test_case`/junctions as before).

### Cost
Steady state: **~1 list call per repo per night, 0 single-branch syncs**. A full single-branch sync runs only for a genuine gap (should be ~0).

## Changes
- `WorkflowRunRepository`: replaced the pure-SQL batch delete with `findRepositoriesWithOrphanCandidates` + `findOrphanBranchRunCandidatesForRepo` (projection of `id`/`headBranch`) + `deleteAllByIdInBatch`; kept `countOrphanBranchRunIds` for dry-run.
- `WorkflowRunCleanupTask`: `purgeOrphanBranchRuns()` now does the confirm → heal-or-delete flow; fail-safe per repo; runs with NULL `repository_id` are never swept (can't confirm against GitHub).
- Tests: unit tests rewritten (mocked GitHub) covering confirmed-delete / heal / repo-skip / dry-run; the embedded-Postgres IT now verifies the candidate SQL predicate + the delete-by-id cascade.

### Verification
- ✅ Full `test jacocoTestReport jacocoTestCoverageVerification` under Gradle 9.
- ✅ checkstyle line-length clean.

> Note: dry-run still reports the DB candidate count (pre-confirmation), clearly labelled — confirmation only runs in delete mode to keep dry-run cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)