### PR TITLE
chore(starter): bump helios-status-spring-starter to 1.2.0

### DIFF
--- a/server/helios-status-spring-starter/CHANGELOG.md
+++ b/server/helios-status-spring-starter/CHANGELOG.md
@@ -7,7 +7,7 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
   When cutting an official release:
     1. Move changes from *Unreleased* to a new, dated version heading.
     2. Use ISO 8601 date format — YYYY-MM-DD — for every released section header.
-    3. Bump the version in pom.xml and commit both files together.
+    3. Bump VERSION_NAME in gradle.properties and commit both files together.
     4. After PR is merged, tag the commit:  git tag -a helios-starter-vX.Y.Z -m "Helios starter X.Y.Z"
 -->
 
@@ -26,6 +26,19 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
 - _(nothing yet)_
 ### Migration notes
 - _(nothing yet)_
+
+---
+
+## [1.2.0] – 2026-06-20
+### Changed
+- **Build system:** migrated the starter from Maven to Gradle (standalone Gradle build with
+  the Vanniktech `maven-publish` plugin; published to Maven Central via the Sonatype Central
+  Portal and to GitHub Packages). No source or runtime behaviour change.
+
+### Migration notes
+- The published POM no longer lists the former `provided`-scope dependencies (`slf4j-api`,
+  `hibernate-validator`); Gradle keeps them off the published model. They were non-transitive
+  under Maven too, so consumers are unaffected.
 
 ---
 

--- a/server/helios-status-spring-starter/gradle.properties
+++ b/server/helios-status-spring-starter/gradle.properties
@@ -2,7 +2,7 @@
 # VERSION_NAME is overridden at release time via -PVERSION_NAME=<version>.
 GROUP=de.tum.cit.aet
 POM_ARTIFACT_ID=helios-status-spring-starter
-VERSION_NAME=1.1.1
+VERSION_NAME=1.2.0
 
 # POM metadata required by Maven Central
 POM_NAME=Helios Status Spring Starter


### PR DESCRIPTION
### Motivation

Prepare the next release of `helios-status-spring-starter` (1.1.1 → **1.2.0**), the first release on the new Gradle build.

### Description

- `gradle.properties`: `VERSION_NAME` 1.1.1 → **1.2.0**
- `CHANGELOG.md`: add the `[1.2.0]` section (records the Maven → Gradle build migration from #1138) and fix the release checklist to reference `gradle.properties` instead of the now-removed `pom.xml`.

**Not changed here:** `application-server`'s dependency stays at `1.1.1`. Bump it to `1.2.0` only **after** 1.2.0 is published, otherwise the app build can't resolve the artifact.

### How to release 1.2.0 (after this merges)
1. **Actions → "Release Helios starter to GitHub Packages and Maven Central" → Run workflow**, `releaseversion = 1.2.0`.
2. Once it's on Maven Central, bump `server/application-server/build.gradle` → `implementation "de.tum.cit.aet:helios-status-spring-starter:1.2.0"`.

(Optional: dispatch a `0.0.1-SNAPSHOT` first to smoke-test the new Gradle publish pipeline end-to-end before the real 1.2.0.)

### Verification
- `./gradlew publishToMavenLocal` produces `helios-status-spring-starter-1.2.0` with `<version>1.2.0</version>` in the generated POM.

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.