### PR TITLE
fix(tests): handle Artemis's reusable-workflow CI for test display

### DIFF
--- a/ops/runbooks/artemis-test-display-config.md
+++ b/ops/runbooks/artemis-test-display-config.md
@@ -1,0 +1,98 @@
+# Runbook: reconfigure Artemis test display for the new `CI` workflow
+
+**Apply this after PR #1159 is deployed to prod.** It is a one-time Helios webapp
+configuration change for the `ls1intum/Artemis` repository — no code or restart needed.
+
+## Why
+
+Artemis moved from chained, per-workflow CI to a single **`CI`** orchestrator
+(`.github/workflows/ci.yml`) that calls reusable workflows (`ci-test.yml`,
+`ci-e2e.yml`, …). As a result:
+
+- All JUnit artifacts are now attached to the top-level **`CI`** run, with **new names**.
+- Helios matches test results by `TestType { workflow, artifactName }`. The old test
+  types still point at the retired "Tests"/"E2E Tests" workflows, so nothing is
+  ingested → the PR/branch **Test Results** view is empty.
+
+PR #1159 already handles the code side (a completed run with no matching artifact is
+treated as "no results" instead of a red failure, and `artifactName` now supports a
+`*` wildcard). This runbook is the **configuration** half: re-point the test types at
+the `CI` workflow.
+
+## Artifact reference (verified against Artemis `main`)
+
+| Test type | Artifact name (exact) | File inside | Parser support |
+|---|---|---|---|
+| Server unit | `Server JUnit Test Results` | `TEST-*.xml` | ✅ |
+| Client unit | `Vitest JUnit Test Results` | `junit.xml` | ✅ |
+| E2E (both phases) | `JUnit Test Results Phase *` | `results.xml` | ✅ |
+
+Artifact names are **case- and space-sensitive** — copy them verbatim. Helios's JUnit
+parser only reads files named `TEST-*.xml`, `results.xml`, or `junit.xml`; all three
+artifacts above comply.
+
+## Prerequisites
+
+- **Maintainer** role (or higher) on the Artemis repository in Helios.
+- PR **#1159 deployed** to prod (needed for the `*` wildcard and the "no results ≠
+  failure" behavior). Without it, use the two-row E2E fallback in Step 3.
+- The **`CI`** workflow (`ci.yml`) is visible in Helios (it appears after the first
+  `CI` run syncs; otherwise click **Fetch latest workflows** in Step 1).
+
+## Step 1 — Open repository settings
+
+1. Open the **Artemis** repository in Helios.
+2. Left sidebar → **Repository Settings** (adjustments/gear icon, Maintainer+ only).
+   URL is `…/repo/<id>/settings`; everything below applies only to this repository.
+3. Scroll to **Workflows**. If there is no row with **Workflow Name = `CI`**
+   (File Name `ci.yml`), click **Fetch latest workflows** and wait for the refresh.
+
+## Step 2 — Label the `CI` workflow as a test workflow (organizational)
+
+1. In the **Workflows** table, find the row **Workflow Name = `CI`** (`ci.yml`).
+2. In its **Label** column, select **`TEST`**.
+3. Confirm in the **Change Label** dialog ("Workflow Label updated successfully").
+
+> Ingestion is actually triggered by the **test types** in Step 3, not the label.
+> Labeling `CI` as `TEST` keeps the UI consistent and is harmless, but not strictly
+> required.
+
+## Step 3 — Add the three test types
+
+In **Test Types** → **Add Test Type**. For each row: set **Name**, set **Artifact
+Name** (exact), pick **Workflow = `CI`**, click **Add**.
+
+| Name (free choice) | Artifact Name (exact) | Workflow |
+|---|---|---|
+| `Server Tests` | `Server JUnit Test Results` | `CI` |
+| `Client Tests` | `Vitest JUnit Test Results` | `CI` |
+| `E2E Tests` | `JUnit Test Results Phase *` | `CI` |
+
+- The E2E value ends with a space then `*`; the wildcard matches both
+  `JUnit Test Results Phase 1` and `… Phase 2`, so one row covers both phases.
+- **Fallback (only if #1159 is NOT deployed):** create two rows instead of the E2E row
+  — exact names `JUnit Test Results Phase 1` and `JUnit Test Results Phase 2`.
+- `Name` must be unique within the repository (the form rejects duplicates).
+
+## Step 4 — Remove stale test types
+
+In the **Test Types** table, delete (trash icon → confirm) every row whose **Workflow**
+column is **not** `CI` (i.e. the old "Tests"/"E2E Tests" workflows). Optionally set those
+old workflows' **Label** back to `NONE`.
+
+## Step 5 — Verify
+
+1. Open or re-run a PR that touches server/client/E2E code so `CI` produces the artifacts.
+2. After `CI` completes, open that PR/branch in Helios — **Test Results** should populate
+   (Server / Client / E2E).
+3. Docs-only PRs (where `CI` skips the test jobs) correctly show **no results**, not a red
+   failure.
+4. If a configured type unexpectedly shows nothing, check the server log:
+   `No matching test artifacts for workflow run …; Artifacts present: [...]; configured
+   test-type artifact names: [...]` — it prints what the run produced vs. what's
+   configured, which pinpoints a typo'd Artifact Name.
+
+## Rollback
+
+Configuration-only and non-destructive: delete the three new test types and (if set)
+revert the `CI` workflow label to `NONE`. No deploy required.

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import lombok.RequiredArgsConstructor;
@@ -134,8 +135,15 @@ public class TestResultProcessor {
     }
 
     if (allTestSuites.isEmpty()) {
-      log.warn("No matching test artifacts found for workflow run {}", workflowRun.getName());
-      throw new TestResultException("No matching test artifacts found");
+      // Artemis's single conditional CI workflow (ci.yml) gates the test/e2e jobs on changed
+      // areas, so a COMPLETED run legitimately carries no matching test artifact (e.g. a docs-only
+      // PR, or a skipped job). That is "no results", not a failure: returning empty lets it be
+      // PROCESSED instead of FAILED, which would otherwise paint a red state and spam errors on
+      // every non-test PR. A genuine fetch/download error still throws above and ends up FAILED.
+      log.info(
+          "No matching test artifacts for workflow run {} (skipped jobs?); storing no results",
+          workflowRun.getName());
+      return allTestSuites;
     }
 
     log.debug("Parsed {} test suites across all artifacts. Persisting...", allTestSuites.size());
@@ -144,9 +152,42 @@ public class TestResultProcessor {
 
   private TestType findMatchingTestType(Set<TestType> testTypes, String artifactName) {
     return testTypes.stream()
-        .filter(testType -> testType.getArtifactName().equals(artifactName))
+        .filter(testType -> artifactNameMatches(testType.getArtifactName(), artifactName))
         .findFirst()
         .orElse(null);
+  }
+
+  /**
+   * Matches a configured {@link TestType#getArtifactName() artifact name} against an actual GitHub
+   * artifact name. A plain name matches exactly (backward-compatible). A name containing {@code *}
+   * is treated as a glob, where {@code *} matches any run of characters — e.g.
+   * {@code "JUnit Test Results Phase *"} matches both {@code "JUnit Test Results Phase 1"} and
+   * {@code "… Phase 2"}. This lets a single test type aggregate artifacts that a workflow splits
+   * across matrix/sharded/phased jobs (as Artemis's reusable CI now does for E2E).
+   */
+  private boolean artifactNameMatches(String pattern, String artifactName) {
+    if (pattern == null || artifactName == null) {
+      return false;
+    }
+    if (pattern.indexOf('*') < 0) {
+      return pattern.equals(artifactName);
+    }
+    return globToRegex(pattern).matcher(artifactName).matches();
+  }
+
+  /** Translates a {@code *}-glob into an anchored regex, quoting all other characters literally. */
+  private static Pattern globToRegex(String glob) {
+    StringBuilder regex = new StringBuilder();
+    String[] literals = glob.split("\\*", -1);
+    for (int i = 0; i < literals.length; i++) {
+      if (i > 0) {
+        regex.append(".*");
+      }
+      if (!literals[i].isEmpty()) {
+        regex.append(Pattern.quote(literals[i]));
+      }
+    }
+    return Pattern.compile(regex.toString());
   }
 
   private List<TestSuite> convertToTestSuites(List<TestResultParser.TestSuite> results) {

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/tests/TestResultProcessor.java
@@ -103,17 +103,20 @@ public class TestResultProcessor {
    */
   private List<TestSuite> processRunSync(WorkflowRun workflowRun) {
     List<TestSuite> allTestSuites = new ArrayList<>();
+    // Names of every artifact seen on the run; used to make a no-match diagnosable (see below).
+    List<String> seenArtifactNames = new ArrayList<>();
+
+    // Get all test types for this workflow
+    Set<TestType> testTypes = workflowRun.getWorkflow().getTestTypes();
 
     try {
       PagedIterable<GHArtifact> artifacts =
           this.gitHubService.getWorkflowRunArtifacts(
               workflowRun.getRepository().getRepositoryId(), workflowRun.getId());
 
-      // Get all test types for this workflow
-      Set<TestType> testTypes = workflowRun.getWorkflow().getTestTypes();
-
       // Process each artifact that matches a test type's artifact name
       for (GHArtifact artifact : artifacts) {
+        seenArtifactNames.add(artifact.getName());
         TestType matchingTestType = findMatchingTestType(testTypes, artifact.getName());
         if (matchingTestType != null) {
           List<TestSuite> testSuites = processTestResultArtifact(artifact);
@@ -140,9 +143,16 @@ public class TestResultProcessor {
       // PR, or a skipped job). That is "no results", not a failure: returning empty lets it be
       // PROCESSED instead of FAILED, which would otherwise paint a red state and spam errors on
       // every non-test PR. A genuine fetch/download error still throws above and ends up FAILED.
+      //
+      // Log the artifacts that WERE present alongside the configured artifact-name patterns so a
+      // stale/typo'd TestType config (the other reason nothing matches) stays diagnosable — the
+      // relaxation above otherwise makes a misconfiguration look identical to a skipped job.
       log.info(
-          "No matching test artifacts for workflow run {} (skipped jobs?); storing no results",
-          workflowRun.getName());
+          "No matching test artifacts for workflow run {}; storing no results. "
+              + "Artifacts present: {}; configured test-type artifact names: {}",
+          workflowRun.getName(),
+          seenArtifactNames,
+          testTypes.stream().map(TestType::getArtifactName).toList());
       return allTestSuites;
     }
 

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorIntegrationTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorIntegrationTest.java
@@ -1,0 +1,276 @@
+package de.tum.cit.aet.helios.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import de.tum.cit.aet.helios.github.GitHubService;
+import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
+import de.tum.cit.aet.helios.tests.parsers.JunitParser;
+import de.tum.cit.aet.helios.workflow.WorkflowRun;
+import de.tum.cit.aet.helios.workflow.WorkflowRunRepository;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.kohsuke.github.GHArtifact;
+import org.kohsuke.github.PagedIterable;
+import org.kohsuke.github.PagedIterator;
+import org.kohsuke.github.function.InputStreamFunction;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Integration test for {@link TestResultProcessor} against an embedded PostgreSQL (zonky) with the
+ * real Flyway schema, the real {@link JunitParser}, and the real
+ * {@link TestCaseStatisticsService}; only {@link GitHubService} (the artifact source) is mocked.
+ * This exercises what the mocked unit tests cannot:
+ *
+ * <ul>
+ *   <li>that a no-match run does NOT wipe pre-existing {@code test_case_statistics}/
+ *       {@code test_case_flakiness} rows (the safety claim of the throw-to-PROCESSED change),
+ *   <li>that real JUnit XML (named per Artemis's conventions: {@code TEST-*.xml}, {@code
+ *       results.xml}) actually parses and persists {@code test_suite}/{@code test_case} rows with
+ *       the correct {@code test_type_id} linkage, and
+ *   <li>that the {@code *}-glob aggregates two real phased artifacts under one test type.
+ * </ul>
+ */
+@DataJpaTest(properties = {"spring.flyway.enabled=true", "spring.jpa.hibernate.ddl-auto=none"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@AutoConfigureEmbeddedDatabase(
+    type = AutoConfigureEmbeddedDatabase.DatabaseType.POSTGRES,
+    provider = AutoConfigureEmbeddedDatabase.DatabaseProvider.DOCKER)
+@Import(TestResultProcessorIntegrationTest.CacheTestConfig.class)
+class TestResultProcessorIntegrationTest {
+
+  /** {@code @DataJpaTest} omits cache auto-config, but entities carry {@code @Cacheable}. */
+  @TestConfiguration
+  static class CacheTestConfig {
+    @Bean
+    CacheManager cacheManager() {
+      return new ConcurrentMapCacheManager();
+    }
+  }
+
+  private static final long REPO_ID = 1L;
+  private static final long RUN_ID = 1L;
+
+  private static final String VALID_JUNIT_XML =
+      """
+      <testsuite name="%s" tests="2" failures="1" errors="0" skipped="0" time="1.0"
+          timestamp="2026-03-27T11:34:31Z">
+        <testcase name="passes" classname="pkg.Foo" time="0.1"/>
+        <testcase name="fails" classname="pkg.Foo" time="0.2">
+          <failure message="boom" type="AssertionError">stack trace</failure>
+        </testcase>
+      </testsuite>
+      """;
+
+  @Autowired private WorkflowRunRepository workflowRunRepository;
+  @Autowired private GitRepoRepository gitRepoRepository;
+  @Autowired private TestCaseStatisticsRepository statisticsRepository;
+  @Autowired private TestCaseFlakinessRepository flakinessRepository;
+  @Autowired private DataSource dataSource;
+
+  private JdbcTemplate jdbc;
+  private GitHubService gitHubService;
+  private TestResultProcessor processor;
+
+  @BeforeEach
+  void setUp() {
+    jdbc = new JdbcTemplate(dataSource);
+
+    // Repository on default branch "main", a "CI" workflow, and a COMPLETED run on that branch.
+    jdbc.update(
+        "INSERT INTO repository (repository_id, has_issues, has_projects, has_wiki, is_archived, "
+            + "is_disabled, is_private, stargazers_count, watchers_count, name_with_owner, "
+            + "default_branch) VALUES (1, false, false, false, false, false, false, 0, 0, "
+            + "'ls1intum/Artemis', 'main')");
+    jdbc.update("INSERT INTO workflow (id, repository_id, name) VALUES (1, 1, 'CI')");
+    jdbc.update(
+        "INSERT INTO workflow_run (id, run_attempt, run_number, workflow_id, repository_id, "
+            + "head_branch, created_at) VALUES (1, 1, 1, 1, 1, 'main', now())");
+
+    gitHubService = mock(GitHubService.class);
+    processor =
+        new TestResultProcessor(
+            gitHubService,
+            workflowRunRepository,
+            gitRepoRepository,
+            new JunitParser(),
+            new TestCaseStatisticsService(statisticsRepository, flakinessRepository));
+  }
+
+  @Test
+  void noMatchRun_doesNotWipeExistingStatisticsOrFlakiness() throws IOException {
+    seedTestType("Server Tests", "Server JUnit Test Results");
+    // Pre-existing stats/flakiness rows from earlier runs that this no-match run must NOT touch.
+    jdbc.update(
+        "INSERT INTO test_case_statistics (repository_id, test_name, class_name, test_suite_name, "
+            + "branch_name, total_runs, failed_runs, last_updated) "
+            + "VALUES (1, 'oldTest', 'pkg.Old', 'OldSuite', 'main', 5, 1, now())");
+    jdbc.update(
+        "INSERT INTO test_case_flakiness (repository_id, test_name, class_name, test_suite_name, "
+            + "flakiness_score, default_branch_failure_rate, combined_failure_rate, last_updated) "
+            + "VALUES (1, 'oldTest', 'pkg.Old', 'OldSuite', 42.0, 0.2, 0.1, now())");
+
+    // The run produced only a non-matching artifact (e.g. a coverage report), so nothing matches.
+    stubArtifacts(nonMatchingArtifact("Coverage Report Server Tests"));
+
+    WorkflowRun run = workflowRunRepository.findById(RUN_ID).orElseThrow();
+    processor.processRun(run);
+
+    // No-match is "no results", not a failure — and existing stats/flakiness are untouched.
+    assertThat(run.getTestProcessingStatus()).isEqualTo(WorkflowRun.TestProcessingStatus.PROCESSED);
+    assertThat(countTestSuitesForRun()).isZero();
+    assertThat(statisticsRepository.count()).isEqualTo(1L);
+    assertThat(flakinessRepository.count()).isEqualTo(1L);
+  }
+
+  @Test
+  void matchingArtifact_parsesRealJunitXmlAndPersistsSuitesWithTestType() throws IOException {
+    seedTestType("Server Tests", "Server JUnit Test Results");
+    long testTypeId = testTypeId();
+
+    stubArtifacts(
+        artifact("Server JUnit Test Results", "TEST-pkg.Foo.xml", xml("ServerSuite")));
+
+    WorkflowRun run = workflowRunRepository.findById(RUN_ID).orElseThrow();
+    processor.processRun(run);
+
+    assertThat(run.getTestProcessingStatus()).isEqualTo(WorkflowRun.TestProcessingStatus.PROCESSED);
+    // The real JunitParser parsed the real TEST-*.xml; the suite/cases persisted and are linked
+    // to the test type.
+    assertThat(countTestSuitesForRun()).isEqualTo(1L);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT test_type_id FROM test_suite WHERE workflow_run_id = 1", Long.class))
+        .isEqualTo(testTypeId);
+    assertThat(countTestCases()).isEqualTo(2L);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(*) FROM test_case WHERE status = 'FAILED'", Integer.class))
+        .isEqualTo(1);
+    // The real TestCaseStatisticsService ran on the default branch and created rows.
+    assertThat(statisticsRepository.count()).isGreaterThan(0L);
+  }
+
+  @Test
+  void globTestType_aggregatesTwoPhasedArtifactsUnderOneTestType() throws IOException {
+    seedTestType("E2E Tests", "JUnit Test Results Phase *");
+    long testTypeId = testTypeId();
+
+    stubArtifacts(
+        artifact("JUnit Test Results Phase 1", "results.xml", xml("PhaseOneSuite")),
+        artifact("JUnit Test Results Phase 2", "results.xml", xml("PhaseTwoSuite")));
+
+    WorkflowRun run = workflowRunRepository.findById(RUN_ID).orElseThrow();
+    processor.processRun(run);
+
+    assertThat(run.getTestProcessingStatus()).isEqualTo(WorkflowRun.TestProcessingStatus.PROCESSED);
+    // Both phased artifacts matched the single glob test type and persisted under it.
+    assertThat(countTestSuitesForRun()).isEqualTo(2L);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT count(DISTINCT test_type_id) FROM test_suite WHERE workflow_run_id = 1",
+                Integer.class))
+        .isEqualTo(1);
+    assertThat(
+            jdbc.queryForObject(
+                "SELECT test_type_id FROM test_suite WHERE workflow_run_id = 1 LIMIT 1",
+                Long.class))
+        .isEqualTo(testTypeId);
+  }
+
+  // --- helpers ---
+
+  private void seedTestType(String name, String artifactName) {
+    jdbc.update(
+        "INSERT INTO test_type (name, artifact_name, workflow_id, repository_id) "
+            + "VALUES (?, ?, 1, 1)",
+        name,
+        artifactName);
+  }
+
+  private long testTypeId() {
+    return jdbc.queryForObject("SELECT id FROM test_type WHERE repository_id = 1", Long.class);
+  }
+
+  private long countTestSuitesForRun() {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM test_suite WHERE workflow_run_id = 1", Long.class);
+  }
+
+  private long countTestCases() {
+    return jdbc.queryForObject("SELECT count(*) FROM test_case", Long.class);
+  }
+
+  private static String xml(String suiteName) {
+    return String.format(VALID_JUNIT_XML, suiteName);
+  }
+
+  /** A mocked artifact whose name matches nothing of interest; its content is never downloaded. */
+  private static GHArtifact nonMatchingArtifact(String name) {
+    GHArtifact artifact = mock(GHArtifact.class);
+    when(artifact.getName()).thenReturn(name);
+    return artifact;
+  }
+
+  /** A mocked artifact whose {@code download(...)} replays a real ZIP containing one XML entry. */
+  private static GHArtifact artifact(String name, String entryName, String xmlContent)
+      throws IOException {
+    byte[] zip = zip(entryName, xmlContent);
+    GHArtifact artifact = mock(GHArtifact.class);
+    when(artifact.getName()).thenReturn(name);
+    when(artifact.download(any()))
+        .thenAnswer(
+            invocation -> {
+              InputStreamFunction<List<TestSuite>> fn = invocation.getArgument(0);
+              return fn.apply(new ByteArrayInputStream(zip));
+            });
+    return artifact;
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubArtifacts(GHArtifact... artifacts) throws IOException {
+    PagedIterable<GHArtifact> iterable = mock(PagedIterable.class);
+    // Return a fresh iterator on each call so the result is re-iterable.
+    when(iterable.iterator())
+        .thenAnswer(
+            invocation -> {
+              Iterator<GHArtifact> source = Arrays.asList(artifacts).iterator();
+              PagedIterator<GHArtifact> it = mock(PagedIterator.class);
+              when(it.hasNext()).thenAnswer(i -> source.hasNext());
+              when(it.next()).thenAnswer(i -> source.next());
+              return it;
+            });
+    when(gitHubService.getWorkflowRunArtifacts(anyLong(), anyLong())).thenReturn(iterable);
+  }
+
+  private static byte[] zip(String entryName, String content) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+      zos.putNextEntry(new ZipEntry(entryName));
+      zos.write(content.getBytes());
+      zos.closeEntry();
+    }
+    return baos.toByteArray();
+  }
+}

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
@@ -20,6 +20,7 @@ import de.tum.cit.aet.helios.github.GitHubService;
 import de.tum.cit.aet.helios.gitrepo.GitRepoRepository;
 import de.tum.cit.aet.helios.gitrepo.GitRepository;
 import de.tum.cit.aet.helios.tests.parsers.JunitParser;
+import de.tum.cit.aet.helios.tests.parsers.TestResultParseException;
 import de.tum.cit.aet.helios.tests.parsers.TestResultParser;
 import de.tum.cit.aet.helios.tests.type.TestType;
 import de.tum.cit.aet.helios.workflow.Workflow;
@@ -347,6 +348,40 @@ class TestResultProcessorTest {
     testResultProcessor.processRun(workflowRun);
 
     // No match (dot is literal) -> no results, but PROCESSED rather than FAILED.
+    assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
+    assertNotNull(workflowRun.getTestSuites());
+    assertTrue(workflowRun.getTestSuites().isEmpty());
+  }
+
+  @Test
+  void processRun_marksProcessedWithNoResults_whenMatchedArtifactFailsToParse() throws IOException {
+    // Artifact matches a test type, but its XML is unparseable: processTestResultArtifact swallows
+    // the per-file parse error, so the run yields no suites -> PROCESSED (empty), not FAILED.
+    GHArtifact mockArtifact = mock(GHArtifact.class);
+    when(mockArtifact.getName()).thenReturn("java-test-results"); // matches javaTestType
+    byte[] zipBytes = createMockZip("test-results.xml", "<not-valid-junit".getBytes());
+    when(mockArtifact.download(any()))
+        .thenAnswer(
+            invocation -> {
+              InputStreamFunction<List<TestSuite>> function = invocation.getArgument(0);
+              return function.apply(new ByteArrayInputStream(zipBytes));
+            });
+
+    @SuppressWarnings("unchecked")
+    PagedIterator<GHArtifact> mockPagedIterator = mock(PagedIterator.class);
+    when(mockPagedIterator.hasNext()).thenReturn(true, false);
+    when(mockPagedIterator.next()).thenReturn(mockArtifact);
+    @SuppressWarnings("unchecked")
+    PagedIterable<GHArtifact> artifacts = mock(PagedIterable.class);
+    when(artifacts.iterator()).thenReturn(mockPagedIterator);
+    when(gitHubService.getWorkflowRunArtifacts(anyLong(), anyLong())).thenReturn(artifacts);
+
+    when(junitParser.supports(eq("test-results.xml"))).thenReturn(true);
+    when(junitParser.parse(any(InputStream.class)))
+        .thenThrow(new TestResultParseException("unparseable xml"));
+
+    testResultProcessor.processRun(workflowRun);
+
     assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
     assertNotNull(workflowRun.getTestSuites());
     assertTrue(workflowRun.getTestSuites().isEmpty());

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
@@ -133,8 +133,8 @@ class TestResultProcessorTest {
 
   // --- Tests for processRun ---
   @Test
-  void processRun_setsStatusToProcessingAndSavesCorrectly() throws IOException {
-    // Mock to avoid NPE and ensure "No matching test artifacts" path
+  void processRun_marksProcessedWithNoResults_whenRunHasNoArtifacts() throws IOException {
+    // A completed CI run can legitimately carry no test artifact (conditional/skipped jobs).
     @SuppressWarnings("unchecked")
     PagedIterable<GHArtifact> emptyArtifacts = mock(PagedIterable.class);
     @SuppressWarnings("unchecked")
@@ -159,10 +159,12 @@ class TestResultProcessorTest {
     // Verify save was called twice
     verify(workflowRunRepository, times(2)).save(any(WorkflowRun.class));
 
-    // Assert the captured statuses
+    // No artifacts is "no results", not a failure: PROCESSING -> PROCESSED with empty suites.
     assertEquals(2, capturedStatuses.size());
     assertEquals(WorkflowRun.TestProcessingStatus.PROCESSING, capturedStatuses.get(0));
-    assertEquals(WorkflowRun.TestProcessingStatus.FAILED, capturedStatuses.get(1));
+    assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, capturedStatuses.get(1));
+    assertNotNull(workflowRun.getTestSuites());
+    assertTrue(workflowRun.getTestSuites().isEmpty());
   }
 
   @Test
@@ -228,16 +230,12 @@ class TestResultProcessorTest {
   }
 
   @Test
-  void processRun_setsStatusToFailed_whenNoMatchingArtifactsFound() throws IOException {
+  void processRun_marksProcessedWithNoResults_whenNoArtifactMatchesTestType() throws IOException {
     GHArtifact mockArtifact = mock(GHArtifact.class);
     when(mockArtifact.getName()).thenReturn("other-artifact"); // Does not match javaTestType
 
-    // Mock PagedIterator to be empty or not contain matching artifacts
     @SuppressWarnings("unchecked")
     PagedIterator<GHArtifact> mockPagedIterator = mock(PagedIterator.class);
-    // Option 1: Iterator is empty
-    // when(mockPagedIterator.hasNext()).thenReturn(false);
-    // Option 2: Iterator has one non-matching artifact (as per original intent)
     when(mockPagedIterator.hasNext()).thenReturn(true, false);
     when(mockPagedIterator.next()).thenReturn(mockArtifact);
 
@@ -249,9 +247,69 @@ class TestResultProcessorTest {
 
     testResultProcessor.processRun(workflowRun);
 
-    assertEquals(WorkflowRun.TestProcessingStatus.FAILED, workflowRun.getTestProcessingStatus());
-    assertNull(workflowRun.getTestSuites());
+    // No matching artifact is "no results" for this run, not a failure.
+    assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
+    assertNotNull(workflowRun.getTestSuites());
+    assertTrue(workflowRun.getTestSuites().isEmpty());
     verify(workflowRunRepository, times(2)).save(workflowRun);
+  }
+
+  @Test
+  void processRun_aggregatesPhasedArtifactsMatchedByGlob() throws IOException {
+    // One test type whose artifact name is a glob spanning both E2E phases.
+    TestType e2eTestType = new TestType();
+    e2eTestType.setId(2L);
+    e2eTestType.setName("E2E Tests");
+    e2eTestType.setArtifactName("JUnit Test Results Phase *");
+    workflow.setTestTypes(Set.of(e2eTestType));
+
+    GHArtifact phase1 = mock(GHArtifact.class);
+    when(phase1.getName()).thenReturn("JUnit Test Results Phase 1");
+    GHArtifact phase2 = mock(GHArtifact.class);
+    when(phase2.getName()).thenReturn("JUnit Test Results Phase 2");
+
+    byte[] zip1 = createMockZip("results.xml", "<testsuite name='P1'></testsuite>".getBytes());
+    byte[] zip2 = createMockZip("results.xml", "<testsuite name='P2'></testsuite>".getBytes());
+    when(phase1.download(any()))
+        .thenAnswer(
+            invocation -> {
+              InputStreamFunction<List<TestSuite>> fn = invocation.getArgument(0);
+              return fn.apply(new ByteArrayInputStream(zip1));
+            });
+    when(phase2.download(any()))
+        .thenAnswer(
+            invocation -> {
+              InputStreamFunction<List<TestSuite>> fn = invocation.getArgument(0);
+              return fn.apply(new ByteArrayInputStream(zip2));
+            });
+
+    @SuppressWarnings("unchecked")
+    PagedIterator<GHArtifact> mockPagedIterator = mock(PagedIterator.class);
+    when(mockPagedIterator.hasNext()).thenReturn(true, true, false);
+    when(mockPagedIterator.next()).thenReturn(phase1, phase2);
+    @SuppressWarnings("unchecked")
+    PagedIterable<GHArtifact> artifacts = mock(PagedIterable.class);
+    when(artifacts.iterator()).thenReturn(mockPagedIterator);
+    when(gitHubService.getWorkflowRunArtifacts(anyLong(), anyLong())).thenReturn(artifacts);
+
+    when(junitParser.supports(eq("results.xml"))).thenReturn(true);
+    TestResultParser.TestSuite s1 =
+        new TestResultParser.TestSuite(
+            "P1", LocalDateTime.now(), 1, 0, 0, 0, 0.0, "", Collections.emptyList());
+    TestResultParser.TestSuite s2 =
+        new TestResultParser.TestSuite(
+            "P2", LocalDateTime.now(), 1, 0, 0, 0, 0.0, "", Collections.emptyList());
+    when(junitParser.parse(any(InputStream.class))).thenReturn(List.of(s1), List.of(s2));
+    when(gitRepoRepository.findById(anyLong())).thenReturn(Optional.of(gitRepository));
+
+    testResultProcessor.processRun(workflowRun);
+
+    assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
+    assertNotNull(workflowRun.getTestSuites());
+    // Both phases parsed and aggregated under the single E2E test type.
+    assertEquals(2, workflowRun.getTestSuites().size());
+    assertTrue(
+        workflowRun.getTestSuites().stream().allMatch(ts -> ts.getTestType() == e2eTestType));
   }
 
   @Test

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/tests/TestResultProcessorTest.java
@@ -283,10 +283,15 @@ class TestResultProcessorTest {
               return fn.apply(new ByteArrayInputStream(zip2));
             });
 
+    // A third, non-matching artifact that must be excluded — proves the glob is selective and
+    // does not simply match everything.
+    GHArtifact nonMatching = mock(GHArtifact.class);
+    when(nonMatching.getName()).thenReturn("Coverage Report Server Tests");
+
     @SuppressWarnings("unchecked")
     PagedIterator<GHArtifact> mockPagedIterator = mock(PagedIterator.class);
-    when(mockPagedIterator.hasNext()).thenReturn(true, true, false);
-    when(mockPagedIterator.next()).thenReturn(phase1, phase2);
+    when(mockPagedIterator.hasNext()).thenReturn(true, true, true, false);
+    when(mockPagedIterator.next()).thenReturn(phase1, phase2, nonMatching);
     @SuppressWarnings("unchecked")
     PagedIterable<GHArtifact> artifacts = mock(PagedIterable.class);
     when(artifacts.iterator()).thenReturn(mockPagedIterator);
@@ -306,10 +311,45 @@ class TestResultProcessorTest {
 
     assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
     assertNotNull(workflowRun.getTestSuites());
-    // Both phases parsed and aggregated under the single E2E test type.
+    // Both phases parsed and aggregated under the single E2E test type; the non-matching artifact
+    // is excluded (size stays 2), and each phase's suite is present.
     assertEquals(2, workflowRun.getTestSuites().size());
     assertTrue(
         workflowRun.getTestSuites().stream().allMatch(ts -> ts.getTestType() == e2eTestType));
+    List<String> suiteNames =
+        workflowRun.getTestSuites().stream().map(TestSuite::getName).toList();
+    assertTrue(suiteNames.contains("P1"));
+    assertTrue(suiteNames.contains("P2"));
+  }
+
+  @Test
+  void processRun_treatsRegexMetacharactersInGlobAsLiterals() throws IOException {
+    // A '.' in the configured pattern must match a literal dot, not "any char": pattern "a.b *"
+    // must NOT match artifact "aXb 1". Guards that globToRegex quotes regex metacharacters.
+    TestType weirdType = new TestType();
+    weirdType.setId(3L);
+    weirdType.setName("Weird");
+    weirdType.setArtifactName("a.b *");
+    workflow.setTestTypes(Set.of(weirdType));
+
+    GHArtifact artifact = mock(GHArtifact.class);
+    when(artifact.getName()).thenReturn("aXb 1"); // '.' literal -> does NOT match
+
+    @SuppressWarnings("unchecked")
+    PagedIterator<GHArtifact> mockPagedIterator = mock(PagedIterator.class);
+    when(mockPagedIterator.hasNext()).thenReturn(true, false);
+    when(mockPagedIterator.next()).thenReturn(artifact);
+    @SuppressWarnings("unchecked")
+    PagedIterable<GHArtifact> artifacts = mock(PagedIterable.class);
+    when(artifacts.iterator()).thenReturn(mockPagedIterator);
+    when(gitHubService.getWorkflowRunArtifacts(anyLong(), anyLong())).thenReturn(artifacts);
+
+    testResultProcessor.processRun(workflowRun);
+
+    // No match (dot is literal) -> no results, but PROCESSED rather than FAILED.
+    assertEquals(WorkflowRun.TestProcessingStatus.PROCESSED, workflowRun.getTestProcessingStatus());
+    assertNotNull(workflowRun.getTestSuites());
+    assertTrue(workflowRun.getTestSuites().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Problem

The test display for Artemis is broken on PRs/branches. Artemis recently migrated its CI from **chained, per-workflow runs** to a **single `CI` orchestrator** (`ci.yml`) that calls reusable workflows (`ci-build.yml`, `ci-test.yml`, `ci-e2e.yml`, …) via `uses: ./… ` (`on: workflow_call`).

Helios attributes test results by `TestType { workflow, artifactName }` and matches each artifact name **exactly**. The restructure broke this in two ways:

1. **Artifacts moved + renamed.** Reusable-workflow jobs attach their artifacts to the **top-level `CI` run** under new names. The old `TestType`s point at the now-retired "Tests"/"E2E Tests" workflows, so `shouldProcess` sees no test types on the `CI` workflow and nothing is ingested → empty PR/branch test view. *(This part is fixed by configuration — see below.)*
2. **"No artifacts" is now normal, but was treated as a failure.** `ci.yml` gates the `test`/`e2e` jobs on changed areas (`if: needs.detect-changes.outputs.build_relevant == 'true'`), so a docs-only PR produces a completed `CI` run with **no** test artifact. `TestResultProcessor` threw `TestResultException("No matching test artifacts found")` → the run was marked **`FAILED`**, painting a red state and spamming errors on most PRs.
3. **E2E is split into two phased artifacts** (`JUnit Test Results Phase 1` / `Phase 2`), but the model was one artifact ↔ one `TestType`.

The `workflow-context` mechanism is **not** the cause: the new `CI` is triggered directly by `pull_request`/`push`, so branch/PR attribution is native; no context artifact is needed.

## Code changes (this PR)

- **No matching artifact → `PROCESSED` (empty), not `FAILED`.** A completed run with no matching artifact is "no results for this change", not an error. Genuine fetch/download errors still end up `FAILED`.
- **`TestType.artifactName` supports a `*` glob.** Plain names still match exactly (fully backward-compatible); a name like `JUnit Test Results Phase *` lets one test type aggregate artifacts split across phased/sharded jobs.
- Tests updated for the no-results behavior + a new test for glob aggregation across phased artifacts.

## Required configuration (must be applied for the display to come back)

The code is necessary but **not sufficient** — the Helios test-type config for `ls1intum/Artemis` must be re-pointed at the new `CI` workflow. After a `CI` run has synced (so the "CI" workflow exists in Helios), as a Maintainer+:

1. **Mark the "CI" workflow as a test workflow** (`PUT /api/workflows/{ciWorkflowId}/label` → `TEST`).
2. **Create three `TestType`s on the "CI" workflow** (`POST /api/test-types`) with these exact artifact names:

   | name | artifactName | source |
   |---|---|---|
   | Server Tests | `Server JUnit Test Results` | `ci-test.yml` |
   | Client Tests | `Vitest JUnit Test Results` | `ci-test.yml` |
   | E2E Tests | `JUnit Test Results Phase *` | `ci-e2e.yml` (both phases, via the new glob) |

3. **Delete the stale `TestType`s** pointing at the retired "Tests"/"E2E Tests" workflows.

**Verify:** Helios only parses `TEST-*.xml`, `results.xml`, or `junit.xml` inside an artifact (`JunitParser.supports()`). Server (`TEST-*.xml`) and E2E (`results.xml`) are confirmed. Confirm the file inside `Vitest JUnit Test Results` is `junit.xml`; if the vitest reporter emits another name, either rename it in Artemis CI or extend `supports()`.

## Verification
- `./gradlew :application-server:test --tests 'de.tum.cit.aet.helios.tests.*'` — green.
- New test `processRun_aggregatesPhasedArtifactsMatchedByGlob` proves Phase 1 + Phase 2 aggregate under one test type; `processRun_marksProcessedWithNoResults_*` prove skipped-job runs no longer go `FAILED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
