### PR TITLE
fix(approval): unique reviewer rows + in-app retry for team-reviewer fallback

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/approval/DeploymentReviewActionService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/deployment/approval/DeploymentReviewActionService.java
@@ -101,9 +101,16 @@ public class DeploymentReviewActionService {
                         HttpStatus.CONFLICT,
                         "This environment has no required-reviewer rule; nothing to approve."));
 
-    if (!reviewers.userLogins().contains(currentLogin)) {
-      // Team-type reviewers (which Helios doesn't yet expand) deliberately don't satisfy this
-      // check from in-app; those approvals still need to happen on GitHub for now.
+    // The caller may act if they are an explicit User-type required reviewer, or if they already
+    // own an approval-request row for this deployment. The row-owner case is the recovery path
+    // for the team-reviewer fallback: when an env has only Team-type reviewers, userLogins() is
+    // empty, so the auto-approve path impersonated the creator and, on a GitHub rejection (e.g.
+    // a transient 5xx), left them a FAILED_AT_GITHUB row they could not otherwise retry in-app.
+    // GitHub stays the authority (it re-checks team membership and 502s an unauthorized retry),
+    // so a row owner retrying cannot bypass it. Full team-member expansion is Phase-4.
+    boolean ownsExistingRequest =
+        existing.stream().anyMatch(r -> currentLogin.equals(r.getReviewerLogin()));
+    if (!reviewers.userLogins().contains(currentLogin) && !ownsExistingRequest) {
       throw new ResponseStatusException(
           HttpStatus.FORBIDDEN, "You are not a required reviewer for this environment.");
     }

--- a/server/application-server/src/main/resources/db/migration/V55__deployment_approval_request_unique_reviewer.sql
+++ b/server/application-server/src/main/resources/db/migration/V55__deployment_approval_request_unique_reviewer.sql
@@ -1,0 +1,25 @@
+-- The deployment-approval find-or-create logic (ApprovalService.notifyReviewers and
+-- DeploymentReviewActionService.findOrCreateForReviewer) assumes at most one row per
+-- (deployment, reviewer_login). Nothing enforced that, so a concurrent/redelivered
+-- `deployment_status: waiting` event racing an in-app click could insert two rows for the
+-- same pair, after which the find-or-create lock query (Optional result) throws
+-- NonUniqueResultException on the reviewer's next click. Enforce the invariant in the schema:
+-- the unique index makes duplicates impossible and turns the rare insert race into a
+-- constraint violation that the webhook simply reprocesses on redelivery.
+
+-- Defensive de-duplication for any rows that already raced in before this constraint exists.
+-- Keep the most-progressed row per (deployment, reviewer_login): a responded row over an
+-- unresponded one, then the highest id.
+DELETE FROM public.deployment_approval_request a
+    USING public.deployment_approval_request b
+WHERE a.helios_deployment_id = b.helios_deployment_id
+  AND a.reviewer_login = b.reviewer_login
+  AND a.id <> b.id
+  AND (
+        (a.responded_at IS NULL AND b.responded_at IS NOT NULL)
+        OR (a.responded_at IS NULL AND b.responded_at IS NULL AND a.id < b.id)
+        OR (a.responded_at IS NOT NULL AND b.responded_at IS NOT NULL AND a.id < b.id)
+    );
+
+CREATE UNIQUE INDEX uniq_dar_deployment_reviewer_login
+    ON public.deployment_approval_request (helios_deployment_id, reviewer_login);


### PR DESCRIPTION
### Motivation

Two review follow-ups from the deep review of #1098 (which merged before these landed, so they need their own PR). Both harden the deployment-approval feature; neither changes the happy path.

### Changes

**1. `UNIQUE(helios_deployment_id, reviewer_login)` — V55 (with defensive dedup)**
The find-or-create logic in `ApprovalService.notifyReviewers` and `DeploymentReviewActionService.findOrCreateForReviewer` already assumes one row per `(deployment, reviewer)`, but nothing enforced it. A redelivered/concurrent `deployment_status: waiting` event racing an in-app click could insert duplicates, after which the find-or-create lock query (single-`Optional` result) throws `NonUniqueResultException` on the reviewer's next click. The unique index makes duplicates impossible and turns the rare insert race into a constraint violation the webhook simply reprocesses on redelivery — this is the correct altitude for the "the no-`@Transactional` pessimistic lock in `notifyReviewers` is a no-op" concern (correctness is now enforced by the DB regardless of the lock). The migration de-dups defensively first so it's safe on any env where a race already slipped a duplicate in.

**2. Team-reviewer fallback recovery — `DeploymentReviewActionService.review`**
For a Team-only environment, `reviewers.userLogins()` is empty, so the auto-approve path impersonates the deployment creator; if GitHub rejects it (e.g. a transient 5xx) the creator is left with a `FAILED_AT_GITHUB` row they could never retry in-app (the authz check 403s them). `review()` now also authorizes a caller who already **owns** an approval-request row for the deployment. GitHub stays the authority (it re-checks team membership and 502s an unauthorized retry), so this cannot bypass its gate. Full team-member expansion remains Phase-4.

### Verification
- `de.tum.cit.aet.helios.deployment.approval.*` tests pass on the current `staging` base.
- V53→V54→**V55** migrate cleanly against PostgreSQL; the `uniq_dar_deployment_reviewer_login` index is created.
- Java line-length/ASCII checked (checkstyle).

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.