### PR TITLE
fix(client): anchor pending-approvals badge to the avatar so it doesn't clip in the header

### DIFF
--- a/client/src/app/components/profile-nav-section/profile-nav-section.component.html
+++ b/client/src/app/components/profile-nav-section/profile-nav-section.component.html
@@ -1,11 +1,17 @@
 <div class="flex flex-col gap-3 items-center">
   @if (isLoggedIn()) {
-    <p-button class="flex gap-3 items-center cursor-pointer relative" (click)="profileMenu.toggle($event)" size="small">
-      <p-avatar class="size-5 flex-shrink-0" shape="circle" size="normal" [image]="getProfilePictureUrl()" />
-      <span class="hidden md:block text-md runcate overflow-hidden whitespace-nowrap max-w-[130px]">{{ fullName() }}</span>
-      @if (pendingApprovalsCount() > 0) {
-        <p-badge [value]="pendingApprovalsCount().toString()" severity="warn" class="!absolute -top-1 -right-1" />
-      }
+    <p-button class="flex gap-3 items-center cursor-pointer" (click)="profileMenu.toggle($event)" size="small">
+      <span class="relative inline-flex flex-shrink-0">
+        <p-avatar class="size-5" shape="circle" size="normal" [image]="getProfilePictureUrl()" />
+        @if (pendingApprovalsCount() > 0) {
+          <p-badge
+            [value]="pendingApprovalsCount().toString()"
+            severity="warn"
+            class="!absolute -top-1.5 -right-1.5 !flex !items-center !justify-center !h-[1.1rem] !min-w-[1.1rem] !p-0 !text-[0.65rem] !leading-none"
+          />
+        }
+      </span>
+      <span class="hidden md:block text-md truncate max-w-[130px]">{{ fullName() }}</span>
     </p-button>
   } @else {
     <p-button (click)="login()" class="rounded-xl flex items-center justify-center gap-2 w-full" size="small">


### PR DESCRIPTION
The pending-approvals count badge was absolutely positioned at the profile **button's** top-right corner (`-top-1 -right-1`). In the tight top header (`py-1.5`) inside an `overflow-hidden` main, that corner is at the header's top edge, so the badge overflowed above it and was **clipped** (and floated far-right past the user's name).

**Fix:** anchor the badge to the **avatar** (relative wrapper) as a compact corner overlay — the avatar's top is more interior, so the badge has headroom and reads as a notification count on the profile picture. Shrank it to fit the 20px avatar, and fixed an adjacent `runcate` → `truncate` typo so long names ellipsize.

Verified: `ng build --configuration production` succeeds, eslint clean. Best confirmed visually on staging (logged in with a pending approval).