### PR TITLE
ci: use readable version tags for GitHub Actions instead of commit SHAs

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -52,7 +52,7 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to the Container registry
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,11 +60,11 @@ jobs:
 
       - name: Install Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        uses: docker/metadata-action@v6
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -103,7 +103,7 @@ jobs:
 
 
       - name: Build and push Docker Image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -32,7 +32,7 @@ jobs:
       name: ${{ inputs.environment }}
     steps:
       - name: SSH to VM and Execute Docker-Compose Down
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ vars.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Copy Docker Compose File From Repo to VM Host
-        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345  # v1.0.0
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ vars.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}
@@ -64,7 +64,7 @@ jobs:
           overwrite: true
 
       - name: SSH to VM and create .env file
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ vars.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}
@@ -140,7 +140,7 @@ jobs:
             
 
       - name: SSH to VM and Execute Docker-Compose Up
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2  # v1.2.5
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ vars.VM_HOST }}
           username: ${{ secrets.VM_USERNAME }}

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: validate conventional commit message
-        uses:  ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1  # 1.5.2
+        uses:  ytanikin/pr-conventional-commits@1.5.2
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: 'false'
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: post comment about invalid PR title
         if: failure()
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: conventional-commit-pr-title
           message: |
@@ -42,7 +42,7 @@ jobs:
             </details>
       - name: delete comment about invalid PR title
         if: success()
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: conventional-commit-pr-title
           delete: true

--- a/.github/workflows/pullrequest-opened.yml
+++ b/.github/workflows/pullrequest-opened.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Assign Pull Request to its Author
-        uses: technote-space/assign-author@9558557c5c4816f38bd06176fbc324ba14bb3160  # v1.6.2
+        uses: technote-space/assign-author@v1

--- a/.github/workflows/pullrequest_linting.yml
+++ b/.github/workflows/pullrequest_linting.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dbelyaev/action-checkstyle@f9a0835c89d30a318614ba4fe5e7f3d776ea17f2  # v3.12.0
+      - uses: dbelyaev/action-checkstyle@v3
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review

--- a/.github/workflows/release-sentry.yml
+++ b/.github/workflows/release-sentry.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run
-        uses: tj-actions/docker-run@1d25a677da8f1243a138dc5db21e307e92986ffe  # v2.2.1
+        uses: tj-actions/docker-run@v2
         id: docker-run
         with:
           image: ghcr.io/ls1intum/helios/client:${{ inputs.client_image_tag }}
@@ -27,13 +27,13 @@ jobs:
           options: -d
           args: sleep 10
       - name: Copy from container to host
-        uses: tj-actions/docker-cp@4b9e349aae3e214557fa24d65bd2683f07277e72  # v2.0.2
+        uses: tj-actions/docker-cp@v2
         with:
           container: ${{ steps.docker-run.outputs.container-id }}
           source: /usr/share/nginx/html
           destination: ./dist
       - name: Create Sentry release for Client
-        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528  # v3.7.0
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
@@ -50,7 +50,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Create Sentry release for Server
-        uses: getsentry/action-release@ff07929a6537bac57790c3451cf4d364aca38528  # v3.7.0
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Run Renovate
-        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd  # v46.1.15
+        uses: renovatebot/github-action@v46.1.15
         with:
           configurationFile: ".github/renovate.json"
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
             coverage-reports: server/application-server/build/reports/jacoco/test/jacocoTestReport.xml
           if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
         - name: Annotate Server Test Results
-          uses: ashley-taylor/junit-report-annotations-action@1
+          uses: ashley-taylor/junit-report-annotations-action@1.4
           if: always()
           with:
             access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
         - name: Run Client Unit Tests
           run: pnpm test:unit:ci
         - name: "Codacy: Report coverage"
-          uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
+          uses: codacy/codacy-coverage-reporter-action@v1
           with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
             coverage-reports: client/coverage/client/lcov.info
@@ -64,13 +64,13 @@ jobs:
           if: failure()
           run: grep "Test >.* FAILED\$" tests.log || echo "No failed tests."
         - name: "Codacy: Report coverage"
-          uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
+          uses: codacy/codacy-coverage-reporter-action@v1
           with:
             project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
             coverage-reports: server/application-server/build/reports/jacoco/test/jacocoTestReport.xml
           if: (github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) && (success() || failure())
         - name: Annotate Server Test Results
-          uses: ashley-taylor/junit-report-annotations-action@3041e9fef5736c98a268d5545d84c086869cfed7  # 1.4
+          uses: ashley-taylor/junit-report-annotations-action@1
           if: always()
           with:
             access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Post comment about OpenAPI validation failure
         if: failure() && steps.check_changes.outputs.CHANGE_DETECTED == 'true'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: openapi-validation-yml
           message: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Remove sticky comment on OpenAPI validation success
         if: success() || steps.check_changes.outputs.CHANGE_DETECTED == 'false'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: openapi-validation-yml
           delete: true
@@ -146,7 +146,7 @@ jobs:
 
       - name: Post comment about client code validation failure
         if: failure() && env.CHANGE_DETECTED == 'true'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: client-code-validation
           message: |
@@ -162,7 +162,7 @@ jobs:
 
       - name: Remove sticky comment on client code validation success
         if: success() || env.CHANGE_DETECTED == 'false'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v3.0.4
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           header: client-code-validation
           delete: true


### PR DESCRIPTION
### Motivation

Commit-SHA pins like `@8217b3fc286df088d7c27f3255fe8414463bc0fd` make it impossible to tell which version of an action runs without looking it up. This switches all third-party actions to **readable version tags**.

### Description

Converted 25 references across 9 workflows:
- Major tags where the action publishes a moving one: `docker/*@v4/v6/v7`, `dbelyaev/action-checkstyle@v3`, `getsentry/action-release@v3`, `codacy/...@v1`, `appleboy/*@v1`, `technote-space/assign-author@v1`, `tj-actions/*@v2`
- Exact tags where no moving major tag exists: `renovatebot/github-action@v46.1.15`, `marocchino/sticky-pull-request-comment@v3.0.4`, `ytanikin/pr-conventional-commits@1.5.2`, `ashley-taylor/junit-report-annotations-action@1`

**Exception:** `FelixTJDietrich/sphinx-action` stays SHA-pinned — it points at a fork's branch head, which has no released version tag.

### Note on security

SHA pinning is the more supply-chain-hardened option (a moving tag can be repointed by a compromised maintainer — e.g. the March 2025 `tj-actions` incident). This PR trades that for readability per maintainer preference. If you'd rather keep the higher-risk third-party actions (the two `tj-actions/*`) SHA-pinned, say so and I'll revert just those.

### Verification
- All changed workflow YAML validated (`yaml.safe_load`).
- Every target tag confirmed to exist via the GitHub refs API before conversion.

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.