### PR TITLE
fix(ci): check out before run steps in the starter release workflow

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: publish-maven
 
+    # Bind the dispatch input to an env var so it is never interpolated directly
+    # into a shell command (avoids GitHub Actions command-injection).
+    env:
+      VERSION: ${{ github.event.inputs.releaseversion }}
+
     permissions:
       contents: read
       packages: write
@@ -22,8 +27,10 @@ jobs:
         working-directory: server/helios-status-spring-starter
 
     steps:
-      - run: echo "Releasing helios-status-spring-starter version ${{ github.event.inputs.releaseversion }}"
+      # Checkout first: the job-level working-directory only exists after checkout,
+      # so any `run:` step must come after it.
       - uses: actions/checkout@v7
+      - run: echo "Releasing helios-status-spring-starter version $VERSION"
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
@@ -31,11 +38,11 @@ jobs:
           java-version: '21'
 
       - name: Build
-        run: ./gradlew build -PVERSION_NAME=${{ github.event.inputs.releaseversion }}
+        run: ./gradlew build -PVERSION_NAME="$VERSION"
 
       # https://github.com/ls1intum/Helios/packages
       - name: Publish to GitHub Packages
-        run: ./gradlew publishMavenPublicationToGitHubPackagesRepository -PVERSION_NAME=${{ github.event.inputs.releaseversion }}
+        run: ./gradlew publishMavenPublicationToGitHubPackagesRepository -PVERSION_NAME="$VERSION"
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
@@ -44,7 +51,7 @@ jobs:
 
       # https://central.sonatype.com/publishing/deployments
       - name: Publish to Maven Central
-        run: ./gradlew publishAndReleaseToMavenCentral -PVERSION_NAME=${{ github.event.inputs.releaseversion }}
+        run: ./gradlew publishAndReleaseToMavenCentral -PVERSION_NAME="$VERSION"
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSS_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSS_SONATYPE_PASSWORD }}


### PR DESCRIPTION
### Motivation

The `1.2.0` release dispatch failed instantly (run [27868975932](https://github.com/ls1intum/Helios/actions/runs/27868975932)):

```
An error occurred trying to start process '/usr/bin/bash' with working directory
'.../server/helios-status-spring-starter'. No such file or directory
```

The job sets `defaults.run.working-directory: server/helios-status-spring-starter`, which applies to **every** `run:` step. The first step (`echo …`) ran **before** `actions/checkout`, so that directory didn't exist yet → immediate failure. **Nothing was built or published** (no partial release).

### Fix
- Move `actions/checkout` to be the first step.
- Harden: bind the dispatch input to a `VERSION` env var and use `"$VERSION"` in `run:` commands instead of interpolating `${{ github.event.inputs.releaseversion }}` directly (avoids command-injection, per the Actions security guidance).

### After merge
Re-dispatch **"Release Helios starter to GitHub Packages and Maven Central"** with `releaseversion = 1.2.0` (or `0.0.1-SNAPSHOT` first to smoke-test).

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally (YAML validated).