### PR TITLE
ci(starter): fix Maven Central signing secrets and target JDK 25

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -31,11 +31,11 @@ jobs:
       # so any `run:` step must come after it.
       - uses: actions/checkout@v7
       - run: echo "Releasing helios-status-spring-starter version $VERSION"
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
 
       - name: Build
         run: ./gradlew build -PVERSION_NAME="$VERSION"
@@ -46,8 +46,8 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
 
       # https://central.sonatype.com/publishing/deployments
       - name: Publish to Maven Central
@@ -55,5 +55,5 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/server/helios-status-spring-starter/CHANGELOG.md
+++ b/server/helios-status-spring-starter/CHANGELOG.md
@@ -29,13 +29,18 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
 
 ---
 
-## [1.2.0] – 2026-06-20
+## [1.2.0] – 2026-07-02
 ### Changed
 - **Build system:** migrated the starter from Maven to Gradle (standalone Gradle build with
   the Vanniktech `maven-publish` plugin; published to Maven Central via the Sonatype Central
   Portal and to GitHub Packages). No source or runtime behaviour change.
+- **Spring Boot:** built against the Spring Boot **4.1.0** dependency BOM.
+- **Java baseline:** the starter is now compiled for **Java 25** (previously Java 21).
 
 ### Migration notes
+- **Requires JDK 25+:** the artifact now targets Java 25 bytecode, so consuming applications
+  must run on Java 25 or newer. Apps on an older JDK will fail to load the starter with
+  `UnsupportedClassVersionError`.
 - The published POM no longer lists the former `provided`-scope dependencies (`slf4j-api`,
   `hibernate-validator`); Gradle keeps them off the published model. They were non-transitive
   under Maven too, so consumers are unaffected.
@@ -76,7 +81,8 @@ The format follows **[Keep a Changelog 1.1.0]** and the project adheres to **[Se
     - Heart-beat every 30 s (configurable).
     - Package README and comprehensive publishing instructions.
 
-[Unreleased]:   https://github.com/ls1intum/Helios/compare/helios-starter-v1.1.0...HEAD
+[Unreleased]:   https://github.com/ls1intum/Helios/compare/helios-starter-v1.2.0...HEAD
+[1.2.0]:        https://github.com/ls1intum/Helios/compare/helios-starter-v1.1.0...helios-starter-v1.2.0
 [1.1.0]:        https://github.com/ls1intum/Helios/compare/helios-starter-v1.0.0...helios-starter-v1.1.0
 [1.0.0]:        https://github.com/ls1intum/Helios/tree/helios-starter-v1.0.0
 [Keep a Changelog 1.1.0]: https://keepachangelog.com/en/1.1.0/

--- a/server/helios-status-spring-starter/build.gradle
+++ b/server/helios-status-spring-starter/build.gradle
@@ -18,7 +18,7 @@ ext {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 


### PR DESCRIPTION
### Motivation
The `helios-status-spring-starter` **1.2.0** release to Maven Central never went out: every dispatch of the release workflow died at `:signMavenPublication` with **`Could not read PGP secret key`**.

Root cause: the workflow fed Gradle `secrets.MAVEN_GPG_PRIVATE_KEY` / `secrets.MAVEN_GPG_PASSPHRASE`, which **do not exist** anywhere (repo, `publish-maven` environment, or org). They resolved to empty strings, so signing failed before anything could be uploaded. The signing key exists at the org level under different names — `GPG_KEY` / `GPG_PASSPHRASE` — and is the same key that signed 1.0.0–1.1.1.

### Description
- **`release-maven.yml`** — point the in-memory signing key/passphrase at the org secrets `GPG_KEY` / `GPG_PASSPHRASE` (both the GitHub Packages and Maven Central steps).
- **`build.gradle`** — bump the Gradle toolchain from Java 21 to **Java 25** (latest LTS); the workflow's `setup-java` step now installs JDK 25.
- **`CHANGELOG.md`** — cut the `1.2.0` entry for today, record the Spring Boot 4.1.0 build, and flag the **JDK 25 baseline** as a breaking change (consumers must run JDK 25+ or hit `UnsupportedClassVersionError`).

> **Note for merge:** the org secrets `GPG_KEY` / `GPG_PASSPHRASE` are "selected-visibility" and Helios is **not yet** in their allow-list. An org admin must add Helios (repo id `880304517`) to both before dispatching the release, otherwise signing will still see empty secrets.

### Testing Instructions
CI/build change — no runtime UI to exercise. Verified locally on JDK 25 (`openjdk 25.0.3`):
- `./gradlew build -PVERSION_NAME=1.2.0` → **BUILD SUCCESSFUL** (compile + `checkstyleMain` pass).
- `./gradlew javadoc plainJavadocJar` → **BUILD SUCCESSFUL** (only pre-existing "no comment" warnings).

End-to-end publish is validated by dispatching **Release Helios starter to GitHub Packages and Maven Central** with `releaseversion=1.2.0` after this merges and the org-secret access is granted.

### Checklist
#### General
- [x] PR description explains the purpose and changes (Conventional Commits).
- [x] Changes have been tested locally.

#### Server
- [x] Code is performant and follows best practices.
