### PR TITLE
fix(ci): use the OSSRH_* secrets that exist for the starter release

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Publish to Maven Central
         run: ./gradlew publishAndReleaseToMavenCentral -PVERSION_NAME="$VERSION"
         env:
-          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSS_SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
### Motivation

The `1.2.0` release re-run ([run 27869128785](https://github.com/ls1intum/Helios/actions/runs/27869128785)) got past the working-directory bug (build ✅) but failed at **Publish to GitHub Packages → `signMavenPublication`** with `Could not read PGP secret key`. The echoed env shows `ORG_GRADLE_PROJECT_signingInMemoryKey:` **empty**.

Cause: the workflow references secret names that don't exist in the `publish-maven` environment. That env only has **`OSSRH_USERNAME`** and **`OSSRH_PASSWORD`** — there is **no** `OSS_SONATYPE_*` and **no** `MAVEN_GPG_*` secret. (The wrong names were inherited from the old Maven workflow, whose only run also failed — it never actually published; 1.1.1 must have been released manually.)

### This PR
Points the Maven Central credentials at the real secret names: `OSS_SONATYPE_USERNAME/PASSWORD` → **`OSSRH_USERNAME/PASSWORD`**.

### ⚠️ Still required before a release can succeed (repo-admin action — secrets can't be set from code)
Maven Central **requires GPG-signed artifacts**, and there is currently **no signing key configured anywhere**. Add these two secrets to the **`publish-maven`** environment:

- `MAVEN_GPG_PRIVATE_KEY` — the **ASCII-armored** private key (full `-----BEGIN PGP PRIVATE KEY BLOCK-----…`)
- `MAVEN_GPG_PASSPHRASE` — its passphrase

Generate + register a key if there isn't one:
```bash
gpg --quick-generate-key "Helios CI <your-team@tum.de>" rsa4096 sign 2y
KEYID=$(gpg --list-keys --keyid-format=long "Helios CI" | awk '/pub/{print $2}' | cut -d/ -f2)
gpg --keyserver keyserver.ubuntu.com --send-keys "$KEYID"   # Central verifies the public key
gpg --armor --export-secret-keys "$KEYID"                   # paste into MAVEN_GPG_PRIVATE_KEY
```

Also confirm `OSSRH_USERNAME` / `OSSRH_PASSWORD` hold a **Central Portal user token** (central.sonatype.com → Account → Generate User Token), not legacy OSSRH login — the Central Portal only accepts the token.

After the secrets are in place and this merges, re-dispatch with `releaseversion = 1.2.0` (or `0.0.1-SNAPSHOT` to smoke-test first).

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes tested locally (YAML validated; signing verified locally with an ephemeral key during the migration).