### PR TITLE
fix(ops): re-resolve nginx upstreams via variables to survive container restarts

### DIFF
--- a/nginx.prod.conf
+++ b/nginx.prod.conf
@@ -44,8 +44,13 @@ http {
 
 
         location / {
-            # Forward to webapp on port 80
-            proxy_pass http://client:80;
+            # Forward to webapp on port 80.
+            # NOTE: the upstream host MUST go through a variable so nginx re-resolves it
+            # via the `resolver` above on each request. A literal hostname in proxy_pass is
+            # resolved only once at startup and cached forever, which causes 502
+            # "No route to host" after a service container restarts with a new IP.
+            set $upstream_client client;
+            proxy_pass http://$upstream_client:80;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -55,7 +60,9 @@ http {
 
         # Proxy API requests
         location /api {
-            proxy_pass http://application-server:8080;  # Forward to application server
+            # Variable + resolver => runtime DNS re-resolution (see note in location /).
+            set $upstream_app application-server;
+            proxy_pass http://$upstream_app:8080;  # Forward to application server
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -65,7 +72,8 @@ http {
 
         # Proxy Keycloak requests
         location ~* ^/(realms|resources|robots\.txt) {
-            proxy_pass http://keycloak:8081;
+            set $upstream_keycloak keycloak;
+            proxy_pass http://$upstream_keycloak:8081;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -77,7 +85,10 @@ http {
 
         # Keycloak admin console
         location /admin {
-            proxy_pass http://keycloak:8081/admin;
+            # No URI part after the variable: nginx forwards the original request URI
+            # unchanged (identity mapping for the /admin prefix), same as http://keycloak:8081/admin.
+            set $upstream_keycloak keycloak;
+            proxy_pass http://$upstream_keycloak:8081;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -112,7 +123,8 @@ http {
             }
 
             # Forward to the webhook listener service
-            proxy_pass http://webhook-listener:4200;  # Forward to webhook listener on port 4200
+            set $upstream_webhook webhook-listener;
+            proxy_pass http://$upstream_webhook:4200;  # Forward to webhook listener on port 4200
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';

--- a/nginx.staging.conf
+++ b/nginx.staging.conf
@@ -44,8 +44,13 @@ http {
 
 
         location / {
-            # Forward to webapp on port 80
-            proxy_pass http://client:80;
+            # Forward to webapp on port 80.
+            # NOTE: the upstream host MUST go through a variable so nginx re-resolves it
+            # via the `resolver` above on each request. A literal hostname in proxy_pass is
+            # resolved only once at startup and cached forever, which causes 502
+            # "No route to host" after a service container restarts with a new IP.
+            set $upstream_client client;
+            proxy_pass http://$upstream_client:80;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -55,7 +60,9 @@ http {
 
         # Proxy API requests
         location /api {
-            proxy_pass http://application-server:8080;  # Forward to application server
+            # Variable + resolver => runtime DNS re-resolution (see note in location /).
+            set $upstream_app application-server;
+            proxy_pass http://$upstream_app:8080;  # Forward to application server
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
@@ -65,7 +72,8 @@ http {
 
         # Proxy Keycloak requests
         location ~* ^/(realms|resources|robots\.txt) {
-            proxy_pass http://keycloak:8081;
+            set $upstream_keycloak keycloak;
+            proxy_pass http://$upstream_keycloak:8081;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -77,7 +85,10 @@ http {
 
         # Keycloak admin console
         location /admin {
-            proxy_pass http://keycloak:8081/admin;
+            # No URI part after the variable: nginx forwards the original request URI
+            # unchanged (identity mapping for the /admin prefix), same as http://keycloak:8081/admin.
+            set $upstream_keycloak keycloak;
+            proxy_pass http://$upstream_keycloak:8081;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -112,7 +123,8 @@ http {
             }
 
             # Forward to the webhook listener service
-            proxy_pass http://webhook-listener:4200;  # Forward to webhook listener on port 4200
+            set $upstream_webhook webhook-listener;
+            proxy_pass http://$upstream_webhook:4200;  # Forward to webhook listener on port 4200
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
## Problem

Prod `/api/*` went down with **502 Bad Gateway** on every backend call (`userLocking`, `pending-approvals`, `user-permissions`, …). The frontend, Keycloak login, and static assets kept working — only proxied backend traffic failed.

**Root cause:** `helios-application-server-1` restarted and Docker assigned it a new IP. nginx resolves a **literal hostname** in `proxy_pass` (`http://application-server:8080`) only **once at startup** and caches the IP forever, so it kept dialing the dead old address → `connect() failed (113: No route to host)` → 502, until nginx was reloaded.

The `resolver 127.0.0.11` directive was already in the config specifically to handle changing container IPs, but nginx only consults the resolver at runtime when the upstream is given via a **variable** — so with literal hostnames it never took effect.

## Fix

Route every `proxy_pass` through a `set $upstream_* …` variable so nginx re-resolves the service name via the existing resolver on each request. The reverse proxy now survives container IP changes automatically (client, application-server, keycloak, webhook-listener). Applied to both `nginx.prod.conf` and `nginx.staging.conf`.

- The `/admin` location drops the `/admin` URI suffix from `proxy_pass`; with a variable and no URI part, nginx forwards the original request URI verbatim, which is identity-equivalent for the `/admin` prefix.
- Validated with `nginx -t` against the running prod container (config test successful).

## Deployment note

Per `docs/admin/setup.rst`, these files are **copied to the servers manually** (no automation). Prod has already been restored via a live `nginx -s reload`; the updated config is being copied to prod and staging as part of this incident response so the fix persists across the next nginx restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)