### PR TITLE
ci(deploy): enable orphan-branch cleanup in the prod deploy

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -126,6 +126,7 @@ jobs:
             echo "EMAIL_FROM=${{ vars.EMAIL_FROM }}" >> .env
             
             echo "CLEANUP_WORKFLOW_RUN_DRY_RUN=${{ vars.CLEANUP_WORKFLOW_RUN_DRY_RUN }}" >> .env
+            echo "CLEANUP_WORKFLOW_RUN_ORPHAN_BRANCHES_ENABLED=${{ vars.CLEANUP_WORKFLOW_RUN_ORPHAN_BRANCHES_ENABLED }}" >> .env
             echo "HELIOS_ENVIRONMENT_NAME=${{ vars.HELIOS_ENVIRONMENT_NAME }}" >> .env
             echo "HELIOS_PROD_SECRET_KEY=${{ secrets.HELIOS_PROD_SECRET_KEY }}" >> .env
             echo "HELIOS_STAGING_SECRET_KEY=${{ secrets.HELIOS_STAGING_SECRET_KEY }}" >> .env


### PR DESCRIPTION
The `production` env variable `CLEANUP_WORKFLOW_RUN_ORPHAN_BRANCHES_ENABLED` is already `true`, but `deploy_docker.yml` never wrote it into the container `.env` (only `DRY_RUN`), so compose used its `:-false` default and the orphan-branch sweep stayed **disabled**. This adds the one missing `.env` line (same pattern as `DRY_RUN`) so the sweep is enabled on the next deploy. `GRACE_DAYS`/`BATCH_SIZE` keep compose defaults (7 days / 5000).

⚠️ With `DRY_RUN=false`, the first sweep will delete runs for **all GitHub-deleted branches** (a large, backup-covered delete). Reclaiming disk still needs a follow-up `VACUUM FULL`.