### PR TITLE
fix(perf,tenancy): fix /environments/enabled CPU storm + restore per-repo scoping on web reads

### DIFF
--- a/.github/workflows/deploy_docker.yml
+++ b/.github/workflows/deploy_docker.yml
@@ -90,6 +90,7 @@ jobs:
             echo "NATS_DURABLE_CONSUMER_NAME=${{ vars.NATS_DURABLE_CONSUMER_NAME }}" >> .env
             echo "NATS_CONSUMER_INACTIVE_THRESHOLD_MINUTES=${{ vars.NATS_CONSUMER_INACTIVE_THRESHOLD_MINUTES }}" >> .env
             echo "NATS_CONSUMER_ACK_WAIT_SECONDS=${{ vars.NATS_CONSUMER_ACK_WAIT_SECONDS }}" >> .env
+            echo "NATS_CONSUMER_MAX_ACK_PENDING=${{ vars.NATS_CONSUMER_MAX_ACK_PENDING }}" >> .env
             echo "WEBHOOK_SECRET=${{ secrets.WEBHOOK_SECRET }}" >> .env
             echo "REPOSITORY_NAME=${{ vars.REPOSITORY_NAME }}" >> .env
             echo "ORGANIZATION_NAME=${{ vars.ORGANIZATION_NAME }}" >> .env

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/config/SecurityConfig.java
@@ -95,7 +95,10 @@ public class SecurityConfig {
 
       @Override
       public void addInterceptors(@NonNull InterceptorRegistry registry) {
-        registry.addWebRequestInterceptor(requestInterceptor);
+        // Order last (Integer.MAX_VALUE == Ordered.LOWEST_PRECEDENCE) so this runs AFTER Spring's
+        // Open-Session-In-View interceptor. That guarantees the request's EntityManager is already
+        // bound when RepositoryInterceptor enables the tenant filter on it.
+        registry.addWebRequestInterceptor(requestInterceptor).order(Integer.MAX_VALUE);
       }
 
       @Override

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/environment/EnvironmentService.java
@@ -67,7 +67,6 @@ public class EnvironmentService {
   private final ReleaseCandidateRepository releaseCandidateRepository;
   private final DeploymentRepository deploymentRepository;
   @Lazy private final GitRepoSettingsService gitRepoSettingsService;
-  private final EnvironmentScheduler environmentScheduler;
   private final WorkflowRepository workflowRepository;
   private final WorkflowRunRepository workflowRunRepository;
   private final ProtectionRuleRepository protectionRuleRepository;
@@ -89,7 +88,6 @@ public class EnvironmentService {
     return environmentRepository.findAllByOrderByNameAsc().stream()
         .map(
             environment -> {
-              environmentScheduler.unlockExpiredEnvironments();
               LatestDeploymentUnion latest = findLatestDeployment(environment);
               DeploymentDurationEstimate estimate = computeEstimate(environment);
               return EnvironmentDto.fromEnvironment(
@@ -103,7 +101,6 @@ public class EnvironmentService {
     return environmentRepository.findByEnabledTrueOrderByNameAsc().stream()
         .map(
             environment -> {
-              environmentScheduler.unlockExpiredEnvironments();
               LatestDeploymentUnion latest = findLatestDeployment(environment);
               DeploymentDurationEstimate estimate = computeEstimate(environment);
               return EnvironmentDto.fromEnvironment(

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/filters/RepositoryInterceptor.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/filters/RepositoryInterceptor.java
@@ -1,22 +1,57 @@
 package de.tum.cit.aet.helios.filters;
 
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.hibernate.Session;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
+import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.context.request.WebRequestInterceptor;
 
 @Component
+@RequiredArgsConstructor
+@Log4j2
 public class RepositoryInterceptor implements WebRequestInterceptor {
 
   public static final String X_REPOSITORY_ID = "X-REPOSITORY-ID";
 
+  private final EntityManagerFactory entityManagerFactory;
+
   @Override
   public void preHandle(@NonNull WebRequest request) {
-    if (request.getHeader(X_REPOSITORY_ID) != null) {
-      String tenantId = request.getHeader(X_REPOSITORY_ID);
-      RepositoryContext.setRepositoryId(tenantId);
+    final String tenantId = request.getHeader(X_REPOSITORY_ID);
+    if (tenantId == null) {
+      return;
+    }
+    RepositoryContext.setRepositoryId(tenantId);
+    final Long repositoryId = RepositoryContext.getRepositoryId();
+    if (repositoryId == null) {
+      return;
+    }
+    // Enable Hibernate's gitRepositoryFilter on this request's EntityManager so tenant-filtered
+    // entities are scoped to the current repository. RepositoryFilterTransactionConfig only
+    // enables the filter on EntityManagers created by the transaction manager, which does NOT
+    // happen under Open-Session-In-View (the request's transaction reuses the EM opened by OSIV).
+    // Without this, web reads (pull requests, environments, ...) leak across all repositories.
+    // This interceptor is ordered after OSIV (see SecurityConfig#corsConfigurer) so the request's
+    // EntityManager is already bound here.
+    final EntityManagerHolder holder =
+        (EntityManagerHolder) TransactionSynchronizationManager.getResource(entityManagerFactory);
+    if (holder != null) {
+      holder
+          .getEntityManager()
+          .unwrap(Session.class)
+          .enableFilter("gitRepositoryFilter")
+          .setParameter("repository_id", repositoryId);
+    } else {
+      log.warn(
+          "gitRepositoryFilter not enabled for repository {}: no EntityManager bound at preHandle",
+          repositoryId);
     }
   }
 

--- a/server/application-server/src/main/resources/db/migration/V56__add_environment_deployment_indexes.sql
+++ b/server/application-server/src/main/resources/db/migration/V56__add_environment_deployment_indexes.sql
@@ -1,0 +1,11 @@
+-- Indexes for the environments "enabled" hot path: findLatestDeployment() and the
+-- release-candidate-by-(repository, commit_sha) lookup ran sequential scans per environment,
+-- which pinned application-server CPU under load. Created live on prod during the 2026-07-03
+-- incident and codified here. IF NOT EXISTS makes this a no-op where they already exist and
+-- creates them on staging / other environments.
+CREATE INDEX IF NOT EXISTS idx_deployment_env_created
+    ON deployment (environment_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_helios_deployment_env_created
+    ON helios_deployment (environment_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_release_candidate_repo_sha
+    ON release_candidate (repository_id, commit_sha);


### PR DESCRIPTION
## Prod incident 2026-07-03
App-server pinned ~140% CPU, `/api/environments/enabled` ~6s TTFB, and pipeline/PR/environment lists showed **all repositories'** data.

### Root causes
1. **Write-in-read:** `getAllEnvironments`/`getAllEnabledEnvironments` called `unlockExpiredEnvironments()` (a `@Scheduled @Transactional` **write**) inside the per-row `.map()` → N write txns + auto-flush/dirty-check churn per request (confirmed via prod thread dump).
2. **Missing indexes:** per-environment latest-deployment + release-candidate lookups were sequential scans.
3. **Tenant filter off on web reads:** the v1.7.0 `RepositoryFilterAspect → RepositoryFilterTransactionConfig` refactor only enables `gitRepositoryFilter` on tx-manager-created EntityManagers. Under **OSIV** (default on) the request tx reuses the OSIV-opened EM, so the filter never enabled for web reads → cross-repo leak (invisible in single-repo staging).

### Fixes (quickfix — option A)
- Remove `unlockExpiredEnvironments()` from the read maps (scheduler still runs every 60s) + drop the unused field.
- **V56** indexes (already created live on prod; `IF NOT EXISTS`).
- **Re-enable the filter for web requests:** `RepositoryInterceptor` enables `gitRepositoryFilter` on the request's OSIV EntityManager, ordered after OSIV via `order(Integer.MAX_VALUE)`. Logs a warning if the EM isn't bound (staging observability).
- Persist the NATS throttle (`MAX_ACK_PENDING` written from repo vars = 20; `ACK_WAIT`=600) so a deploy won't revert to 500 and re-trigger the redelivery storm.

### Follow-up (no time pressure)
Migrate to explicit per-query `repository_id` filtering and remove the Hibernate-filter magic (option B).

### Verification plan
Merge → staging deploy → confirm CPU normal, `/enabled` fast, no `gitRepositoryFilter not enabled` warnings, endpoints scoped correctly → cut **1.7.2** → prod → verify.