### PR TITLE
chore(deps): final non-breaking sweep (github-actions + maven plugin)

### DIFF
--- a/.github/workflows/pullrequest_linting.yml
+++ b/.github/workflows/pullrequest_linting.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dbelyaev/action-checkstyle@ebd9df2e22f6696655aeba7c6d26956e7f41e1cc  # v3.10.0
+      - uses: dbelyaev/action-checkstyle@f9a0835c89d30a318614ba4fe5e7f3d776ea17f2  # v3.12.0
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.4.0
+          version: 11.8.0
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -46,7 +46,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.4.0
+          version: 11.8.0
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -33,7 +33,7 @@ jobs:
           source: /usr/share/nginx/html
           destination: ./dist
       - name: Create Sentry release for Client
-        uses: getsentry/action-release@f71adb49d4b2aeeda98052d3de234bbb0f3e03ab  # v3.6.1
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528  # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Create Sentry release for Server
-        uses: getsentry/action-release@f71adb49d4b2aeeda98052d3de234bbb0f3e03ab  # v3.6.1
+        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528  # v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Renovate
-        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961  # v46.1.14
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd  # v46.1.15
         with:
           configurationFile: ".github/renovate.json"
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         - name: Setup pnpm
           uses: pnpm/action-setup@v6
           with:
-            version: 11.4.0
+            version: 11.8.0
         - name: Setup Node.js
           uses: actions/setup-node@v6
           with:

--- a/server/helios-status-spring-starter/pom.xml
+++ b/server/helios-status-spring-starter/pom.xml
@@ -30,7 +30,7 @@
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
-        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
         <checkstyle.version>13.6.0</checkstyle.version>
         <spring-javaformat-checkstyle.version>0.0.47</spring-javaformat-checkstyle.version>


### PR DESCRIPTION
### Motivation

Final pass to get Helios **completely up to date on everything non-breaking**, after #1117, #1125 and #1128. This folds in the last two open non-major Renovate PRs so nothing safe is left dangling.

### Description

**github-actions (#1126)**
- `dbelyaev/action-checkstyle` v3.10.0 → v3.12.0
- `getsentry/action-release` v3.6.1 → v3.7.0
- `renovatebot/github-action` v46.1.14 → v46.1.15
- CI pnpm `version:` 11.4.0 → **11.8.0** (aligns CI with the `packageManager` field in `client`/`keycloakify`)

**helios-status-spring-starter (#1127)**
- `central-publishing-maven-plugin` 0.7.0 → 0.11.0

### Verification
- Clean `pnpm install --frozen-lockfile` passes under pnpm **11.8.0** for both `client` and `keycloakify` (supply-chain policy satisfied — no fresh packages in either lockfile).
- `client` + `keycloakify` ESLint pass; `keycloakify` build passes.
- All changed workflow YAML and the pom XML validated.

### Status of everything else (for overview)

| State | Items |
|---|---|
| ✅ Already on staging (Renovate PRs will auto-close) | openapi-generator 7.23.0 (#1124), spring-javaformat-checkstyle 0.0.47 (#1122), maven-gpg-plugin 3.2.8 (#1120), nats 2.14.2 (#1121), checkstyle 13.6.0 (#1128) |
| ⏸ Held by <24h `minimumReleaseAge` policy | keycloakify 11.15.10 (part of #1123) — will land once it ages |
| 🚫 Deliberately deferred (BREAKING) | typescript 6 (#1089), postgres 18 (#1097), marked 18 (#1102), Angular 22, tailwindcss 4, @vitejs/plugin-react 6, @types/node 25/26 |
| 🔒 Pinned by policy | keycloak base image (Dockerfile: "Do NOT update on renovatebot PRs") |

After this merges, the only open Renovate PRs left should be the breaking majors + the keycloakify-leftover group.

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.