### PR TITLE
fix(pipeline): scope the "Last result" footer to the CI run, not a co-running workflow

### DIFF
--- a/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineService.java
+++ b/server/application-server/src/main/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineService.java
@@ -112,25 +112,28 @@ public class PipelineService {
         context.displayedSha() == null
             ? null
             : buildHead(repositoryId, context.displayedSha(), context.upToDate());
-    final PipelineDto.PreviousRun previous = previousRun(context);
+    final PipelineDto.PreviousRun previous = previousRun(repositoryId, context);
     return new PipelineDto(categories, gate, head, previous);
   }
 
   /** The freshness anchor: short SHA, subject line, author time, and a link to the commit. */
   private PipelineDto.Head buildHead(Long repositoryId, String fullSha, boolean upToDate) {
-    final String htmlUrl =
-        gitRepoRepository
-            .findByRepositoryId(repositoryId)
-            .map(GitRepository::getNameWithOwner)
-            .map(nameWithOwner -> "https://github.com/" + nameWithOwner + "/commit/" + fullSha)
-            .orElse(null);
     final var commit = commitRepository.findByShaAndRepositoryRepositoryId(fullSha, repositoryId);
     return new PipelineDto.Head(
         shortSha(fullSha),
         upToDate,
         commit.map(c -> firstLine(c.getMessage())).orElse(null),
         commit.map(Commit::getAuthoredAt).orElse(null),
-        htmlUrl);
+        commitUrl(repositoryId, fullSha));
+  }
+
+  /** Link to a commit on GitHub, or null when the repository's {@code nameWithOwner} is unknown. */
+  private String commitUrl(Long repositoryId, String fullSha) {
+    return gitRepoRepository
+        .findByRepositoryId(repositoryId)
+        .map(GitRepository::getNameWithOwner)
+        .map(nameWithOwner -> "https://github.com/" + nameWithOwner + "/commit/" + fullSha)
+        .orElse(null);
   }
 
   /** Commit subject (first non-blank line), or null. */
