### PR TITLE
fix(client): keep long workflow names inside the pipeline card

### DIFF
--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -67,9 +67,9 @@
                       }
                     </div>
                     <!-- Fixed width to ensure consistent alignment -->
-                    <span class="font-medium flex gap-1 items-center justify-between w-full overflow-hidden">
-                      <span [pTooltip]="workflowRun.name" class="truncate">{{ workflowRun.name }}</span>
-                      <span class="flex items-center gap-1">
+                    <span class="font-medium flex gap-1 items-center w-full min-w-0 overflow-hidden">
+                      <span [pTooltip]="workflowRun.name" class="truncate min-w-0 flex-1">{{ workflowRun.name }}</span>
+                      <span class="flex items-center gap-1 flex-shrink-0">
                         @if (permissions.hasWritePermission() && !!workflowRun.id && !!repositoryId()) {
                           <a
                             [routerLink]="['/repo', repositoryId(), 'ci-cd', 'runs', workflowRun.id, 'logs']"


### PR DESCRIPTION
**Bug:** long workflow names (e.g. *Automatic Dependency Submission (Gradle)* in the Ungrouped group) overflow past the pipeline card's rounded border, dragging the log/GitHub icons outside the box. (Reported on prod PR #13092.)

**Cause:** classic flexbox truncation bug — the name has `truncate` but is a flex child without `min-width: 0`, so it won't shrink below its content width and overflows.

**Fix:** name → `flex-1 min-w-0 truncate` (shrinks + ellipsis within the 250px card), icons → `flex-shrink-0` (stay pinned inside), row wrapper → `min-w-0` (so the shrink chain propagates). Full name still shown via the existing `pTooltip`.