### PR TITLE
ci(staging): allow manual deploy of any ref via workflow_dispatch

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -2,6 +2,12 @@ name: Build Docker Image
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref (branch, tag, or SHA) to build. Defaults to the triggering ref.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -38,6 +44,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          # When called from a workflow_dispatch with an explicit ref input, build that ref's
+          # source. For normal push-triggered calls, inputs.ref is empty and we fall back to
+          # github.ref (the triggering ref). The ref is passed only to actions/checkout, which
+          # validates it as a git reference — never used in a `run:` step (no shell exposure).
+          ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 1
 
       - name: Log in to the Container registry

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,6 +19,26 @@ on:
       - '!.github/workflows/deploy_docker.yml'
       - '.vscode/**'
       - 'docs/**'
+  # Admins (repo write permission) can manually deploy any branch / tag / SHA to
+  # helios-staging without going through git push. The chosen ref is built and pushed
+  # under the `:staging` image tag (overwriting it), then the standard deploy_docker.yml
+  # step rolls it out. To revert, dispatch again with `ref: staging`.
+  #
+  # Limitations (acceptable for ad-hoc PR testing):
+  #   - validate-flyway and deploy_docker.yml's checkout both run against github.ref
+  #     (the dispatching branch, normally `staging`), not against `inputs.ref`. So the
+  #     compose.prod.yaml on the VM and the validated migrations come from the
+  #     dispatching branch. A PR that changes compose.prod.yaml or migrations relies on
+  #     its own PR-side CI to have validated them.
+  #   - The input flows only to actions/checkout's `ref:` parameter — never to a
+  #     `run:` step. See build_docker.yml for the validation.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch / tag / SHA to deploy to helios-staging (default: staging)'
+        required: true
+        type: string
+        default: staging
 
 concurrency:
   group: staging
@@ -35,6 +55,11 @@ jobs:
     needs: validate-flyway
     uses: ./.github/workflows/build_docker.yml
     secrets: inherit
+    with:
+      # On push triggers `inputs.ref` is undefined and this resolves to github.ref
+      # (preserving the existing behavior). On workflow_dispatch, the user-supplied
+      # ref wins.
+      ref: ${{ inputs.ref || github.ref }}
   deploy-staging-container:
     needs: build-staging-container
     uses: ./.github/workflows/deploy_docker.yml


### PR DESCRIPTION
### Motivation

Today we have no path to deploy a feature PR to helios-staging short of force-pushing it onto the `staging` branch (destructive + pollutes git history). This blocks pre-merge smoke testing of features that need real GitHub-side integration — webhooks, OAuth federation, deployment workflows, etc.

### Change

Add a `workflow_dispatch` entry point to `.github/workflows/staging.yml` with a `ref` input (default `staging`). Admins (repo write permission) can dispatch from the Actions UI or via `gh workflow run`, picking any branch / tag / SHA to deploy. Images are still tagged `:staging` (because `github.ref_name = staging` in the dispatched run), so the existing `deploy_docker.yml` step deploys them unchanged. To revert, re-dispatch with `ref: staging`.

`build_docker.yml` gains an optional `ref` input on its `workflow_call` signature; the checkout step uses `inputs.ref || github.ref` so the pre-existing push behavior is preserved.

### Security

- `inputs.ref` flows **only** into `actions/checkout`'s `ref:` parameter, which validates the value as a git reference. It is **never** used in a `run:` step, so there is no shell exposure.
- `workflow_dispatch` is gated by GitHub's repo write permission. Anyone who can dispatch already has push access, so this introduces no new privilege.

### Acknowledged limitations (documented inline)

- `validate-flyway` and `deploy_docker.yml`'s `compose.prod.yaml` checkout both still run against `github.ref` (= the dispatching branch, usually `staging`), not against `inputs.ref`. For PRs that change migrations or `compose.prod.yaml`, the PR's own CI is the safety net. If we want to remove this caveat, both reusable workflows would need their own `ref` input parameterized — happy to do as a follow-up if needed.

### Test plan

1. After merge, dispatch with `ref: staging` from Actions UI → confirms revert path works (deploys current staging).
2. Dispatch with `ref: feat/deployment-approval-in-helios` → smoke-tests the approval-flow PR end-to-end against `test-server-7`.
3. Dispatch with `ref: staging` again → restores helios-staging to staging branch state.