@@ -146,20 +149,43 @@ public class PipelineService {
    * The previous commit's outcome for the confidence footer — only a <i>definitive</i> pass/fail is
    * a useful signal, so anything else (the resolver already walks past inconclusive commits, but we
    * guard here too) yields no footer rather than a meaningless "cancelled".
+   *
+   * <p>The outcome and link are scoped to the pipeline's CI run via {@link #pipelineScopedRuns}, so
+   * an unrelated workflow on the same commit (Codacy, PR labeler, coverage) can neither set the
+   * pass/fail label nor be linked in place of the CI run.
    */
-  private static PipelineDto.PreviousRun previousRun(PipelineRunContext context) {
+  private PipelineDto.PreviousRun previousRun(Long repositoryId, PipelineRunContext context) {
     if (context.previousSha() == null) {
       return null;
     }
-    final String conclusion = aggregateRunConclusion(context.previousRuns());
+    final List<WorkflowRunDto> ciRuns = pipelineScopedRuns(context.previousRuns());
+    final String conclusion = aggregateRunConclusion(ciRuns);
     if (!WorkflowRun.Conclusion.SUCCESS.name().equals(conclusion)
         && !WorkflowRun.Conclusion.FAILURE.name().equals(conclusion)) {
       return null;
     }
+    final String runUrl = previousRunUrl(ciRuns, conclusion);
     return new PipelineDto.PreviousRun(
         shortSha(context.previousSha()),
         conclusion,
-        previousRunUrl(context.previousRuns(), conclusion));
+        runUrl != null ? runUrl : commitUrl(repositoryId, context.previousSha()));
+  }
+
+  /**
+   * Narrows a commit's runs to the pipeline's CI workflow — the one the nodes and gate reflect,
+   * identified by the gate's {@code workflowNameMatcher}. Without a configured matcher (a
+   * non-canonical setup) all runs are kept.
+   */
+  private List<WorkflowRunDto> pipelineScopedRuns(List<WorkflowRunDto> runs) {
+    final String matcher =
+        properties.gate() == null ? null : properties.gate().workflowNameMatcher();
+    if (matcher == null || matcher.isBlank()) {
+      return runs;
+    }
+    final String needle = matcher.toLowerCase(Locale.ROOT);
+    return runs.stream()
+        .filter(run -> run.name() != null && run.name().toLowerCase(Locale.ROOT).contains(needle))
+        .toList();
   }
 
   /** Links the footer to the previous commit's CI run — the failing run when it failed. */

--- a/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineIT.java
+++ b/server/application-server/src/test/java/de/tum/cit/aet/helios/workflow/pipeline/PipelineIT.java
@@ -354,6 +354,32 @@ class PipelineIT extends HeliosIntegrationTest {
   }
 
   @Test
+  void previousFooterLinksTheCiRunNotACoRunningWorkflow() throws Exception {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    final String branch = "ci-scope-br";
+    insertBranch(jdbc, REPO, branch, "aaaahead");
+    insertRun(jdbc, 300L, REPO, WF, branch, "aaaahead", "IN_PROGRESS", null, 0);
+    insertJob(jdbc, 640, REPO, 300L, "Build / Build .war artifact", "IN_PROGRESS", null);
+    // Previous commit: the CI run passed, and a *separate* workflow (e.g. Code Quality) also ran on
+    // the same commit. The footer must reflect and link the CI run — never the other workflow.
+    insertRun(jdbc, 301L, REPO, WF, branch, "eeeeprev", "COMPLETED", "SUCCESS", 60);
+    insertWorkflow(jdbc, 52L, REPO);
+    insertNamedRun(
+        jdbc, 302L, REPO, 52L, branch, "eeeeprev", "Code Quality", "COMPLETED", "SUCCESS", 60);
+
+    mockMvc
+        .perform(
+            get("/api/pipeline/branch")
+                .param("branch", branch)
+                .header(X_REPOSITORY_ID, String.valueOf(REPO)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.previous.sha").value("eeeepre"))
+        .andExpect(jsonPath("$.previous.conclusion").value("SUCCESS"))
+        // The CI run (301), never the Code Quality run (302), regardless of run ordering.
+        .andExpect(jsonPath("$.previous.htmlUrl").value("https://example/run/301"));
+  }
+
+  @Test
   void previousFooterHiddenWhenNoDefiniteResultInHistory() throws Exception {
     JdbcTemplate jdbc = new JdbcTemplate(dataSource);
     final String branch = "nodef-br";


### PR DESCRIPTION
### Motivation

The "Last result" confidence footer added in #1194 links its commit SHA to the previous commit's CI run. But a commit runs **many** workflows — on `ls1intum/Artemis` a single commit routinely has `CI`, `Code Quality`, `PR Coverage Reporter`, `Validate PR Title/Description`, `Pull Request Labeler`, `Automatic Dependency Submission`, … each producing its own `workflow_run`.

`getLatestWorkflowRuns` returns **one run per workflow**, grouped in a `HashMap`, and `previousRun`:
- aggregated the pass/fail across **all** of those workflows, and
- picked the linked run with `findFirst()` over that HashMap — i.e. an **arbitrary, non-deterministic** workflow.

So *"Last result ✓ Passed · `abc1234`"* could link to **"Pull Request Labeler"** (or Code Quality, coverage, …) instead of the CI run the pipeline actually represents — and, less visibly, the pass/fail label could come from an unrelated workflow too. This was reported from staging.

### Fix

Scope the footer to the pipeline's CI run — the same workflow the nodes and gate reflect — identified by the gate's configured `workflowNameMatcher` (`"CI"` for the canonical Artemis config; no hard-coding). Both the **conclusion** and the **link** now derive from that run only (the failing run when it failed), and the link falls back to the **commit page** if no run URL is available. When no matcher is configured (a non-canonical setup) behaviour is unchanged.

- Extracted `commitUrl()`, shared between the freshness anchor and the footer fallback.
- No DTO/contract change — only the URL *value* the server returns; `openapi.yaml` and the client are untouched.

### Testing

- New `PipelineIT.previousFooterLinksTheCiRunNotACoRunningWorkflow` seeds a previous commit with a passing **CI** run **and** a passing **Code Quality** run on the same commit, and asserts `previous.htmlUrl` is the **CI** run — regardless of run ordering. The bug fails this test; the fix passes it.
- Full `PipelineIT` green (**22/22**), Checkstyle line-length clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)