### PR TITLE
fix(ci): authenticate Maven Central with the org OSSRH_TOKEN

### DIFF
--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -41,7 +41,11 @@ jobs:
         run: ./gradlew build -PVERSION_NAME="$VERSION"
 
       # https://github.com/ls1intum/Helios/packages
+      # Secondary mirror only — don't fail the release if this version already exists
+      # here (GitHub Packages returns 409 when re-publishing a release version, e.g. on a
+      # retry after the Maven Central step failed). Maven Central below is the source of truth.
       - name: Publish to GitHub Packages
+        continue-on-error: true
         run: ./gradlew publishMavenPublicationToGitHubPackagesRepository -PVERSION_NAME="$VERSION"
         env:
           GITHUB_ACTOR: ${{ github.actor }}
@@ -54,6 +58,6 @@ jobs:
         run: ./gradlew publishAndReleaseToMavenCentral -PVERSION_NAME="$VERSION"
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}


### PR DESCRIPTION
### Motivation
Follow-up to #1161. The starter **1.2.0** release then built and signed correctly and published to **GitHub Packages**, but the **Maven Central** step failed:

```
Failed to stop service 'maven-central-build-service'.
> Upload failed: {"error":{"message":"Invalid token"}}
```

The `publish-maven` environment held a **stale** Sonatype Central Portal token (`OSSRH_USERNAME` / `OSSRH_PASSWORD`, 2025-05-30) that was rotated org-wide on 2025-06-23. The valid, current token is the org's `OSSRH_USERNAME` + `OSSRH_TOKEN` pair — the same one Athena-CoFee and edutelligence publish with.

### Description
- **`release-maven.yml`** — point the Central password at **`OSSRH_TOKEN`** (was `OSSRH_PASSWORD`).
- **`release-maven.yml`** — mark **Publish to GitHub Packages** `continue-on-error: true`. It's the secondary mirror and returns **409** when re-publishing an existing release version; without this, a Central retry would fail on the already-published 1.2.0 before ever reaching Central.

Out-of-band secret changes already applied (can't be done in the workflow file):
- Granted Helios access to org secrets `OSSRH_USERNAME` + `OSSRH_TOKEN`.
- Deleted the stale `OSSRH_USERNAME` / `OSSRH_PASSWORD` from the `publish-maven` environment so the org values take effect (env secrets override org secrets of the same name).

### Testing Instructions
CI/build change — no runtime UI. Validated end-to-end by re-dispatching **Release Helios starter to GitHub Packages and Maven Central** with `releaseversion=1.2.0` after merge; success = `de.tum.cit.aet:helios-status-spring-starter:1.2.0` appears on Maven Central.

### Checklist
#### General
- [x] PR description explains the purpose and changes (Conventional Commits).
