### PR TITLE
chore(approval): polish items from the deployment-approval review

### DIFF
--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.ts
@@ -16,6 +16,7 @@ import { myPendingApprovalsOptions } from '@app/core/modules/openapi/@tanstack/a
 import { computed } from '@angular/core';
 import { Badge } from 'primeng/badge';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs';
 
 @Component({
@@ -50,9 +51,14 @@ export class ProfileNavSectionComponent {
   pendingApprovalsCount = computed(() => this.pendingApprovalsQuery.data()?.length ?? 0);
 
   constructor() {
-    this.router.events.pipe(filter(event => event instanceof NavigationEnd)).subscribe(() => {
-      this.profileMenu?.hide?.();
-    });
+    this.router.events
+      .pipe(
+        filter(event => event instanceof NavigationEnd),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => {
+        this.profileMenu?.hide?.();
+      });
   }
 
   isLoggedIn() {

--- a/client/src/app/pages/pending-approvals/pending-approvals.component.html
+++ b/client/src/app/pages/pending-approvals/pending-approvals.component.html
@@ -105,6 +105,6 @@
   }
   <ng-template pTemplate="footer">
     <p-button label="Cancel" severity="secondary" (onClick)="declineDialogVisible.set(false)" />
-    <p-button label="Decline deployment" severity="danger" (onClick)="confirmDecline()" />
+    <p-button label="Decline deployment" severity="danger" [disabled]="inFlightDeploymentId() !== null" [loading]="inFlightDeploymentId() !== null" (onClick)="confirmDecline()" />
   </ng-template>
 </p-dialog>

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/github/GitHubService.java
@@ -559,7 +559,8 @@ public class GitHubService {
             .url(url)
             .post(requestBody)
             .header("Authorization", "Bearer " + userGithubToken)
-            .header("Accept", "application/json")
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
             .build();
 
     try (Response response = okHttpClient.newCall(request).execute()) {


### PR DESCRIPTION
### Motivation

The three LOW-severity polish items surfaced by the deep review of #1098. None affect the happy path; bundled here so they don't get lost.

### Changes
1. **`GitHubService.reviewPendingDeployment`** — sends `Accept: application/vnd.github+json` + `X-GitHub-Api-Version` (the pinned `GITHUB_API_VERSION`), matching every other GitHub call in the file. Previously it used `Accept: application/json` with no version header, pinning this deployment-blocking call to GitHub's rolling default API version.
2. **Decline dialog confirm button** (`pending-approvals.component.html`) — now binds `[disabled]`/`[loading]` to the in-flight signal like the row buttons, so it can't double-submit and gives visual feedback.
3. **`profile-nav-section`** — the `router.events` subscription now uses `takeUntilDestroyed()` so it's torn down with the component.

### Verification
- Server: `GitHubServiceTest` + `de.tum.cit.aet.helios.deployment.approval.*` tests pass.
- Client: ESLint clean, `pnpm build` succeeds.

Related: the Phase-4 team-reviewer expansion work is tracked in #1156.

### Checklist
- [x] PR description explains the purpose and changes.
- [x] Changes have been tested locally.