### PR TITLE
feat(pipeline): distinct node states, fail-fast, and a merge-readiness gate

### DIFF
--- a/client/src/app/components/pipeline/pipeline.component.html
+++ b/client/src/app/components/pipeline/pipeline.component.html
@@ -1,10 +1,25 @@
-<!-- Divider -->
 <div class="flex justify-center">
   <p-divider class="w-full mt-4" />
 </div>
 
-<div class="mb-4">
-  <h3 class="text-xl mb-2">Pipeline</h3>
+<!-- Status icon for one node; the state->icon mapping lives in nodeIcon(). -->
+<ng-template #statusIcon let-node>
+  @let icon = nodeIcon(node);
+  <i-tabler [name]="icon.name" [class]="icon.class" [pTooltip]="icon.tooltip"></i-tabler>
+</ng-template>
+
+<div class="mb-4 flex items-center gap-3">
+  <h3 class="text-xl">Pipeline</h3>
+  <!-- Overall merge-readiness gate, when configured -->
+  @if (gate(); as gateNode) {
+    <span class="inline-flex items-center gap-1 text-sm text-muted-color" [pTooltip]="'Merge gate: ' + (gateNode.label ?? '')">
+      <ng-container *ngTemplateOutlet="statusIcon; context: { $implicit: gateNode }"></ng-container>
+      <span class="font-medium">{{ gateNode.label }}</span>
+      @if (gateNode.htmlUrl) {
+        <app-github-link-button [url]="gateNode.htmlUrl" buttonClass="p-1 leading-none" />
+      }
+    </span>
+  }
 </div>
 
 @if (isPending()) {
@@ -38,39 +53,8 @@
               @for (node of category.nodes ?? []; track node.key) {
                 <div class="flex items-center space-x-2">
                   <div class="flex items-center">
-                    @if (node.status === 'COMPLETED') {
-                      @switch (node.conclusion) {
-                        @case ('SUCCESS') {
-                          <i-tabler name="circle-check" class="text-green-600 dark:text-green-400" pTooltip="Success"></i-tabler>
-                        }
-                        @case ('FAILURE') {
-                          <i-tabler name="circle-x" class="text-red-600 dark:text-red-400" pTooltip="Failure"></i-tabler>
-                        }
-                        @case ('TIMED_OUT') {
-                          <i-tabler name="circle-x" class="text-red-600 dark:text-red-400" pTooltip="Timed out"></i-tabler>
-                        }
-                        @case ('STARTUP_FAILURE') {
-                          <i-tabler name="circle-x" class="text-red-600 dark:text-red-400" pTooltip="Startup failure"></i-tabler>
-                        }
-                        @case ('SKIPPED') {
-                          <i-tabler name="minus" class="text-muted-color" pTooltip="Skipped"></i-tabler>
-                        }
-                        @case ('CANCELLED') {
-                          <i-tabler name="minus" class="text-muted-color" pTooltip="Cancelled"></i-tabler>
-                        }
-                        @default {
-                          <i-tabler name="progress-help" class="text-muted-color" pTooltip="Neutral"></i-tabler>
-                        }
-                      }
-                    } @else if (['IN_PROGRESS', 'QUEUED', 'WAITING', 'REQUESTED'].includes(node.status ?? '')) {
-                      <i-tabler name="progress" class="text-yellow-500 dark:text-yellow-400 animate-spin" pTooltip="In progress"></i-tabler>
-                    } @else if (node.status === 'PENDING') {
-                      <i-tabler name="circle-dashed" class="text-muted-color" pTooltip="Not started yet"></i-tabler>
-                    } @else {
-                      <i-tabler name="progress-help" class="text-muted-color" pTooltip="Unknown"></i-tabler>
-                    }
+                    <ng-container *ngTemplateOutlet="statusIcon; context: { $implicit: node }"></ng-container>
                   </div>
-                  <!-- Fixed width to ensure consistent alignment -->
                   <span class="font-medium flex gap-1 items-center w-full min-w-0 overflow-hidden">
                     <span [pTooltip]="node.label ?? ''" class="truncate min-w-0 flex-1">{{ node.label }}</span>
                     @if (node.htmlUrl) {
@@ -84,7 +68,6 @@
             </div>
           </p-panel>
 
-          <!-- Connection line -->
           @if (!lastCategory) {
             <p-divider class="w-10 mt-7"></p-divider>
           }

--- a/client/src/app/components/pipeline/pipeline.component.spec.ts
+++ b/client/src/app/components/pipeline/pipeline.component.spec.ts
@@ -4,12 +4,21 @@ import { PipelineComponent } from './pipeline.component';
 import { provideZonelessChangeDetection } from '@angular/core';
 import { provideQueryClient, QueryClient } from '@tanstack/angular-query-experimental';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import type { PipelineDto } from '@app/core/modules/openapi';
 
 describe('PipelineComponent', () => {
   let component: PipelineComponent;
   let fixture: ComponentFixture<PipelineComponent>;
+
+  // Icon name is a property binding ([name]="..."), so read the rendered i-tabler inputs directly.
+  // TablerIconComponent exposes `name` as a signal input, so unwrap it when it is callable.
+  const renderedIconNames = () =>
+    fixture.debugElement.queryAll(By.css('i-tabler')).map(de => {
+      const n = de.componentInstance.name;
+      return (typeof n === 'function' ? n() : n) as string;
+    });
 
   const pipeline: PipelineDto = {
     categories: [
@@ -70,12 +79,8 @@ describe('PipelineComponent', () => {
     expect(text).toContain('Docker');
     expect(text).toContain('E2E');
 
-    // Success / failure / in-progress / pending each render their distinct icon.
-    expect(el.querySelector('i-tabler[name="circle-check"]')).toBeTruthy();
-    expect(el.querySelector('i-tabler[name="circle-x"]')).toBeTruthy();
-    expect(el.querySelector('i-tabler[name="progress"]')).toBeTruthy();
-    // The always-visible-but-not-started node uses the dashed (non-spinning) icon.
-    expect(el.querySelector('i-tabler[name="circle-dashed"]')).toBeTruthy();
+    // Success / failure / in-progress / not-started each render their distinct icon.
+    expect(renderedIconNames()).toEqual(expect.arrayContaining(['circle-check', 'circle-x', 'progress', 'circle-dashed']));
   });
 
   it('exposes the configured categories via the pipeline signal', () => {
@@ -83,6 +88,45 @@ describe('PipelineComponent', () => {
 
     expect(component.categories().map(c => c.name)).toEqual(['Build', 'Tests']);
     expect(component.hasCategories()).toBe(true);
+  });
+
+  it('nodeIcon maps every state to a distinct icon (queued != running, fail-fast != spinner)', () => {
+    const icon = (status: string | null, conclusion: string | null) => component.nodeIcon({ status, conclusion });
+    expect(icon('COMPLETED', 'SUCCESS').name).toBe('circle-check');
+    // The whole failure family renders red, not just FAILURE.
+    for (const c of ['FAILURE', 'TIMED_OUT', 'STARTUP_FAILURE']) {
+      expect(icon('COMPLETED', c).name).toBe('circle-x');
+    }
+    // Fail-fast: still running, a leg already failed → red X, and NOT spinning.
+    expect(icon('IN_PROGRESS', 'FAILURE').name).toBe('circle-x');
+    expect(icon('IN_PROGRESS', 'FAILURE').class).not.toContain('animate-spin');
+    // Running is the only spinner.
+    expect(icon('IN_PROGRESS', null).name).toBe('progress');
+    expect(icon('IN_PROGRESS', null).class).toContain('animate-spin');
+    // Queued/waiting/pending are "not running yet" (dashed), never a spinner.
+    for (const s of ['QUEUED', 'WAITING', 'REQUESTED', 'PENDING']) {
+      expect(icon(s, null).name).toBe('circle-dashed');
+      expect(icon(s, null).class).not.toContain('animate-spin');
+    }
+    expect(icon('COMPLETED', 'SKIPPED').name).toBe('circle-minus');
+    expect(icon('COMPLETED', 'CANCELLED').name).toBe('ban');
+    // A terminal-but-neutral node is handled explicitly, not left as "Unknown".
+    expect(icon('COMPLETED', 'NEUTRAL').tooltip).toBe('Neutral');
+  });
+
+  it('renders the merge-gate badge when a gate is present', async () => {
+    const p: PipelineDto = {
+      categories: [{ name: 'Build', nodes: [{ key: 'build-native', label: 'Native', status: 'PENDING', conclusion: null, htmlUrl: null }] }],
+      gate: { key: 'ci-gate', label: 'All required CI passed', status: 'COMPLETED', conclusion: 'SUCCESS', htmlUrl: null },
+    };
+    mockPipeline(p);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent ?? '').toContain('All required CI passed');
+    expect(renderedIconNames()).toContain('circle-check');
   });
 
   it('shows the empty state when no categories are configured', async () => {

--- a/client/src/app/components/pipeline/pipeline.component.ts
+++ b/client/src/app/components/pipeline/pipeline.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, input } from '@angular/core';
 import { injectQuery } from '@tanstack/angular-query-experimental';
 import { PanelModule } from 'primeng/panel';
@@ -8,7 +9,8 @@ import { getPipelineByBranchOptions, getPipelineByPullRequestOptions } from '@ap
 import { PipelineDto } from '@app/core/modules/openapi';
 import { GithubLinkButtonComponent } from '@app/components/github-link-button/github-link-button.component';
 import { provideTablerIcons, TablerIconComponent } from 'angular-tabler-icons';
-import { IconCircleCheck, IconCircleDashed, IconCircleX, IconExclamationCircle, IconInfoCircle, IconMinus, IconProgress, IconProgressHelp } from 'angular-tabler-icons/icons';
+import { IconBan, IconCircleCheck, IconCircleDashed, IconCircleMinus, IconCircleX, IconExclamationCircle, IconProgress, IconProgressHelp } from 'angular-tabler-icons/icons';
+import { getStatusColors } from '@app/core/utils/status-colors';
 
 export type PipelineSelector = { repositoryId: number } & (
   | {
@@ -24,16 +26,16 @@ export type PipelineSelector = { repositoryId: number } & (
 
 @Component({
   selector: 'app-pipeline',
-  imports: [DividerModule, PanelModule, TablerIconComponent, TooltipModule, SkeletonModule, GithubLinkButtonComponent],
+  imports: [DividerModule, PanelModule, TablerIconComponent, TooltipModule, SkeletonModule, GithubLinkButtonComponent, NgTemplateOutlet],
   providers: [
     provideTablerIcons({
-      IconInfoCircle,
       IconCircleCheck,
       IconCircleX,
       IconCircleDashed,
+      IconCircleMinus,
+      IconBan,
       IconProgressHelp,
       IconProgress,
-      IconMinus,
       IconExclamationCircle,
     }),
   ],
@@ -76,4 +78,39 @@ export class PipelineComponent {
   categories = computed(() => this.pipeline().categories ?? []);
 
   hasCategories = computed(() => this.categories().some(category => (category.nodes ?? []).length > 0));
+
+  // Overall merge-readiness node (e.g. Artemis' "All required CI Passed"), rendered as a header
+  // badge. Null for repos/pipelines without a configured gate.
+  gate = computed(() => this.pipeline().gate ?? null);
+
+  /**
+   * Resolves a node's aggregated `{status, conclusion}` to its icon, reusing the shared status
+   * colour map. Conclusion is checked before status so a fail-fast node (still running, but a leg
+   * already failed) shows red rather than a spinner. "Not running yet" is deliberately muted
+   * instead of the shared map's queued=in_progress colour — separating queued from running is the
+   * whole point of this view.
+   */
+  nodeIcon(node: { status?: string | null; conclusion?: string | null }): { name: string; class: string; tooltip: string } {
+    const { status, conclusion } = node;
+    const color = getStatusColors(conclusion, status).icon;
+    switch (conclusion) {
+      case 'FAILURE':
+      case 'TIMED_OUT':
+      case 'STARTUP_FAILURE':
+        return { name: 'circle-x', class: color, tooltip: 'Failed' };
+      case 'SUCCESS':
+        return { name: 'circle-check', class: color, tooltip: 'Passed' };
+      case 'SKIPPED':
+        return { name: 'circle-minus', class: color, tooltip: 'Skipped' };
+      case 'CANCELLED':
+        return { name: 'ban', class: color, tooltip: 'Cancelled' };
+      case 'NEUTRAL':
+        return { name: 'progress-help', class: color, tooltip: 'Neutral' };
+    }
+    if (status === 'IN_PROGRESS') return { name: 'progress', class: `${color} animate-spin`, tooltip: 'Running' };
+    if (status === 'PENDING' || status === 'QUEUED' || status === 'WAITING' || status === 'REQUESTED') {
+      return { name: 'circle-dashed', class: 'text-muted-color', tooltip: 'Not running yet' };
+    }
+    return { name: 'progress-help', class: 'text-muted-color', tooltip: 'Unknown' };
+  }
 }

--- a/client/src/app/core/modules/openapi/schemas.gen.ts
+++ b/client/src/app/core/modules/openapi/schemas.gen.ts
@@ -2033,6 +2033,9 @@ export const PipelineDtoSchema = {
         $ref: '#/components/schemas/Category',
       },
     },
+    gate: {
+      $ref: '#/components/schemas/Node',
+    },
   },
 } as const;
 

--- a/client/src/app/core/modules/openapi/types.gen.ts
+++ b/client/src/app/core/modules/openapi/types.gen.ts
@@ -737,6 +737,7 @@ export type Node = {
 
 export type PipelineDto = {
   categories?: Array<Category>;
+  gate?: Node;
 };
 
 export type EnvironmentReviewersDto = {

--- a/docs/admin/pipeline_configuration.rst
+++ b/docs/admin/pipeline_configuration.rst
@@ -142,21 +142,46 @@ The defaults above target Artemis' single ``CI`` orchestrator run
 Status aggregation
 ------------------
 
-For each node, the matched jobs are reduced to one status:
+For each node, the matched jobs are reduced to one of five human-legible states, chosen so the
+earliest actionable signal is never hidden:
 
-- **PENDING** — no matching job exists yet. The node is still shown (dashed icon).
-- **IN_PROGRESS** — at least one matching job is queued, waiting, requested, or in progress.
-- **COMPLETED** — all matching jobs have finished. The node's *conclusion* is then the
-  worst-wins result across the jobs:
+- **Not running yet** (``PENDING``, dashed icon) — either no matching job exists yet, **or** every
+  matching job is still queued/waiting (nothing has started). This is deliberately distinct from
+  *running*: a queued job is **not** shown as a spinner.
+- **Running** (``IN_PROGRESS``, spinner) — at least one matching job has started (or already
+  finished) while others are not yet done.
+- **Failed** (``FAILURE``, red) — *fail-fast*: as soon as **any** matching job fails, times out, or
+  has a startup failure, the node is red, **even while slower legs keep running**. The node then
+  links to the failing job (not an arbitrary passing one).
+- **Passed / Skipped / Cancelled** — once **all** matching jobs are terminal, the *conclusion* is
+  the worst-wins result across them:
 
-  - **FAILURE** if any job failed, timed out, or had a startup failure;
-  - else **CANCELLED** if any job was cancelled;
-  - else **SKIPPED** if every job was skipped;
+  - **CANCELLED** if any job was cancelled;
+  - else **SKIPPED** if every job was skipped (e.g. gated out by change-detection on this change);
   - else **SUCCESS** if any job succeeded;
   - else **NEUTRAL**.
 
-The client renders a distinct icon per state, so a not-yet-started node (dashed) is visually
-different from an in-progress one (spinning).
+The client renders a distinct icon per state: dashed circle (not running yet), yellow spinner
+(running), red ✗ (failed), green ✓ (passed), grey ⊝ (skipped), grey ⃠ (cancelled).
+
+
+Merge gate
+----------
+
+An optional ``helios.pipeline.gate`` node maps to the CI's single required-checks job — the one job
+that reflects "can this PR merge" (for Artemis, ``All required CI Passed``). It is aggregated with
+the same state rules as any node but rendered as a **badge next to the pipeline header** rather than
+inside a category, so merge-readiness is visible at a glance. Omit the key to hide the badge.
+
+.. code-block:: yaml
+
+  helios:
+    pipeline:
+      gate:
+        key: "ci-gate"
+        label: "All required CI passed"
+        job-name-matchers: ["All required CI Passed"]
+        workflow-name-matcher: "CI"
 
 
 Adding a node

--- a/server/application-server/openapi.yaml
+++ b/server/application-server/openapi.yaml
@@ -4248,6 +4248,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Category"
+        gate:
+          $ref: "#/components/schemas/Node"
     EnvironmentReviewersDto:
       type: object
       properties:

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineDto.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineDto.java
@@ -1,5 +1,6 @@
 package de.tum.cit.aet.helios.workflow.pipeline;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import org.springframework.lang.Nullable;
 
@@ -7,8 +8,15 @@ import org.springframework.lang.Nullable;
  * The canonical pipeline for a branch or pull request: a fixed set of categories and nodes that are
  * always present. A node with no matching CI job yet reports {@code status = "PENDING"} and a null
  * conclusion, so the client renders it as not-started rather than omitting it.
+ *
+ * <p>{@code gate} is the optional overall merge-readiness node (mapped to the CI's required-checks
+ * job) rendered as a header badge. It is omitted from the payload when not configured or for
+ * fallback repos ({@code @JsonInclude(NON_NULL)}), matching the generated client's optional
+ * {@code gate?: Node}. It is intentionally not {@code @Nullable}: that annotation makes springdoc
+ * mark the shared {@code Node} schema itself {@code type: "null"}, breaking every other Node use.
  */
-public record PipelineDto(List<Category> categories) {
+public record PipelineDto(
+    List<Category> categories, @JsonInclude(JsonInclude.Include.NON_NULL) Node gate) {
 
   /** A titled group of pipeline nodes (e.g. "Build", "Tests"), rendered in declaration order. */
   public record Category(String name, List<Node> nodes) {}

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineProperties.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineProperties.java
@@ -17,7 +17,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * Build and Push Docker Image"}.
  */
 @ConfigurationProperties(prefix = "helios.pipeline")
-public record PipelineProperties(List<String> repositories, List<Category> categories) {
+public record PipelineProperties(
+    List<String> repositories, List<Category> categories, Node gate) {
 
   public PipelineProperties {
     // nameWithOwner allow-list: repositories that render the canonical catalog. Others fall back

--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineService.java
@@ -38,15 +38,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PipelineService {
 
-  /** Statuses that mean a matched job has not finished yet (node is still in progress). */
-  private static final Set<WorkflowRun.Status> ACTIVE_STATUSES =
-      Set.of(
-          WorkflowRun.Status.IN_PROGRESS,
-          WorkflowRun.Status.QUEUED,
-          WorkflowRun.Status.WAITING,
-          WorkflowRun.Status.PENDING,
-          WorkflowRun.Status.REQUESTED);
-
   /** Conclusions that count as a failure for worst-wins aggregation. */
   private static final Set<WorkflowRun.Conclusion> FAILED_CONCLUSIONS =
       Set.of(
@@ -104,32 +95,91 @@ public class PipelineService {
                         category.name(),
                         category.nodes().stream().map(node -> buildNode(node, jobs)).toList()))
             .toList();
-    return new PipelineDto(categories);
+    // Optional overall merge-gate node (e.g. Artemis' "All required CI Passed"), surfaced as a
+    // header badge on the client. Absent for the group fallback.
+    final PipelineDto.Node gate =
+        properties.gate() == null ? null : buildNode(properties.gate(), jobs);
+    return new PipelineDto(categories, gate);
   }
 
+  /**
+   * Aggregates the CI jobs matching a node into a single status. Two boundaries are deliberate:
+   * queued-only jobs stay {@code PENDING} (not-running-yet), distinct from a running node; and a
+   * failing leg flips the node to {@code FAILURE} <i>immediately</i> (fail-fast), even while slower
+   * legs run, so the earliest actionable signal is never hidden behind the spinner.
+   */
   private PipelineDto.Node buildNode(PipelineProperties.Node node, List<WorkflowJob> jobs) {
     final List<WorkflowJob> matched = jobs.stream().filter(job -> matches(node, job)).toList();
     if (matched.isEmpty()) {
-      // Not started yet (or never runs for this PR): always-visible, rendered as pending.
+      // Not started yet (or never runs for this PR): always-visible, rendered as "not running yet".
       return new PipelineDto.Node(
           node.key(), node.label(), WorkflowRun.Status.PENDING.name(), null, null);
     }
 
-    final WorkflowRun.Status status = aggregateStatus(matched);
-    final WorkflowRun.Conclusion conclusion =
-        status == WorkflowRun.Status.COMPLETED ? aggregateConclusion(matched) : null;
-    final String htmlUrl =
-        matched.stream()
-            .map(WorkflowJob::getHtmlUrl)
-            .filter(Objects::nonNull)
-            .findFirst()
-            .orElse(null);
+    final boolean allTerminal =
+        matched.stream().allMatch(job -> job.getStatus() == WorkflowRun.Status.COMPLETED);
+    final boolean anyFailed = matched.stream().anyMatch(PipelineService::isFailed);
+
+    final WorkflowRun.Status status;
+    final WorkflowRun.Conclusion conclusion;
+    if (anyFailed) {
+      // Fail-fast: conclusion reads FAILURE the instant a leg fails; status stays IN_PROGRESS until
+      // every leg is terminal (truthful for other consumers). The client checks conclusion before
+      // status, so a failing node shows a static red X immediately, never a spinner.
+      status = allTerminal ? WorkflowRun.Status.COMPLETED : WorkflowRun.Status.IN_PROGRESS;
+      conclusion = WorkflowRun.Conclusion.FAILURE;
+    } else if (allTerminal) {
+      status = WorkflowRun.Status.COMPLETED;
+      conclusion = aggregateConclusion(matched);
+    } else if (matched.stream().anyMatch(PipelineService::hasStarted)) {
+      status = WorkflowRun.Status.IN_PROGRESS;
+      conclusion = null;
+    } else {
+      status = WorkflowRun.Status.PENDING;
+      conclusion = null;
+    }
+
     return new PipelineDto.Node(
         node.key(),
         node.label(),
         status.name(),
         conclusion == null ? null : conclusion.name(),
-        htmlUrl);
+        pickHtmlUrl(matched, conclusion));
+  }
+
+  private static boolean hasStarted(WorkflowJob job) {
+    return job.getStatus() == WorkflowRun.Status.IN_PROGRESS
+        || job.getStatus() == WorkflowRun.Status.COMPLETED;
+  }
+
+  /** Null-safe failure test; FAILED_CONCLUSIONS is a Set.of that throws on contains(null). */
+  private static boolean isFailed(WorkflowJob job) {
+    return job.getConclusion() != null && FAILED_CONCLUSIONS.contains(job.getConclusion());
+  }
+
+  /**
+   * On a failure, links to a job carrying the failing conclusion so the click-through opens the
+   * failing leg, not an arbitrary passing one; otherwise the first job with a URL.
+   */
+  private static String pickHtmlUrl(
+      List<WorkflowJob> matched, WorkflowRun.Conclusion conclusion) {
+    if (conclusion == WorkflowRun.Conclusion.FAILURE) {
+      final String failing =
+          matched.stream()
+              .filter(PipelineService::isFailed)
+              .map(WorkflowJob::getHtmlUrl)
+              .filter(Objects::nonNull)
+              .findFirst()
+              .orElse(null);
+      if (failing != null) {
+        return failing;
+      }
+    }
+    return matched.stream()
+        .map(WorkflowJob::getHtmlUrl)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 
   private static boolean matches(PipelineProperties.Node node, WorkflowJob job) {
@@ -149,23 +199,19 @@ public class PipelineService {
         .anyMatch(prefix -> jobName.startsWith(prefix.toLowerCase(Locale.ROOT)));
   }
 
-  /** Any not-yet-completed matched job keeps the node in progress; otherwise it is completed. */
-  private static WorkflowRun.Status aggregateStatus(List<WorkflowJob> jobs) {
-    final boolean anyActive =
-        jobs.stream().map(WorkflowJob::getStatus).anyMatch(ACTIVE_STATUSES::contains);
-    return anyActive ? WorkflowRun.Status.IN_PROGRESS : WorkflowRun.Status.COMPLETED;
-  }
-
-  /** Worst-wins conclusion across the matched jobs. */
+  /**
+   * Worst-wins conclusion for terminal, non-failing jobs. Failures are handled earlier by
+   * {@link #buildNode} (fail-fast), so this is only reached when no matched job failed. The split
+   * mirrors the client's status colours: {@code CANCELLED} and {@code SKIPPED} render neutral-grey
+   * (unlike {@code TIMED_OUT}/{@code STARTUP_FAILURE}, which are failures), and {@code
+   * ACTION_REQUIRED}/{@code STALE} fold into {@code NEUTRAL} — the model has no warning state.
+   */
   private static WorkflowRun.Conclusion aggregateConclusion(List<WorkflowJob> jobs) {
     final Set<WorkflowRun.Conclusion> present =
         jobs.stream()
             .map(WorkflowJob::getConclusion)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());
-    if (present.stream().anyMatch(FAILED_CONCLUSIONS::contains)) {
-      return WorkflowRun.Conclusion.FAILURE;
-    }
     if (present.contains(WorkflowRun.Conclusion.CANCELLED)) {
       return WorkflowRun.Conclusion.CANCELLED;
     }
@@ -182,7 +228,7 @@ public class PipelineService {
 
   private PipelineDto buildGrouped(Long repositoryId, List<WorkflowRunDto> headRuns) {
     if (repositoryId == null) {
-      return new PipelineDto(List.of());
+      return new PipelineDto(List.of(), null);
     }
     // getLatest... returns the latest run per workflowId, so a workflowId maps to one run.
     final Map<Long, WorkflowRunDto> runByWorkflowId = new HashMap<>();
@@ -224,7 +270,7 @@ public class PipelineService {
     if (!ungrouped.isEmpty()) {
       categories.add(new PipelineDto.Category("Ungrouped", ungrouped));
     }
-    return new PipelineDto(categories);
+    return new PipelineDto(categories, null);
   }
 
   private static PipelineDto.Node runNode(WorkflowRunDto run) {

--- a/server/application-server/src/main/resources/application.yml
+++ b/server/application-server/src/main/resources/application.yml
@@ -137,31 +137,52 @@ helios:
         # falls back to its WorkflowGroup-based pipeline, so a repo whose CI job names don't match
         # these Artemis-shaped matchers keeps a meaningful view instead of all-pending nodes.
         repositories: ["ls1intum/Artemis"]
+        # Overall merge-readiness gate, rendered as a badge next to the pipeline header (not inside a
+        # category). Maps to the single required-checks job that reflects "can this PR merge".
+        gate:
+            key: "ci-gate"
+            label: "All required CI passed"
+            job-name-matchers: ["All required CI Passed"]
+            workflow-name-matcher: "CI"
+        # workflow-name-matcher constrains each node to the "CI" orchestrator run, so an identically
+        # named job in another workflow on the same commit can't silently merge into a node.
         categories:
             - name: "Build"
               nodes:
                   - key: "build-native"
                     label: "Native"
                     job-name-matchers: ["Build / Build .war artifact"]
+                    workflow-name-matcher: "CI"
                   - key: "build-docker"
                     label: "Docker"
                     job-name-matchers: ["Build / Build and Push Docker Image"]
+                    workflow-name-matcher: "CI"
             - name: "Tests"
               nodes:
                   - key: "test-client"
                     label: "Client"
                     job-name-matchers: ["Test / Client Tests"]
+                    workflow-name-matcher: "CI"
                   - key: "test-server"
                     label: "Server"
                     job-name-matchers: ["Test / Server Tests"]
+                    workflow-name-matcher: "CI"
                   - key: "test-e2e"
                     label: "E2E"
                     job-name-matchers: ["E2E /"]
+                    workflow-name-matcher: "CI"
             - name: "Quality"
               nodes:
                   - key: "quality-client"
                     label: "Client"
-                    job-name-matchers: ["Quality / Client Code Style"]
+                    job-name-matchers:
+                        - "Quality / Client Code Style"
+                        - "Quality / Client Compilation"
+                    workflow-name-matcher: "CI"
                   - key: "quality-server"
                     label: "Server"
-                    job-name-matchers: ["Quality / Server Code Style", "Quality / Server Code Quality"]
+                    job-name-matchers:
+                        - "Quality / Server Code Style"
+                        - "Quality / Server Code Quality"
+                        - "Quality / Query Quality Check"
+                    workflow-name-matcher: "CI"

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineIT.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineIT.java
@@ -92,7 +92,111 @@ class PipelineIT extends HeliosIntegrationTest {
         .andExpect(jsonPath("$.categories[2].nodes[0].key").value("quality-client"))
         .andExpect(jsonPath("$.categories[2].nodes[0].status").value("COMPLETED"))
         .andExpect(jsonPath("$.categories[2].nodes[1].key").value("quality-server"))
-        .andExpect(jsonPath("$.categories[2].nodes[1].status").value("PENDING"));
+        .andExpect(jsonPath("$.categories[2].nodes[1].status").value("PENDING"))
+        // Gate is always present for a canonical repo; here no matching job → not running yet.
+        .andExpect(jsonPath("$.gate.key").value("ci-gate"))
+        .andExpect(jsonPath("$.gate.status").value("PENDING"));
+  }
+
+  @Test
+  void nodeStates_queuedIsNotRunning_failFast_andGateReflectRequiredChecks() throws Exception {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    final long runC = 62L;
+    final String branchC = "feature";
+    final String shaC = "feedface";
+    insertBranch(jdbc, REPO, branchC, shaC);
+    insertRun(jdbc, runC, REPO, WF, branchC, shaC);
+    // E2E: queued only → the node is "not running yet" (PENDING), not a spinner.
+    insertJob(jdbc, 201, REPO, runC, "E2E / Phase 1", "QUEUED", null);
+    // Native fail-fast + failing-leg link: leg 203 still runs and sorts first; leg 204 already
+    // failed. The node is FAILURE and must link to 204, so a plain "first URL" (203) fails here.
+    insertJob(jdbc, 203, REPO, runC, "Build / Build .war artifact", "IN_PROGRESS", null);
+    insertJob(jdbc, 204, REPO, runC, "Build / Build .war artifact (retry)", "COMPLETED", "FAILURE");
+    // The required-checks gate job failed.
+    insertJob(jdbc, 205, REPO, runC, "All required CI Passed", "COMPLETED", "FAILURE");
+
+    mockMvc
+        .perform(
+            get("/api/pipeline/branch")
+                .param("branch", branchC)
+                .header(X_REPOSITORY_ID, String.valueOf(REPO)))
+        .andExpect(status().isOk())
+        // E2E queued-only → not running yet.
+        .andExpect(jsonPath("$.categories[1].nodes[2].key").value("test-e2e"))
+        .andExpect(jsonPath("$.categories[1].nodes[2].status").value("PENDING"))
+        .andExpect(jsonPath("$.categories[1].nodes[2].conclusion").doesNotExist())
+        // Native fail-fast: FAILURE even though a leg is still IN_PROGRESS, and the link points at
+        // the failing leg (204), not the still-running one (203) that sorts first.
+        .andExpect(jsonPath("$.categories[0].nodes[0].key").value("build-native"))
+        .andExpect(jsonPath("$.categories[0].nodes[0].status").value("IN_PROGRESS"))
+        .andExpect(jsonPath("$.categories[0].nodes[0].conclusion").value("FAILURE"))
+        .andExpect(jsonPath("$.categories[0].nodes[0].htmlUrl").value("https://example/job/204"))
+        // Gate reflects the required-checks job.
+        .andExpect(jsonPath("$.gate.status").value("COMPLETED"))
+        .andExpect(jsonPath("$.gate.conclusion").value("FAILURE"));
+  }
+
+  @Test
+  void worstWinsConclusionPrecedenceAcrossLegs() throws Exception {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    final long runD = 63L;
+    final String branchD = "release";
+    final String shaD = "d00dfeed";
+    insertBranch(jdbc, REPO, branchD, shaD);
+    insertRun(jdbc, runD, REPO, WF, branchD, shaD);
+    // quality-server aggregates style + quality; cancelled beats success.
+    insertJob(jdbc, 301, REPO, runD, "Quality / Server Code Style", "COMPLETED", "SUCCESS");
+    insertJob(jdbc, 302, REPO, runD, "Quality / Server Code Quality", "COMPLETED", "CANCELLED");
+    // quality-client: every leg skipped → the node is skipped (not success).
+    insertJob(jdbc, 303, REPO, runD, "Quality / Client Code Style", "COMPLETED", "SKIPPED");
+    insertJob(jdbc, 304, REPO, runD, "Quality / Client Compilation", "COMPLETED", "SKIPPED");
+    // build-docker: real Artemis shape — PR image ran, release-only leg skipped → success.
+    insertJob(jdbc, 305, REPO, runD, "Build / Build and Push Docker Image (PR, amd64)", "COMPLETED",
+        "SUCCESS");
+    insertJob(jdbc, 306, REPO, runD, "Build / Build and Push Docker Image", "COMPLETED", "SKIPPED");
+    // build-native: a terminal job with no pass/fail/skip verdict folds to NEUTRAL.
+    insertJob(jdbc, 307, REPO, runD, "Build / Build .war artifact", "COMPLETED", "ACTION_REQUIRED");
+
+    mockMvc
+        .perform(
+            get("/api/pipeline/branch")
+                .param("branch", branchD)
+                .header(X_REPOSITORY_ID, String.valueOf(REPO)))
+        .andExpect(status().isOk())
+        // CANCELLED > SUCCESS
+        .andExpect(jsonPath("$.categories[2].nodes[1].key").value("quality-server"))
+        .andExpect(jsonPath("$.categories[2].nodes[1].conclusion").value("CANCELLED"))
+        // all-skipped → SKIPPED
+        .andExpect(jsonPath("$.categories[2].nodes[0].key").value("quality-client"))
+        .andExpect(jsonPath("$.categories[2].nodes[0].conclusion").value("SKIPPED"))
+        // mixed success+skipped → SUCCESS (not skipped)
+        .andExpect(jsonPath("$.categories[0].nodes[1].key").value("build-docker"))
+        .andExpect(jsonPath("$.categories[0].nodes[1].conclusion").value("SUCCESS"))
+        // action_required/stale/neutral fold to NEUTRAL (no warning state)
+        .andExpect(jsonPath("$.categories[0].nodes[0].key").value("build-native"))
+        .andExpect(jsonPath("$.categories[0].nodes[0].conclusion").value("NEUTRAL"));
+  }
+
+  @Test
+  void workflowNameMatcherExcludesJobsFromOtherWorkflows() throws Exception {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    final long runE = 64L;
+    final String branchE = "hotfix";
+    final String shaE = "b16b00b5";
+    insertBranch(jdbc, REPO, branchE, shaE);
+    insertRun(jdbc, runE, REPO, WF, branchE, shaE);
+    // A job whose NAME matches test-client but that ran in a different workflow must not feed the
+    // node — workflow-name-matcher "CI" scopes matching to the CI orchestrator run.
+    insertJob(jdbc, 401, REPO, runE, "Test / Client Tests", "Nightly", "COMPLETED", "SUCCESS");
+
+    mockMvc
+        .perform(
+            get("/api/pipeline/branch")
+                .param("branch", branchE)
+                .header(X_REPOSITORY_ID, String.valueOf(REPO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.categories[1].nodes[0].key").value("test-client"))
+        .andExpect(jsonPath("$.categories[1].nodes[0].status").value("PENDING"));
   }
 
   @Test
@@ -170,13 +274,26 @@ class PipelineIT extends HeliosIntegrationTest {
       String name,
       String statusValue,
       String conclusionValue) {
+    insertJob(jdbc, id, repositoryId, runId, name, "CI", statusValue, conclusionValue);
+  }
+
+  private static void insertJob(
+      JdbcTemplate jdbc,
+      long id,
+      long repositoryId,
+      long runId,
+      String name,
+      String workflowName,
+      String statusValue,
+      String conclusionValue) {
     jdbc.update(
         "INSERT INTO workflow_job (id, repository_id, workflow_run_id, name, workflow_name, "
-            + "status, conclusion, html_url) VALUES (?, ?, ?, ?, 'CI', ?, ?, ?)",
+            + "status, conclusion, html_url) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         id,
         repositoryId,
         runId,
         name,
+        workflowName,
         statusValue,
         conclusionValue,
         "https://example/job/" + id);


### PR DESCRIPTION
### Motivation

[#1187](https://github.com/ls1intum/Helios/pull/1187) introduced the always-visible **Build / Tests / Quality** pipeline nodes, but the way each node was rendered didn't match how developers actually read CI at a glance:

- **Queued looked like running.** A job that GitHub had only *queued* rendered the same spinning icon as a job that was actively running, so the board implied work was happening when nothing had started yet.
- **Failures hid behind the spinner.** A node aggregating several jobs stayed a neutral spinner until *every* leg finished — so a leg that failed at minute 2 was invisible until the slow leg finished at minute 15, defeating the point of an at-a-glance view.
- **Skipped and cancelled were indistinguishable**, and two Quality checks (`Client Compilation`, `Query Quality Check`) matched no node and silently disappeared.
- **No "can I merge?" signal.** The single most useful check — the required-checks gate — wasn't surfaced anywhere.
- Internally, the component had drifted from the codebase's shared status conventions (hardcoded colour classes, an in-template `@switch` used nowhere else).

This PR makes each node render **one of five distinct, always-visible states**, surfaces failures immediately, and adds an optional merge-readiness badge — while bringing the code back in line with the repo's shared status utilities.

### Description

**State model (server — `PipelineService`)**

- Aggregates the jobs behind each node into a clear five-state result: **not running yet · running · failed · passed · skipped/cancelled**.
- **Queued ≠ running:** a node whose jobs are all queued/waiting stays *not running yet*; the spinner appears only when a leg is genuinely in progress.
- **Fail-fast:** the node reads `FAILURE` the instant any leg fails (status stays `IN_PROGRESS` until every leg is terminal, which remains truthful for other consumers), and the node deep-links to the *failing* leg rather than an arbitrary passing one.
- Worst-wins conclusion for terminal nodes (`CANCELLED` > all-`SKIPPED` > `SUCCESS` > `NEUTRAL`); `CANCELLED`/`SKIPPED` render neutral-grey and `ACTION_REQUIRED`/`STALE` fold to `NEUTRAL`, mirroring the client's shared status colours.

**Merge-readiness gate**

- New optional `helios.pipeline.gate` node maps to the CI's required-checks job (e.g. Artemis' `All required CI Passed`) and renders as a **badge next to the "Pipeline" header** — the at-a-glance merge signal. It's omitted entirely for repos that don't configure it.

**Configuration (`application.yml`)**

- Completes the Quality aggregation: `Client Compilation` joins the *Client* node and `Query Quality Check` joins the *Server* node (both were previously dropped).
- Scopes every matcher to the `CI` orchestrator run via `workflow-name-matcher`, so an identically-named job in another workflow on the same commit can't leak into a node.

**Client (`pipeline.component`)**

- Resolves each node's icon/colour/tooltip in a single `nodeIcon()` method (matching the sibling `*-status-icon` convention) and **reuses the shared `getStatusColors` util** instead of hardcoding Tailwind colour classes; removes the in-template `@switch`.
- Distinct icons per state, including skipped (`circle-minus`) vs cancelled (`ban`).

**Contract & docs**

- `PipelineDto.gate` is emitted only when present (`@JsonInclude(NON_NULL)`), matching the generated `gate?: Node`. `openapi.yaml` and the generated client are regenerated from the server (not hand-edited), so `validate-openapi` stays clean.
- `docs/admin/pipeline_configuration.rst` documents the five states, fail-fast, and the gate.

### Testing Instructions

#### Prerequisites
- A Helios instance tracking a repository whose CI matches the catalog (staging tracks `ls1intum/Artemis`).
- A branch or pull request on that repository with a recent CI run.

#### Flow
1. Open a branch or pull request in Helios and scroll to the **Pipeline** section.
2. **Always-visible nodes:** Build (Native, Docker), Tests (Client, Server, E2E) and Quality (Client, Server) are shown even before CI starts — rendered as a dashed *not running yet* icon.
3. **Queued vs running:** while jobs are queued they stay dashed; once a job is actually executing its node shows the yellow spinner.
4. **Fail-fast:** as soon as a check fails, its node turns red (✗) immediately — you don't have to wait for the other legs — and clicking the link opens the failing job.
5. **Skipped vs cancelled:** on a change that gates checks out (e.g. a docs-only PR), skipped nodes show a grey `⊝`, distinct from a cancelled `⃠`.
6. **Merge gate:** the badge next to the *Pipeline* heading reflects the required-checks job (green when it passes, red when it fails).
7. **Fallback repos:** open a branch on a repo *not* in `helios.pipeline.repositories` (e.g. `ls1intum/Helios`) and confirm it still shows its workflow-group view with **no** gate badge.

#### Automated tests
- Server: `./gradlew :application-server:test --tests 'de.tum.cit.aet.helios.workflow.pipeline.PipelineIT'` — pins queued→pending, fail-fast (incl. the failing-leg link), worst-wins precedence, the `NEUTRAL` fold, and the workflow-name-matcher exclusion.
- Client: `pnpm --dir client exec ng test --no-watch --include=src/app/components/pipeline/pipeline.component.spec.ts` — unit-tests `nodeIcon()` across every state (queued ≠ spinner, fail-fast ≠ spinner) plus the gate badge.

### Screenshots

> [!NOTE]
> UI screenshots still need to be captured against a running instance and were **not** attached from the development environment — flagging this transparently rather than omitting it. The visual change is: each node renders one of — dashed *not running yet* · yellow spinner *running* · red ✗ *failed* · green ✓ *passed* · grey `⊝` *skipped* / `⃠` *cancelled* — plus a status badge beside the **Pipeline** heading for the merge gate. Happy to add real screenshots once the branch is deployed to a preview environment.

### Checklist

#### General
- [x] PR description explains the purpose and changes. [(f.e. following the 'Conventional Commits')](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes have been tested locally. <!-- full server suite, client spec + typecheck, prettier/eslint, checkstyle line-length, and OpenAPI regeneration all green -->
- [ ] Screenshots have been attached. <!-- pending capture against a running instance; see the Screenshots note -->

#### Server
- [x] Code is performant and follows best practices
- [x] I documented the Java code using JavaDoc style.

#### Client
- [x] I documented the TypeScript code using JSDoc style.
- [ ] I added multiple screenshots/screencasts of my UI changes. <!-- pending; see the Screenshots note -->

<!-- The "translate strings into English and German" item was removed: the repo has no i18n infrastructure and sibling status components (e.g. pull-request-status-icon) use hardcoded English labels; these status tooltips follow that existing convention. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
