### PR TITLE
chore(renovate): cap docutils <0.22, block Sphinx major bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -166,6 +166,17 @@
       ],
       "groupName": "all non-major github-actions dependencies",
       "groupSlug": "all-minor-patch-github-actions"
+    },
+    {
+      "description": "Sphinx 8.x (current docs pin) requires docutils <0.22; cap until the docs toolchain is upgraded.",
+      "matchPackageNames": ["docutils"],
+      "allowedVersions": "<0.22"
+    },
+    {
+      "description": "Sphinx 9 requires a coordinated upgrade of theme + extensions + docutils; block major bumps until that work happens in its own PR.",
+      "matchPackageNames": ["sphinx"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
### Motivation

Renovate has kept proposing two doc-dep bumps that both break the `docs` job, with no realistic fix outside a coordinated docs-stack upgrade:

- **#1068** `chore(deps): update dependency docutils to v0.23` — Sphinx 8.x (current pin) requires `docutils>=0.20,<0.22`. v0.23 fails the docs build.
- **#1087** `chore(deps): update dependency sphinx to v9` — would also require updating the theme, extensions, and relaxing the docutils cap. Out of scope for a one-package bump.

Both PRs have been closed.

### Changes

`.github/renovate.json` gains two `packageRules`:

1. `docutils`: `allowedVersions: "<0.22"` — Renovate will no longer propose updates that exceed the Sphinx-8 cap.
2. `sphinx`: `matchUpdateTypes: ["major"], enabled: false` — minor / patch updates still flow; major (v9+) is blocked.

### Reversal

Both rules should be removed (or relaxed) the moment we decide to upgrade Sphinx + the rest of the docs toolchain in a focused PR. Until then they're load-bearing — without them, the same two bot PRs will reappear within hours.